### PR TITLE
Update pip install 'unionai[byoc]' command

### DIFF
--- a/source/api/index.md
+++ b/source/api/index.md
@@ -16,11 +16,26 @@ pip install -U unionai
 
 {@@ elif byoc @@}
 
+::::{tab-set}
+
+:::{tab-item} Unix/macOS
+
+```{code-block} shell
+pip install -U 'unionai[byoc]'
 ```
+
+:::
+
+
+:::{tab-item} Windows
+
+```{code-block} shell
 pip install -U "unionai[byoc]"
 ```
 
-{@@ endif @@}
+:::
+::::
 
+{@@ endif @@}
 
 This will install the `flytekit` and `unionai` SDKs, the `unionai` CLI, and `UnionRemote`.

--- a/source/getting-started/index.md
+++ b/source/getting-started/index.md
@@ -80,9 +80,25 @@ $ pip install -U unionai
 
 {@@ elif byoc @@}
 
+::::{tab-set}
+
+:::{tab-item} Unix/macOS
+
 ```{code-block} shell
-$ pip install -U "unionai[byoc]"
+pip install -U 'unionai[byoc]'
 ```
+
+:::
+
+
+:::{tab-item} Windows
+
+```{code-block} shell
+pip install -U "unionai[byoc]"
+```
+
+:::
+::::
 
 :::{note}
 The `[byoc]` extra package includes configuration defaults specific to Union BYOC that differ from those needed for Serverless.


### PR DESCRIPTION
Need single quotes for Unix/macOS and double quotes for Windows around `pip install 'unionai[byoc]'` command.