### PR TITLE
Remove local cluster and config from serverless docs

### DIFF
--- a/sitemap.json
+++ b/sitemap.json
@@ -106,7 +106,7 @@
                 {"name": "interactive-tasks", "variants": ["byoc", "serverless"]},
                 {"name": "setting-up-ci-cd-deployment", "variants": ["byoc"]},
                 {"name": "unionremote", "variants": ["byoc", "serverless"]},
-                {"name": "running-in-a-local-cluster", "variants": ["byoc", "serverless"]}
+                {"name": "running-in-a-local-cluster", "variants": ["byoc"]}
             ]},
         {"name": "data-input-output", "variants": ["byoc", "serverless"],
             "children": [
@@ -190,7 +190,7 @@
                         {"name": "entity-components", "variants": ["byoc", "serverless"]},
                         {"name": "execution-objects", "variants": ["byoc", "serverless"]}
                     ]},
-                {"name": "config", "variants": ["byoc", "serverless"]}
+                {"name": "config", "variants": ["byoc"]}
             ]},
         {"name": "faq", "variants": ["byoc"]}
     ]}


### PR DESCRIPTION
For serverless, the user does not need to specify the endpoint when using `UnionRemote`:

```python
remote = UnionRemote()
```

Since the config is not required by `UnionRemte`, we do not need to document the Config API.