### PR TITLE
FIX Unionai config: set insecure to false

### DIFF
--- a/source/getting-started/index.md
+++ b/source/getting-started/index.md
@@ -139,12 +139,10 @@ Note that there are two `host` values to substitute and the resulting URLs are p
 union:
   connection:
     host: dns:///<union-host-domain>
-    insecure: false
   auth:
     type: Pkce
 admin:
   endpoint: dns:///<union-host-domain>
-  insecure: false
   authType: Pkce
 ```
 


### PR DESCRIPTION
FIX Unionai config: set insecure to false

Spotted by a customer here: 
https://app.usepylon.com/issues?conversationID=fddc0f64-0995-4c56-bcf8-408aa0495b87