### PR TITLE
DOC-446 Document UnionRemote methods without docstrings

### DIFF
--- a/source/api/unionremote/entrypoint.md
+++ b/source/api/unionremote/entrypoint.md
@@ -4,6 +4,7 @@
 
 .. autoclass:: unionai.remote.UnionRemote
    :members: activate_launchplan, create_artifact, download, execute, execute_local_launch_plan, execute_local_task, execute_local_workflow, execute_reference_launch_plan, execute_reference_task, execute_reference_workflow, execute_remote_task_lp, execute_remote_wf, fast_package, fetch_execution, fetch_launch_plan, fetch_task, fetch_task_lazy, fetch_workflow, fetch_workflow_lazy, generate_console_http_domain, generate_console_url, get, get_artifact, get_extra_headers_for_protocol, launch_backfill, list_signals, list_tasks_by_version, raw_register, recent_executions, register_launch_plan, register_script, register_task, register_workflow, remote_context, set_signal, sync, sync_execution, sync_node_execution, sync_task_execution, terminate, upload_file, wait
+   :undoc-members:
 
 
 .. autoclass:: flytekit.remote.remote.Options


### PR DESCRIPTION
Document `UnionRemote` (actually technically `FlyteRemote`) methods without docstrings, to match `FlyteRemote` docs.