### PR TITLE
fix some typos and add examples

### DIFF
--- a/source/core-concepts/tasks/task-software-environment/imagespec.md
+++ b/source/core-concepts/tasks/task-software-environment/imagespec.md
@@ -100,12 +100,12 @@ As their names imply, the former defines the Python packages that you will need 
 while the latter defines only those packages need to run the workflow in the container on Union.
 This setup is not mandatory, but it is a good practice to follow since it makes clear which dependencies are used where.
 
-The `local-requirements.txt` includes the `flytekit` and `flytekitplugins-env` packages as well as the contents of the `image-requirements.txt` file.
+The `local-requirements.txt` includes the `flytekit` and `flytekitplugins-envd` packages as well as the contents of the `image-requirements.txt` file.
 
 The `unionai` package is, of course, needed in your local requirements to define workflows and to provide the `unionai` SDK, the `flytekit` SDK, and the `unionai` CLI.
 It is not need in the `image-requirements.txt` file because the task container image is based on an image that already includes `flytekit` (specifically the image `flytekit:py3.11-latest`).
 
-The `flytekitplugins-env` package is needed in your local requirements because it provides (together with your local Docker install) the functionality to build and push the container image defined by the `ImageSpec`.
+The `flytekitplugins-envd` package is needed in your local requirements because it provides (together with your local Docker install) the functionality to build and push the container image defined by the `ImageSpec`.
 It is not needed in the `image-requirements.txt` file because it is not needed in the container image itself.
 
 The content of the `image-requirements.txt` file is just the `pandas` package, which is needed by the task, so it is need both locally and in the container image running on Union.

--- a/source/core-concepts/tasks/task-types.md
+++ b/source/core-concepts/tasks/task-types.md
@@ -32,11 +32,22 @@ This is the most common task variant and the one that, thus far, we have focused
 This task variant represents a raw container, with no assumptions made about what is running within it.
 Here is an example of declaring a `ContainerTask`:
 
-<!-- TODO: Example code -->
+```{code-block} python
+greeting_task = ContainerTask(
+    name="echo_and_return_greeting",
+    image="alpine:latest",
+    input_data_dir="/var/inputs",
+    output_data_dir="/var/outputs",
+    inputs=kwtypes(name=str),
+    outputs=kwtypes(greeting=str),
+    command=["/bin/sh", "-c", "echo 'Hello, my name is {{.inputs.name}}.' | tee -a /var/outputs/greeting"],
+)
+
+```
 
 The `ContainerTask` enables you to include a task in your workflow that executes arbitrary code in any language, not just Python.
 
-<!--TODO: Besides support for other languages, there are other reasons to use a container task. Mention them her -->
+<!--TODO: Besides support for other languages, there are other reasons to use a container task. Mention them here. -->
 
 See the [Container Task example](https://github.com/unionai-oss/union-cloud-docs-examples/tree/main/container_task).
 
@@ -53,7 +64,19 @@ Map tasks find application in various scenarios, including:
 
 Just like normal tasks, map tasks are automatically parallelized to the extent possible given resources available in the cluster.
 
-<!-- TODO: example code-->
+```{code-block} python
+THRESHOLD = 11
+
+@task
+def detect_anomalies(data_point: int) -> bool:
+    return data_point > THRESHOLD
+
+@workflow
+def map_workflow(data: list[int] = [10, 12, 11, 10, 13, 12, 100, 11, 12, 10]) -> list[bool]:
+    # Use the map task to apply the anomaly detection function to each data point
+    return map_task(detect_anomalies)(data_point=data)
+
+```
 
 See:
 * The [Map Task example](https://github.com/unionai-oss/union-cloud-docs-examples/tree/main/map_task).

--- a/source/getting-started/looking-at-the-dependencies.md
+++ b/source/getting-started/looking-at-the-dependencies.md
@@ -25,12 +25,12 @@ When deployed to Union (or your local demo cluster), each task in a Union workfl
 The `image-requirements.txt` file includes all (and only) the packages needed to run the workflow in the container.
 This file is used to define the container image through the `ImageSpec` object (which we will see when we look at the Python code).
 
-The `local-requirements.txt` file includes the contents of `image-requirements.txt` and adds the `unionai` and `flytekitplugins-env` packages.
+The `local-requirements.txt` file includes the contents of `image-requirements.txt` and adds the `unionai` and `flytekitplugins-envd` packages.
 
 The `unionai` package is needed in your local requirements file to define workflows and tasks and to provide the `unionai` CLI. (Though you may already have installed `unionai`, it is good practice to have it listed in this file as well.) `unionai` (which would install `flytekit`) is not need in the `image-requirements.txt` file because the task container image  is based on an image that already includes `flytekit` (you will see this in the `ImageSpec` definition later).
 
-The `flytekitplugins-env` package is needed in your local requirements file because it provides (together with your local Docker installation) the functionality to build and push the container image defined by the `ImageSpec`.
-`flytekitplugins-env` is not needed in the `image-requirements.txt` file because it is not needed in the container image itself.
+The `flytekitplugins-envd` package is needed in your local requirements file because it provides (together with your local Docker installation) the functionality to build and push the container image defined by the `ImageSpec`.
+`flytekitplugins-envd` is not needed in the `image-requirements.txt` file because it is not needed in the container image itself.
 
 The `image-requirements.txt` file includes the `pandas` and `scikit-learn` packages, which are used by the task code in the following example project. These dependencies are needed both locally and in the container image.
 


### PR DESCRIPTION
I noticed some flytekitplugins-envd typos and the container task section referencing an example that wasn't there.

I was going to re-word the container task section to not reference an example, but I saw that TODO sections so I added an example for container task and map tasks as well. We can remove these if you guys had different examples in mind. If so, we can just change the wording of the container task section.