### PR TITLE
fix a mistake in download section

### DIFF
--- a/source/data-input-output/downloading-with-ff-and-fd.md
+++ b/source/data-input-output/downloading-with-ff-and-fd.md
@@ -81,7 +81,7 @@ or similarly calling `os.path.isdir` on a `FlyteDirectory` to check if a directo
 
 **Inspecting the contents of a directory without downloading using `crawl`**
 
-As we saw above, using `os.listdir` (or `FlyteDirectory.listdir`) on a `FlyteDirectory` to view the contents in remote blob storage
+As we saw above, using `os.listdir` on a `FlyteDirectory` to view the contents in remote blob storage
 results in the contents being downloaded to the task container. If this should be avoided, the `crawl` method offers a means of inspecting
 the contents of the directory without calling `__fspath__` and therefore downloading the directory contents.
 


### PR DESCRIPTION
I made a mistake in my initial addition to the flyte directory download section. here is the fix

ticket: https://linear.app/unionai/issue/SE-79/fix-docs-typo-in-flyte-directory-section