### PR TITLE
DOC-45 Add missing APIs to enable in GCP dataplane setup docs

### DIFF
--- a/source/data-plane-setup/data-plane-setup-on-gcp.md
+++ b/source/data-plane-setup/data-plane-setup-on-gcp.md
@@ -153,6 +153,8 @@ You will need to enable the following service APIs.
 | Secret Manager API | `secretmanager.googleapis.com` |
 | Service Networking API | `servicenetworking.googleapis.com` |
 | Security Token Service API | `sts.googleapis.com` |
+| Cloud SQL Admin API | `sqladmin.googleapis.com` |
+| Cloud Storage Services API | `storage-api.googleapis.com` |
 
 ### In the GCP web console
 
@@ -178,6 +180,8 @@ $ gcloud services enable monitoring.googleapis.com
 $ gcloud services enable secretmanager.googleapis.com
 $ gcloud services enable servicenetworking.googleapis.com
 $ gcloud services enable sts.googleapis.com
+$ gcloud services enable sqladmin.googleapis.com
+$ gcloud services enable storage-api.googleapis.com
 ```
 
 ## Export Workflow Identity Config


### PR DESCRIPTION
See https://linear.app/unionai/issue/DOC-435/missing-apis-to-enable-in-gcp-dataplane-setup-docs