### PR TITLE
Fix code highlighting in "Example code components"

### DIFF
--- a/source/first-workflow/example-code-components.md
+++ b/source/first-workflow/example-code-components.md
@@ -87,5 +87,5 @@ The Flyte Deck feature allows you to enable visualizations in Union's user inter
 ```{rli} https://raw.githubusercontent.com/unionai/examples/main/guides/01_getting_started/ml_workflow/ml_workflow.py
 :language: python
 :lines: 67-96
-:emphasize-lines: 69
+:emphasize-lines: 3
 ```


### PR DESCRIPTION
Fixes the emphasized line in the code included in "Example code components" > "Visualizations". (The persistent error about this when building docs was bothering me.)