### PR TITLE
update auth details

### DIFF
--- a/source/guide/administration/cli-authentication.md
+++ b/source/guide/administration/cli-authentication.md
@@ -2,6 +2,25 @@
 
 The command line tools `uctl` or `union` must authenticate to Union in order to perform operations on the platform.
 The authentication mechanism is configured in the `config.yaml` file used by the command line tool.
+
+By default, the `union` CLI will look for a configuration file at `~/.union/config.yaml`. (See [union CLI](../api/union-cli) for more details.)
+You can override this behavior to specify a different configuration file by setting the `UNION_CONFIG` environment variable:
+
+```{code-block} shell
+export UNION_CONFIG=~/.my-config-location/my-config.yaml
+```
+
+Alternatively, you can always specify the configuration file on the command line when invoking `union` by using the `--config` flag:
+
+```{code-block} shell
+$ union --config ~/.my-config-location/my-config.yaml run my_script.py my_workflow
+```
+
+```{warning}
+If you have previously used Union, you may have configuration files left over that will interfere with access to Union Serverless through the `union` CLI tool.
+Make sure to remove any files in `~/.unionai/` or `~/.union/` and unset the environment variables `UNIONAI_CONFIG` and `UNION_CONFIG` to avoid conflicts.
+```
+
 There are three authentication mechanisms available: **PKCE**, **DeviceFlow**, and **ClientSecret**.
 
 ## PKCE

--- a/source/guide/core-concepts/tasks/task-hardware-environment/customizing-task-resources.md
+++ b/source/guide/core-concepts/tasks/task-hardware-environment/customizing-task-resources.md
@@ -32,7 +32,7 @@ The `requests` and `limits` settings each takes a [`Resource`](https://docs.flyt
 * `mem`: Main memory (in `Mi`, `Gi`, etc.).
 * `ephemeral_storage`: Ephemeral storage (in `Mi`,  `Gi` etc.).
 
-Note that CPU and GPU allocations can be specified either as whole numbers or in millicores (`m`). For example, `cpu="2"` means 2 CPU cores and `gpu="3500m"`, meaning three and a half GPU cores.
+Note that CPU and GPU allocations can be specified either as whole numbers or in millicores (`m`). For example, `cpu="2500m"` means two and a half CPU cores and `gpu="3000m"`, meaning three GPU cores.
 
 The `requests` setting tells the system that the task requires _at least_ the resources specified and therefore the pod running this task should be scheduled only on a node that meets or exceeds the resource profile specified.
 

--- a/source/guide/quick-start.md
+++ b/source/guide/quick-start.md
@@ -95,6 +95,7 @@ This will create the `~/.union/config.yaml` with the configuration information t
 
 :::{note}
 These directions apply to Union Serverless. To configure a connection to your Union instance in Union BYOC, see the [BYOC version of this page](https://docs.union.ai/byoc/guide/quick-start.html#configure-the-union-cli).
+:::
 
 {@@ elif byoc @@}
 
@@ -212,3 +213,12 @@ Go to the UI to see the execution:
 ![Dashboard](/_static/images/first-execution-byoc.png)
 
 {@@ endif @@}
+
+:::{note}
+When you use `union create login --host <union-host-url>` to configure the `union` CLI, this creates a `config.yaml` file
+configured for a Proof Key of Code Exchange (PKCE) mechanism. This is one of three authentication options, including DeviceFlow and 
+ClientSecret. In short, PKCE opens a browser window allowing you to login, DeviceFlow returns a URL you can navigate to, 
+and ClientSecret authenticates via a pre-configured secret. If you are using Union in a headless fashion, either on a 
+VM, connecting to a machine via SSH, in CI/CD, etc., DeviceFlow and ClientSecret should be considered. 
+See [CLI authentication](administration/cli-authentication.md) for more information.
+:::


### PR DESCRIPTION
smaller fix to hopefully add clarity on authentication:
1. add info about authentication options in quick start guide with a link to the cli authentication page
2. add information on the cli authentication page about where the config should be and how to specify it. This was just copied from the quick start guide
3. Unrelated but a section of the GPU docs were technically wrong - we cant target half a gpu right now/