### PR TITLE
Use HTTPS for cloning examples repo

### DIFF
--- a/source/guide/first-workflow/setting-up-your-local-environment.md
+++ b/source/guide/first-workflow/setting-up-your-local-environment.md
@@ -31,7 +31,7 @@ source venvs/ml_workflow_venv/bin/activate
 After setting up a virtual environment, clone the [`unionai/unionai-examples`](https://github.com/unionai/unionai-examples) repository:
 
 ```{code-block} shell
-$ git clone https://github.com/unionai/unionai-examples/
+$ git clone https://github.com/unionai/unionai-examples
 ```
 
 ## Install the dependencies


### PR DESCRIPTION
There are a few gotchas with using SSH + GitHub: https://docs.github.com/en/authentication/troubleshooting-ssh/error-permission-denied-publickey 

I have completely switched over to HTTPS. 

- For private repos, users only need to run `gh auth login` https://cli.github.com/manual/gh_auth_login. 
- For public repos, cloning with HTTP works out of the box.