### PR TITLE
add note about ephemeral storage

### DIFF
--- a/source/user-guide/core-concepts/tasks/task-hardware-environment/customizing-task-resources.md
+++ b/source/user-guide/core-concepts/tasks/task-hardware-environment/customizing-task-resources.md
@@ -34,7 +34,7 @@ The `requests` and `limits` settings each takes a [`Resource`](https://docs.flyt
 
 Note that CPU and GPU allocations can be specified either as whole numbers or in millicores (`m`). For example, `cpu="2500m"` means two and a half CPU cores and `gpu="3000m"`, meaning three GPU cores.
 
-The type of ephemeral storage used depends on the node type and configuration you request from the Union team. By default, all nodes will use network-attached storage for ephemeral storage. However, if a node type has attached NVMe SSD storage, you can request that the Union team configure your cluster to use the attached NVMe ephemeral storage for that node type.
+The type of ephemeral storage used depends on the node type and configuration you request from the Union team. By default, all nodes will use network-attached storage for ephemeral storage. However, if a node type has attached NVMe SSD storage, you can request that the Union team configure your cluster to use the attached NVMe as ephemeral storage for that node type.
 
 The `requests` setting tells the system that the task requires _at least_ the resources specified and therefore the pod running this task should be scheduled only on a node that meets or exceeds the resource profile specified.
 


### PR DESCRIPTION
We had a customer with a question about the storage type that is used when they configure ephemeral storage for a container. They were wondering if the disk that comes with certain node types are used or if only network attached storage is used. This line can hopefully add those details.

second spectrum question: https://unionai.slack.com/archives/C06UV4B4G4T/p1730743799868279

help eng: https://unionai.slack.com/archives/C06RE4ZR5QQ/p1730747475376749

