### PR TITLE
feat: Include all union CLI cmds to docs

### DIFF
--- a/source/api-reference/union-cli.md
+++ b/source/api-reference/union-cli.md
@@ -77,6 +77,5 @@ If none of these are present, the CLI will raise an error.
 .. click:: union.cli._main:main
     :prog: union
     :nested: full
-    :commands: backfill, build, create, delete, deploy, execution, fetch, get, info, init, launchplan, local-cache, metrics, package, register, run, serialize, serve, stop, update
 
 ```


### PR DESCRIPTION
This PR ensures all union CLI commands are included in the union docs at build time by removing the explicit/hard coded commands within `union-cli.md`