### PR TITLE
Use absolute paths in app serving

### DIFF
--- a/source/user-guide/core-concepts/serving/adding-your-own-code.md
+++ b/source/user-guide/core-concepts/serving/adding-your-own-code.md
@@ -41,8 +41,8 @@ app = App(
     args=["streamlit", "run", "main.py", "--server.port", "8080"],
     port=8080,
     include=[
-        "./main.py",
-        "./utils.py",
+        "main.py",
+        "utils.py",
     ],
     limits=Resources(cpu="1", mem="1Gi"),
 )

--- a/source/user-guide/core-concepts/serving/serving-a-model.md
+++ b/source/user-guide/core-concepts/serving/serving-a-model.md
@@ -46,7 +46,7 @@ fast_api_app = App(
     container_image=image_spec,
     limits=Resources(cpu="1", mem="1Gi"),
     port=8082,
-    include=["./main.py"],
+    include=["main.py"],
     args=["fastapi", "dev", "--port", "8082"],
 )
 ```

--- a/source/user-guide/core-concepts/serving/serving-workflow-output.md
+++ b/source/user-guide/core-concepts/serving/serving-workflow-output.md
@@ -48,7 +48,7 @@ app = App(
     container_image=image,
     args="streamlit run main.py --server.port 8080",
     port=8080,
-    include=["./main.py"],
+    include=["main.py"],
     limits=Resources(cpu="1", mem="1Gi"),
 )
 ```


### PR DESCRIPTION
This is mostly to simplify how to use app serving.

With absolute paths, this behaviors like `pyflyte`. The paths are relative to where you run `union run`.

With the relative paths `./`, it's relative to where the application was defined. (This can be confusing for those that are use to flyte semantics).