### PR TITLE
Update secret management to use --name

### DIFF
--- a/source/user-guide/development-cycle/accessing-aws-s3.md
+++ b/source/user-guide/development-cycle/accessing-aws-s3.md
@@ -8,7 +8,7 @@ As a prerequisite, we assume that our AWS S3 bucket is accessible with API keys:
 First, we create secrets on Union by running the following command:
 
 ```{code-block} shell
-union create secret AWS_ACCESS_KEY_ID
+union create secret --name AWS_ACCESS_KEY_ID
 ```
 
 This will open a prompt where we paste in our AWS credentials:

--- a/source/user-guide/development-cycle/managing-secrets.md
+++ b/source/user-guide/development-cycle/managing-secrets.md
@@ -9,7 +9,7 @@ You can use secrets to interact with external services.
 To create a secret, use the `union create secret` command:
 
 ```{code-block} shell
-union create secret --project my_project --domain my_domain my_secret
+union create secret --project my_project --domain my_domain --name my_secret
 ```
 
 You'll be prompted to enter a secret value in the terminal:
@@ -23,7 +23,7 @@ Enter secret value: ...
 To create a secret from a file, run the following command:
 
 ```{code-block} shell
-union create secret --project my_project --domain my_domain my_file_secret -f /path/to/file
+union create secret --project my_project --domain my_domain --name my_file_secret -f /path/to/file
 ```
 
 ## Listing secrets


### PR DESCRIPTION
Note that the old `union create secret MY_NAME` still works. This PR to push users to use the new `--name` to be consistent with the other `union` commands.