### PR TITLE
[Docs] Add warning block for installing ca certificate for specific usage

### DIFF
--- a/content/user-guide/core-concepts/image-spec.md
+++ b/content/user-guide/core-concepts/image-spec.md
@@ -70,6 +70,16 @@ sklearn_image_spec = ImageSpec(
 )
 ```
 
+{{< variant flyte >}}
+{{< markdown >}}
+
+> [!WARNING]
+> Images built with ImageSpec do **not** include CA certificates by default, which can break TLS validation and block access to remote storage when Polars uses its native Rust-based networking (e.g., when using `polars.scan_parquet()`).
+> **Solution:** Add `"ca-certificates"` to `apt_packages` in your `ImageSpec`.
+
+{{< /markdown >}}
+{{< /variant >}}
+
 ## Install Conda packages
 
 Define the `ImageSpec` to install packages from a specific conda channel.


### PR DESCRIPTION
As discussed in this issue: https://github.com/flyteorg/flyte/issues/6438, it is unclear that Flyte `ImageSpec`'s default image does not include apt package `ca-certificate`, which can cause confusion when user want to use polars.

Document this in `ImageSpec` docs