### PR TITLE
Restructure security docs for zero-trust architecture

### DIFF
--- a/content/security/_index.md
+++ b/content/security/_index.md
@@ -8,6 +8,9 @@ sidebar_expanded: true
 
 # Security
 
+> [!TIP] Updated for zero-trust architecture
+> This page has been updated to reflect the zero-trust security architecture. Tabbed comparisons below highlight key changes.
+
 Union.ai provides a production-grade workflow orchestration platform built on Flyte, designed for AI/ML and data-intensive workloads.
 Security is foundational to Union.ai's architecture, not an afterthought.
 Union.ai's zero-trust architecture ensures that no customer data ever transits the control plane: all data visualization, logs, and metrics are served directly from the customer's data plane.
@@ -15,6 +18,9 @@ This document provides a comprehensive overview of Union.ai's security practices
 
 Union.ai's security model is built on several core principles:
 
+{{< tabs >}}
+{{< tab "Zero-trust (current)" >}}
+{{< markdown >}}
 * **Zero-trust data isolation:** No customer data, operational metadata, or logs ever transit through Union.ai's control plane. All data visualization---including logs, task inputs and outputs, metrics, and dashboards---is served directly from the customer's data plane via the Direct-to-DataPlane tunnel. The `dataproxy` service runs entirely within the data plane, ensuring that data requests are fulfilled without leaving the customer's VPC. This zero-trust data isolation guarantee is contractual.
 * **Data residency:** Customer data is stored and computed only within the customer's data plane. The Union.ai control plane never sees or relays customer data. It stores only orchestration metadata---task definitions, run identifiers, phase timestamps, and typed interface references---and holds no task inputs, outputs, code, logs, secrets, or container images.
 * **Architectural isolation:** A strict separation between the Union-hosted control plane and the customer-hosted data plane ensures that the blast radius of any control plane compromise does not extend to customer data. The zero-trust model further reduces this blast radius: because no customer data flows through the control plane at any point, a control plane compromise exposes only orchestration metadata, never customer data.
@@ -22,6 +28,19 @@ Union.ai's security model is built on several core principles:
 * **Compliance:** Union.ai is SOC 2 Type II certified for Security, Availability, and Integrity, with practices aligned to ISO 27001 and GDPR standards. Union is designed to meet HIPAA compliance requirements for handling Protected Health Information (PHI) and maintains CIS 1.4 AWS certification while pursuing CIS 3.0 certification (in progress). The Union.ai trust portal can be found at [trust.union.ai](https://trust.union.ai).
 * **Defense in depth:** Multiple layers of encryption, authentication, authorization, and network segmentation protect data throughout its lifecycle.
 * **Human / operational isolation:** In the default deployment, Union.ai personnel cannot see customer data even through the Union UI, because all data is served directly from the data plane via the Direct-to-DataPlane tunnel. Personnel do not have IAM credentials for customer cloud accounts and cannot directly access customer data stores, secrets, or compute infrastructure. In the Enterprise 1 security tier, data plane access is further restricted to VPN-connected users only, eliminating any external access path. In BYOC deployments, Union.ai additionally has [K8s cluster management access](./byoc-differences#human-access-to-customer-environments).
+{{< /markdown >}}
+{{< /tab >}}
+{{< tab "Previous architecture" >}}
+{{< markdown >}}
+* **Data residency:** Customer data is stored and computed only within the customer's data plane. The Union.ai control plane stores only orchestration metadata—no task inputs, outputs, code, logs, secrets, or container images.
+* **Architectural isolation:** A strict separation between the Union-hosted control plane and the customer-hosted data plane ensures that the blast radius of any control plane compromise does not extend to customer data.
+* **Outbound only connectivity:** The Cloudflare Tunnel connecting the control plane to the data plane is outbound-only from the customer's network, requiring no inbound firewall rules. All communication uses mutual TLS (mTLS) and is authenticated using the customer's Auth / SSO.
+* **Compliance:** Union.ai is SOC 2 Type II certified for Security, Availability, and Integrity, with practices aligned to ISO 27001 and GDPR standards. Union is designed to meet HIPAA compliance requirements for handling Protected Health Information (PHI) and maintains CIS 1.4 AWS certification while pursuing CIS 3.0 certification (in progress). The Union.ai trust portal can be found at [trust.union.ai](https://trust.union.ai)
+* **Defense in depth:** Multiple layers of encryption, authentication, authorization, and network segmentation protect data throughout its lifecycle.
+* **Human / operational isolation:** Union.ai personnel access the customer's control plane UI only through authenticated, RBAC-controlled channels. Personnel do not have IAM credentials for customer cloud accounts and cannot directly access customer data stores, secrets, or compute infrastructure. In BYOC deployments, Union.ai additionally has [K8s cluster management access](./byoc-differences#human-access-to-customer-environments).
+{{< /markdown >}}
+{{< /tab >}}
+{{< /tabs >}}
 
 ## Deployment models
 
@@ -29,6 +48,9 @@ Union.ai's deployment model has two independent dimensions: a **security tier** 
 
 ### Security tiers
 
+{{< tabs >}}
+{{< tab "Zero-trust (current)" >}}
+{{< markdown >}}
 Union.ai offers two security tiers that control how data flows between the data plane and end users:
 
 * **Default** (all plans): All data visualization is served directly from the customer's data plane via the Direct-to-DataPlane tunnel. No customer data transits the control plane. The `dataproxy` service runs within the data plane, handling presigned URL generation and data streaming entirely within the customer's VPC.
@@ -36,6 +58,14 @@ Union.ai offers two security tiers that control how data flows between the data 
 
 > [!NOTE] Information needed
 > A dedicated deployment models page with detailed comparison of security tiers is planned. Link will be added here when available.
+{{< /markdown >}}
+{{< /tab >}}
+{{< tab "Previous architecture" >}}
+{{< markdown >}}
+This section did not exist in the previous architecture. There was a single deployment model without security tier distinctions.
+{{< /markdown >}}
+{{< /tab >}}
+{{< /tabs >}}
 
 ### Operational models
 

--- a/content/security/_index.md
+++ b/content/security/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Security
-weight: 0
+weight: 6
 variants: -flyte +union
 top_menu: true
 sidebar_expanded: true

--- a/content/security/_index.md
+++ b/content/security/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Security
-weight: 6
+weight: 0
 variants: -flyte +union
 top_menu: true
 sidebar_expanded: true
@@ -9,24 +9,39 @@ sidebar_expanded: true
 # Security
 
 Union.ai provides a production-grade workflow orchestration platform built on Flyte, designed for AI/ML and data-intensive workloads.
-Security is foundational to Union.ai’s architecture, not an afterthought.
-This document provides a comprehensive overview of Union.ai’s security practices, architecture, and compliance posture for enterprise security professionals evaluating the platform.
+Security is foundational to Union.ai's architecture, not an afterthought.
+Union.ai's zero-trust architecture ensures that no customer data ever transits the control plane: all data visualization, logs, and metrics are served directly from the customer's data plane.
+This document provides a comprehensive overview of Union.ai's security practices, architecture, and compliance posture for enterprise security professionals evaluating the platform.
 
-Union.ai’s security model is built on several core principles:
+Union.ai's security model is built on several core principles:
 
-* **Data residency:** Customer data is stored and computed only within the customer's data plane. The Union.ai control plane stores only orchestration metadata—no task inputs, outputs, code, logs, secrets, or container images.
-* **Architectural isolation:** A strict separation between the Union-hosted control plane and the customer-hosted data plane ensures that the blast radius of any control plane compromise does not extend to customer data.
-* **Outbound only connectivity:** The Cloudflare Tunnel connecting the control plane to the data plane is outbound-only from the customer’s network, requiring no inbound firewall rules. All communication uses mutual TLS (mTLS) and is authenticated using the customer's Auth / SSO.
-* **Compliance:** Union.ai is SOC 2 Type II certified for Security, Availability, and Integrity, with practices aligned to ISO 27001 and GDPR standards. Union is designed to meet HIPAA compliance requirements for handling Protected Health Information (PHI) and maintains CIS 1.4 AWS certification while pursuing CIS 3.0 certification (in progress). The Union.ai trust portal can be found at [trust.union.ai](https://trust.union.ai)
+* **Zero-trust data isolation:** No customer data, operational metadata, or logs ever transit through Union.ai's control plane. All data visualization---including logs, task inputs and outputs, metrics, and dashboards---is served directly from the customer's data plane via the Direct-to-DataPlane tunnel. The `dataproxy` service runs entirely within the data plane, ensuring that data requests are fulfilled without leaving the customer's VPC. This zero-trust data isolation guarantee is contractual.
+* **Data residency:** Customer data is stored and computed only within the customer's data plane. The Union.ai control plane never sees or relays customer data. It stores only orchestration metadata---task definitions, run identifiers, phase timestamps, and typed interface references---and holds no task inputs, outputs, code, logs, secrets, or container images.
+* **Architectural isolation:** A strict separation between the Union-hosted control plane and the customer-hosted data plane ensures that the blast radius of any control plane compromise does not extend to customer data. The zero-trust model further reduces this blast radius: because no customer data flows through the control plane at any point, a control plane compromise exposes only orchestration metadata, never customer data.
+* **Outbound-only connectivity:** The Cloudflare Tunnel connecting the control plane to the data plane is outbound-only from the customer's network, requiring no inbound firewall rules. All communication uses mutual TLS (mTLS) and is authenticated using the customer's Auth / SSO.
+* **Compliance:** Union.ai is SOC 2 Type II certified for Security, Availability, and Integrity, with practices aligned to ISO 27001 and GDPR standards. Union is designed to meet HIPAA compliance requirements for handling Protected Health Information (PHI) and maintains CIS 1.4 AWS certification while pursuing CIS 3.0 certification (in progress). The Union.ai trust portal can be found at [trust.union.ai](https://trust.union.ai).
 * **Defense in depth:** Multiple layers of encryption, authentication, authorization, and network segmentation protect data throughout its lifecycle.
-* **Human / operational isolation:** Union.ai personnel access the customer's control plane UI only through authenticated, RBAC-controlled channels. Personnel do not have IAM credentials for customer cloud accounts and cannot directly access customer data stores, secrets, or compute infrastructure. In BYOC deployments, Union.ai additionally has [K8s cluster management access](./byoc-differences#human-access-to-customer-environments).
+* **Human / operational isolation:** In the default deployment, Union.ai personnel cannot see customer data even through the Union UI, because all data is served directly from the data plane via the Direct-to-DataPlane tunnel. Personnel do not have IAM credentials for customer cloud accounts and cannot directly access customer data stores, secrets, or compute infrastructure. In the Enterprise 1 security tier, data plane access is further restricted to VPN-connected users only, eliminating any external access path. In BYOC deployments, Union.ai additionally has [K8s cluster management access](./byoc-differences#human-access-to-customer-environments).
 
 ## Deployment models
 
-Union.ai offers two deployment models, both sharing the same control plane / data plane architecture and security controls described in this document.
+Union.ai's deployment model has two independent dimensions: a **security tier** that determines data access controls, and an **operational model** that determines who manages the data plane infrastructure.
 
-In **Self-Managed** deployments, the customer operates their data plane independently; Union.ai has zero access to the customer’s infrastructure, with the Cloudflare tunnel as the only connection.
+### Security tiers
 
-In **BYOC** deployments, Union.ai manages the Kubernetes cluster in the customer’s cloud account via private connectivity (PrivateLink/PSC), handling upgrades, monitoring, and provisioning while maintaining strict separation from customer data, secrets, and logs.
+Union.ai offers two security tiers that control how data flows between the data plane and end users:
 
-The core security architecture—encryption, RBAC, tenant isolation, presigned URL data access, and audit logging—is identical across both models. Sections where operational responsibilities differ are noted inline. [BYOC deployment differences](./byoc-differences) provides a detailed comparison.
+* **Default** (all plans): All data visualization is served directly from the customer's data plane via the Direct-to-DataPlane tunnel. No customer data transits the control plane. The `dataproxy` service runs within the data plane, handling presigned URL generation and data streaming entirely within the customer's VPC.
+* **Enterprise 1** (VPN-restricted): In addition to all Default tier guarantees, data plane access is restricted to users connected through the customer's VPN. The customer manages their own load balancer, and no Union.ai employee has access to the data plane. This tier is designed for organizations with the strictest data access requirements.
+
+> [!NOTE] Information needed
+> A dedicated deployment models page with detailed comparison of security tiers is planned. Link will be added here when available.
+
+### Operational models
+
+Independently of the security tier, customers choose how their data plane infrastructure is managed:
+
+* **Self-Managed:** The customer operates their data plane independently. Union.ai has zero access to the customer's infrastructure, with the Cloudflare tunnel as the only connection between the control plane and data plane.
+* **BYOC (Bring Your Own Cloud):** Union.ai manages the Kubernetes cluster in the customer's cloud account via private connectivity (PrivateLink/PSC), handling upgrades, monitoring, and provisioning while maintaining strict separation from customer data, secrets, and logs.
+
+The core security architecture---encryption, RBAC, tenant isolation, presigned URL data access, and audit logging---is identical across both operational models and both security tiers. Sections where operational responsibilities differ are noted inline. [BYOC deployment differences](./byoc-differences) provides a detailed comparison of the operational models.

--- a/content/security/aws-iam-roles.md
+++ b/content/security/aws-iam-roles.md
@@ -1,6 +1,6 @@
 ---
 title: AWS IAM roles
-weight: 18
+weight: 20
 variants: -flyte +union
 ---
 

--- a/content/security/byoc-differences.md
+++ b/content/security/byoc-differences.md
@@ -1,6 +1,6 @@
 ---
 title: BYOC deployment differences
-weight: 13
+weight: 21
 variants: -flyte +union
 ---
 

--- a/content/security/compliance-and-certifications.md
+++ b/content/security/compliance-and-certifications.md
@@ -43,12 +43,14 @@ In addition to certifications, Union.ai complies with the following standard con
 
 Union.ai is designed to support HIPAA compliance requirements, enabling healthcare and life sciences organizations to process protected health information (PHI) within their data planes.
 Because all customer data—including any PHI—remains exclusively in the customer’s own cloud infrastructure, Union.ai’s architecture inherently supports HIPAA’s data protection requirements.
+Under the zero-trust architecture, no customer data — including PHI — ever transits the control plane, providing absolute assurance for HIPAA compliance.
 The control plane stores only orchestration metadata and never persists PHI.
 
 ## GDPR alignment
 
 Union.ai’s architecture inherently supports GDPR through its data residency model.
 For EU-region data planes, all customer data remains within the European Union.
+Under the zero-trust architecture, no customer data ever transits the control plane, strengthening GDPR compliance by ensuring data never leaves the customer’s chosen region even temporarily.
 The control plane stores only orchestration metadata, and where error messages may contain user-generated content, this is documented and scoped.
 
 ## Trust Center
@@ -75,6 +77,7 @@ Union.ai operates under a shared responsibility model:
 | Data encryption at rest | Default cloud encryption | Optional CMK configuration |
 | Network security (tunnel) | Tunnel management | Firewall and VPC configuration |
 | IAM roles and policies | Role templates and documentation | Role creation and binding |
+| Data visualization/retrieval | Direct-to-DataPlane tunnel infrastructure | VPN/LB configuration (Enterprise 1 only) |
 | Secrets management | API and relay infrastructure | Backend selection and secret values |
 | Application-level access control | RBAC framework | Role assignment and policy |
 | Compliance documentation | SOC 2 report, Trust Center | Customer-specific attestations |

--- a/content/security/components-architecture.md
+++ b/content/security/components-architecture.md
@@ -7,6 +7,9 @@ mermaid: true
 
 # Compute and control plane components
 
+> [!TIP] Updated for zero-trust architecture
+> This page has been substantially revised. DataProxy has moved from the control plane to the data plane, and the tunnel architecture now distinguishes between the control plane tunnel and the Direct-to-DataPlane tunnel.
+
 This section provides a detailed reference for each security-relevant component running on the data plane and/or control plane.
 Understanding these components is essential for enterprise security teams conducting architecture reviews.
 

--- a/content/security/components-architecture.md
+++ b/content/security/components-architecture.md
@@ -13,8 +13,13 @@ Understanding these components is essential for enterprise security teams conduc
 ## Component architecture
 
 The diagram below shows the major components in both planes and how they communicate.
-All cross-plane traffic flows through the Cloudflare Tunnel—an outbound-only, mTLS-encrypted connection initiated from the data plane.
-No inbound ports are opened on the customer’s cluster.
+Two types of Cloudflare Tunnel connect the planes:
+
+- **Control plane tunnel** carries orchestration commands, state transitions, and health checks.
+- **Direct-to-DataPlane tunnel** carries data, logs, metrics, apps, and signed URLs directly from the customer's VPC to the client, without passing through the control plane.
+
+Both tunnels are outbound-only, mTLS-encrypted connections initiated from the data plane.
+No inbound ports are opened on the customer's cluster.
 
 ```mermaid
 graph TB
@@ -23,46 +28,56 @@ graph TB
         QueueSvc["Queue Service<br/>(schedules TaskActions)"]
         StateSvc["State Service<br/>(receives state transitions)"]
         ClusterSvc["Cluster Service<br/>(cluster health &amp; DNS reconciliation)"]
-        DataProxy["DataProxy<br/>(streaming relay for logs &amp; metrics)"]
     end
 
-    subgraph Tunnel["Cloudflare Tunnel (outbound-only, mTLS)"]
+    subgraph CPTunnel["Control Plane Tunnel (outbound-only, mTLS)"]
         direction LR
-        TunnelEdge(["Cloudflare edge"])
+        CPTunnelEdge(["Cloudflare edge"])
+    end
+
+    subgraph D2DPTunnel["Direct-to-DataPlane Tunnel (outbound-only, mTLS)"]
+        direction LR
+        D2DPTunnelEdge(["Cloudflare edge"])
     end
 
     subgraph DP["Data plane (customer hosted — customer cloud account)"]
-        TunnelSvc["Tunnel Service<br/>(maintains outbound tunnel connection)"]
+        TunnelSvc["Tunnel Service<br/>(maintains outbound tunnel connections)"]
         Executor["Executor<br/>(Kubernetes controller — runs task pods)"]
         ObjStore["Object Store Service<br/>(presigned URL generation)"]
         LogProvider["Log Provider<br/>(live K8s logs + cloud log aggregator)"]
         ImageBuilder["Image Builder<br/>(Buildkit — on-cluster image builds)"]
+        DataProxy["DataProxy<br/>(data, logs, metrics, signed URLs)"]
 
         subgraph Apps["Apps &amp; Serving"]
-            Kourier["Kourier gateway<br/>(Envoy — auth + routing)"]
+            Kourier["Kourier gateway<br/>(Envoy — auth + RBAC + routing)"]
             Knative["Knative Services<br/>(app containers)"]
         end
 
         Executor -->|"submit and watch"| Pods["Task pods<br/>(customer workloads)"]
         Pods -->|"read/write via IAM"| ObjBucket[("Object store<br/>(metadata + fast-reg buckets)")]
         ObjStore -->|"signs URLs using admin IAM role"| ObjBucket
+        DataProxy -->|"presigned URLs"| ObjStore
         LogProvider -->|"live: K8s API<br/>completed: CloudWatch / Cloud Logging / Azure Monitor"| Pods
+        DataProxy -->|"log retrieval"| LogProvider
         Kourier --> Knative
+        Kourier -->|"auth + RBAC"| DataProxy
     end
 
     Admin -->|"ConnectRPC / HTTPS"| User(["Client<br/>(browser / CLI / SDK)"])
     User -->|"presigned URL — direct fetch"| ObjBucket
 
-    CP <-->|"Cloudflare Tunnel"| TunnelEdge
-    TunnelEdge <-->|"outbound-initiated from data plane"| TunnelSvc
+    CP <-->|"Control Plane Tunnel"| CPTunnelEdge
+    CPTunnelEdge <-->|"outbound-initiated from data plane"| TunnelSvc
+
+    D2DPTunnelEdge <-->|"outbound-initiated from data plane"| TunnelSvc
+    User -->|"data, logs, metrics, apps, signed URLs"| D2DPTunnelEdge
+    D2DPTunnelEdge --> Kourier
+
     TunnelSvc --- Executor
     TunnelSvc --- ObjStore
-    TunnelSvc --- LogProvider
-    TunnelSvc --- Apps
 
     QueueSvc -->|"TaskAction"| Executor
     Executor -->|"state transitions (ConnectRPC)"| StateSvc
-    LogProvider -->|"streamed relay — never persisted"| DataProxy
     ClusterSvc -->|"health checks &amp; DNS"| TunnelSvc
 ```
 
@@ -71,30 +86,34 @@ graph TB
 | From | To | What flows |
 | --- | --- | --- |
 | Queue Service | Executor | TaskAction custom resources (orchestration instructions) |
-| Executor | State Service | Phase transitions (Queued → Running → Succeeded/Failed) |
+| Executor | State Service | Phase transitions (Queued -> Running -> Succeeded/Failed) |
 | Executor | Task pods | Pod lifecycle management |
 | Task pods | Object store | Task inputs/outputs via IAM role (workload identity) |
 | Object Store Service | Object store | Presigned URL generation using admin IAM role |
-| Log Provider | DataProxy | Log streams relayed in memory — optionally persisted on customer storage |
+| DataProxy | Object Store Service | Presigned URL generation requests |
+| DataProxy | Log Provider | Log retrieval requests |
+| DataProxy | Client | Data, logs, metrics, and signed URLs served via Direct-to-DataPlane tunnel |
+| Log Provider | Client | Log streams served directly via Direct-to-DataPlane tunnel |
 | Cluster Service | Tunnel Service | Health checks and DNS record reconciliation |
-| Tunnel Service | Cloudflare edge | Single outbound-only mTLS connection covering all data-plane services |
+| Tunnel Service | Cloudflare edge | Two outbound-only mTLS connections: control plane tunnel (orchestration) and Direct-to-DataPlane tunnel (data, logs, metrics, apps, signed URLs) |
 
 ## Executor
 
-The Executor is a Kubernetes controller that runs on the customer’s data plane.
+The Executor is a Kubernetes controller that runs on the customer's data plane.
 It is the core component responsible for translating orchestration instructions into actual workload execution.
-The Executor watches for `TaskAction` custom resources created by the Queue Service, reconciles each `TaskAction` through its lifecycle (`Queued`, `Initializing`, `Running`, `Succeeded`/`Failed`), reports state transitions back to the control plane’s State Service via `ConnectRPC` through the Cloudflare tunnel, and creates and manages Kubernetes pods for task execution.
+The Executor watches for `TaskAction` custom resources created by the Queue Service, reconciles each `TaskAction` through its lifecycle (`Queued`, `Initializing`, `Running`, `Succeeded`/`Failed`), reports state transitions back to the control plane's State Service via `ConnectRPC` through the control plane tunnel, and creates and manages Kubernetes pods for task execution.
 
-The Executor runs entirely within the customer’s cluster.
-It accesses the customer’s object store and secrets using IAM roles bound to its Kubernetes service account via workload identity federation.
-At no point does the Executor communicate directly with external services outside the customer’s cloud account (except through the Cloudflare tunnel to the control plane).
+The Executor runs entirely within the customer's cluster.
+It accesses the customer's object store and secrets using IAM roles bound to its Kubernetes service account via workload identity federation.
+At no point does the Executor communicate directly with external services outside the customer's cloud account (except through the Cloudflare tunnel to the control plane).
 
 ## Apps and serving
 
-- Apps and Serving enables customers to deploy long-running web applications — Streamlit dashboards, FastAPI services, notebooks, and inference endpoints — directly on the customer's data plane.
+- Apps and Serving enables customers to deploy long-running web applications -- Streamlit dashboards, FastAPI services, notebooks, and inference endpoints -- directly on the customer's data plane.
 - Apps run as Knative Services within tenant-scoped Kubernetes namespaces, with the Union Operator managing the full lifecycle including autoscaling and scale-to-zero.
 - No application code, data, or serving traffic passes through the Union control plane.
-- Inbound traffic routes through Cloudflare for DDoS protection to a Kourier gateway (Union's Envoy fork) running on the customer's cluster, which enforces authentication against the control plane before forwarding to the app container.
+- Traffic reaches apps via the **Direct-to-DataPlane tunnel**, an outbound-only mTLS connection from the data plane through Cloudflare. This same tunnel infrastructure also serves data visualization traffic including logs, task inputs/outputs, metrics, and signed URLs, ensuring that no customer data is relayed through the control plane.
+- Inbound traffic routes through Cloudflare for DDoS protection to a Kourier gateway (Union's Envoy fork) running on the customer's cluster, which enforces authentication and RBAC before forwarding to the app container or DataProxy.
 - Browser access uses SSO; programmatic access requires a Union API key.
 - All endpoints require authentication by default, with optional per-app anonymous access.
 - Union's RBAC controls which users can deploy and access apps per project, and resource quotas constrain consumption.
@@ -104,8 +123,9 @@ At no point does the Executor communicate directly with external services outsid
 ## Object store service
 
 The Object Store Service runs on the data plane and provides the signing capabilities that enable the presigned URL security model.
+All presigned URLs are generated locally on the data plane using the customer's IAM credentials -- the control plane is never involved in the signing process.
 Its key operations include:
-- `CreateSignedURL` (generates presigned URLs using the customer’s IAM credentials via the admin role).
+- `CreateSignedURL` (generates presigned URLs using the customer's IAM credentials via the admin role).
 - `CreateUploadLocation` (generates presigned `PUT` URLs for fast registration with `Content-MD5` integrity verification)
 - `Presign` (generic presigning for arbitrary object store keys)
 - `Get`/`Put` (direct object store read/write used internally by platform services).
@@ -119,17 +139,51 @@ The Log Provider runs on the data plane and serves task logs from two sources.
 For live tasks, logs are streamed directly from the Kubernetes API (pod stdout/stderr) in real time.
 For completed tasks, logs are read from the cloud log aggregator (CloudWatch, Cloud Logging, or Azure Monitor) after pod termination.
 Union also supports persisting logs in object storage.
+
+Logs are served directly from the data plane to the client via the Direct-to-DataPlane tunnel.
+The control plane never sees or relays log content.
+
 Log lines include structured metadata: timestamp, message content, and originator classification (user vs. system).
 This structured approach enables security teams to distinguish between application-generated logs and platform-generated logs for audit purposes.
 
 ## Image builder
 
-When enabled, the Image Builder runs on the data plane and uses Buildkit to construct container images without exposing source code or built artifacts outside the customer’s infrastructure.
-The build process pulls the base image from a customer-approved registry (public or private), accesses user code via a presigned URL with a limited time-to-live, builds the container image with specified layers (pip packages, apt packages, custom commands, UV/Poetry projects), and pushes the built image to the customer’s container registry (ECR, GCR, ACR, or others).
-Source code and built images never leave the customer’s infrastructure during the build process.
+When enabled, the Image Builder runs on the data plane and uses Buildkit to construct container images without exposing source code or built artifacts outside the customer's infrastructure.
+The build process pulls the base image from a customer-approved registry (public or private), accesses user code via a presigned URL with a limited time-to-live, builds the container image with specified layers (pip packages, apt packages, custom commands, UV/Poetry projects), and pushes the built image to the customer's container registry (ECR, GCR, ACR, or others).
+Source code and built images never leave the customer's infrastructure during the build process.
 
 ## Tunnel service
 
-The Tunnel Service maintains the Cloudflare Tunnel connection between the data plane and control plane.
-It is responsible for initiating and maintaining the outbound-only encrypted connection, performing periodic health checks and heartbeats, and reconnecting automatically in case of network disruption.
+The Tunnel Service maintains two Cloudflare Tunnel connections between the data plane and the outside world.
+Both tunnels are outbound-only, mTLS-encrypted connections initiated from the data plane, so no inbound ports are opened on the customer's cluster.
+
+**Control plane tunnel.** Carries orchestration traffic between the data plane and control plane:
+- TaskAction delivery from Queue Service to Executor.
+- State transitions from Executor to State Service.
+- Health checks and DNS reconciliation from Cluster Service.
+
+**Direct-to-DataPlane tunnel.** Carries data, logs, metrics, apps, and signed URLs directly between the client and the data plane, bypassing the control plane entirely:
+- Task input/output data and presigned URLs via DataProxy.
+- Log streams via DataProxy.
+- Metrics via DataProxy.
+- App serving traffic via Kourier gateway.
+
+Traffic on the Direct-to-DataPlane tunnel is authenticated by the Envoy router in the Kourier gateway, which enforces RBAC policies before forwarding requests to DataProxy or app containers.
+Endpoints follow the subdomain pattern `*.apps.<org>.hosted.unionai.cloud`.
+
 The Cluster Service on the control plane performs periodic reconciliation to ensure tunnel health and DNS records are current.
+The Tunnel Service is responsible for initiating and maintaining both outbound-only encrypted connections, performing periodic health checks and heartbeats, and reconnecting automatically in case of network disruption.
+
+## DataProxy
+
+DataProxy runs on the data plane and serves as the single point through which all non-orchestration data reaches the client.
+It handles:
+- **Presigned URL generation** -- delegates to the Object Store Service, which signs URLs locally using the customer's IAM credentials.
+- **Log retrieval** -- fetches live and completed logs from the Log Provider.
+- **Task input/output serving** -- provides data needed by the UI to display task details.
+- **Auxiliary UI display data** -- serves supplementary information (deck HTML, metadata) for the Union console.
+- **Metrics** -- serves execution metrics for display and monitoring.
+
+All DataProxy traffic reaches the data plane via the Direct-to-DataPlane tunnel.
+The Envoy router in the Kourier gateway authenticates every request and enforces RBAC before forwarding to DataProxy.
+The control plane never sees or relays any of this data.

--- a/content/security/components-architecture.md
+++ b/content/security/components-architecture.md
@@ -179,6 +179,9 @@ The Tunnel Service is responsible for initiating and maintaining both outbound-o
 
 ## DataProxy
 
+{{< tabs >}}
+{{< tab "Zero-trust (current)" >}}
+{{< markdown >}}
 DataProxy runs on the data plane and serves as the single point through which all non-orchestration data reaches the client.
 It handles:
 - **Presigned URL generation** -- delegates to the Object Store Service, which signs URLs locally using the customer's IAM credentials.
@@ -190,3 +193,11 @@ It handles:
 All DataProxy traffic reaches the data plane via the Direct-to-DataPlane tunnel.
 The Envoy router in the Kourier gateway authenticates every request and enforces RBAC before forwarding to DataProxy.
 The control plane never sees or relays any of this data.
+{{< /markdown >}}
+{{< /tab >}}
+{{< tab "Previous architecture" >}}
+{{< markdown >}}
+This section did not exist in the previous architecture. DataProxy previously ran on the control plane, where it acted as a stateless relay for logs and metrics and proxied presigned URL generation requests to the data plane.
+{{< /markdown >}}
+{{< /tab >}}
+{{< /tabs >}}

--- a/content/security/data-protection.md
+++ b/content/security/data-protection.md
@@ -56,6 +56,9 @@ Every data type handled by the platform is classified by residency and access pa
 
 ## Zero-trust data guarantees
 
+{{< tabs >}}
+{{< tab "Zero-trust (current)" >}}
+{{< markdown >}}
 Union.ai's zero-trust architecture ensures that no customer data, operational metadata, or logs ever transit through the control plane.
 This guarantee applies to all data retrieval and visualization operations:
 
@@ -69,6 +72,14 @@ The control plane handles only orchestration metadata: task definitions, run/act
 
 This zero-trust guarantee is contractual.
 See [Deployment models and security tiers](./deployment-models) for details on the Default and Enterprise 1 configurations.
+{{< /markdown >}}
+{{< /tab >}}
+{{< tab "Previous architecture" >}}
+{{< markdown >}}
+This section did not exist in the previous architecture.
+{{< /markdown >}}
+{{< /tab >}}
+{{< /tabs >}}
 
 ## Encryption at rest
 

--- a/content/security/data-protection.md
+++ b/content/security/data-protection.md
@@ -17,13 +17,32 @@ Every data type handled by the platform is classified by residency and access pa
 | Code bundles | Customer Data | Customer object store | No — direct via presigned URL |
 | Container images | Customer Data | Customer registry | No — stays in customer infra |
 | Reports (HTML) | Customer Data | Customer object store | No — direct via presigned URL |
-| Task logs | Customer Data | Customer log aggregator | Relayed in-memory (not stored) |
+| Task logs | Customer Data | Customer log aggregator | No — served directly from data plane |
 | Secrets | Customer Data | Customer secrets backend | Relayed during create (not stored) |
-| Observability metrics | Customer Data | Customer data plane | Relayed in-memory (not stored) |
+| Observability metrics | Customer Data | Customer data plane | No — served directly from data plane |
 | Task definitions | Orchestration Metadata | Control plane DB | Yes — metadata only |
 | Run/action metadata | Orchestration Metadata | Control plane DB | Yes |
 | User identity/RBAC | Platform Metadata | Control plane DB | Yes |
 | Cluster records | Platform Metadata | Control plane DB | Yes |
+
+> [!NOTE] Information needed
+> The zero-trust architecture eliminates all data transit through the control plane for visualization and retrieval. Whether the secret creation relay is also being changed is not yet confirmed.
+
+## Zero-trust data guarantees
+
+Union.ai's zero-trust architecture ensures that no customer data, operational metadata, or logs ever transit through the control plane.
+This guarantee applies to all data retrieval and visualization operations:
+
+* **Task inputs and outputs** are accessed via presigned URLs generated entirely on the data plane
+* **Logs** are served directly from the data plane via the [Direct-to-DataPlane tunnel](./network-security#direct-to-dataplane-tunnel)
+* **Observability metrics** are served directly from the data plane
+* **Reports and code bundles** are accessed via presigned URLs generated on the data plane
+* **Apps and auxiliary UIs** (Ray dashboard, Spark history server) are served from the data plane
+
+The control plane handles only orchestration metadata: task definitions, run/action state, user identity, and cluster records.
+
+This zero-trust guarantee is contractual.
+See [Deployment models and security tiers](./deployment-models) for details on the Default and Enterprise 1 configurations.
 
 ## Encryption at rest
 
@@ -45,21 +64,22 @@ No unencrypted communication paths exist in the platform architecture.
 
 - All client-to-control-plane communication uses TLS 1.2 or higher.
 - All control-plane-to-data-plane communication uses mutual TLS via Cloudflare Tunnel.
+- All client-to-data-plane communication (via the Direct-to-DataPlane tunnel) uses TLS 1.2 or higher, with authentication enforced by the Envoy router.
 - All client-to-object-store communication (via presigned URLs) uses HTTPS, enforced by cloud providers.
 - All internal data plane communication uses cloud-native TLS.
 
 ## Data residency and sovereignty
 
-Union.ai’s architecture provides strong data residency guarantees:
+Union.ai's architecture provides strong data residency guarantees:
 
 ### Data plane
 
-* All customer data resides in the customer’s own cloud account and region
+* All customer data resides exclusively in the customer's own cloud account and region. Under the zero-trust architecture, customer data never leaves the customer's infrastructure — not even temporarily for visualization.
 * Customers choose the region for their data plane deployment
 
 ### Control plane
 
 * Union.ai hosts your control plane in these supported regions: US West, US East, EU West-1 (Ireland), EU West-2 (London), EU Central, with more being added
-* No customer data is replicated to or cached in Union.ai infrastructure. See [Data classification](#data-classification) for more detail on data classification and handling.
+* No customer data is stored, relayed, or cached in Union.ai infrastructure. See [Data classification](#data-classification) for more detail on data classification and handling.
 
-For organizations operating under GDPR or other data residency regulations, Union.ai’s EU-region data planes ensure all customer data remains within the European Union.
+For organizations operating under GDPR or other data residency regulations, Union.ai's EU-region data planes ensure all customer data remains within the European Union.

--- a/content/security/data-protection.md
+++ b/content/security/data-protection.md
@@ -6,11 +6,17 @@ variants: -flyte +union
 
 # Data protection
 
+> [!TIP] Updated for zero-trust architecture
+> This page has been updated to reflect the zero-trust security architecture. Tabbed comparisons below highlight key changes.
+
 ## Data classification
 
 Union.ai maintains a rigorous data classification framework.
 Every data type handled by the platform is classified by residency and access pattern:
 
+{{< tabs >}}
+{{< tab "Zero-trust (current)" >}}
+{{< markdown >}}
 | Data Type | Classification | Residency | Transits Control Plane? |
 | --- | --- | --- | --- |
 | Task inputs/outputs | Customer Data | Customer object store | No — direct via presigned URL |
@@ -24,6 +30,26 @@ Every data type handled by the platform is classified by residency and access pa
 | Run/action metadata | Orchestration Metadata | Control plane DB | Yes |
 | User identity/RBAC | Platform Metadata | Control plane DB | Yes |
 | Cluster records | Platform Metadata | Control plane DB | Yes |
+{{< /markdown >}}
+{{< /tab >}}
+{{< tab "Previous architecture" >}}
+{{< markdown >}}
+| Data Type | Classification | Residency | Transits Control Plane? |
+| --- | --- | --- | --- |
+| Task inputs/outputs | Customer Data | Customer object store | No — direct via presigned URL |
+| Code bundles | Customer Data | Customer object store | No — direct via presigned URL |
+| Container images | Customer Data | Customer registry | No — stays in customer infra |
+| Reports (HTML) | Customer Data | Customer object store | No — direct via presigned URL |
+| Task logs | Customer Data | Customer log aggregator | Relayed in-memory (not stored) |
+| Secrets | Customer Data | Customer secrets backend | Relayed during create (not stored) |
+| Observability metrics | Customer Data | Customer data plane | Relayed in-memory (not stored) |
+| Task definitions | Orchestration Metadata | Control plane DB | Yes — metadata only |
+| Run/action metadata | Orchestration Metadata | Control plane DB | Yes |
+| User identity/RBAC | Platform Metadata | Control plane DB | Yes |
+| Cluster records | Platform Metadata | Control plane DB | Yes |
+{{< /markdown >}}
+{{< /tab >}}
+{{< /tabs >}}
 
 > [!NOTE] Information needed
 > The zero-trust architecture eliminates all data transit through the control plane for visualization and retrieval. Whether the secret creation relay is also being changed is not yet confirmed.

--- a/content/security/data-residency-summary.md
+++ b/content/security/data-residency-summary.md
@@ -1,6 +1,6 @@
 ---
 title: Data residency summary
-weight: 14
+weight: 16
 variants: -flyte +union
 ---
 
@@ -15,8 +15,11 @@ variants: -flyte +union
 | Code bundles | Customer object store | Presigned URL | No — direct client ↔ object store |
 | Reports (HTML) | Customer object store | Presigned URL | No — direct client ↔ object store |
 | Container images | Customer container registry | Pulled by K8s | No — stays in customer infra |
-| Task logs | Customer log aggregator | Streamed via tunnel | Relayed in-memory (not stored) |
-| Secrets | Customer secrets backend | Injected at runtime | Relayed during create (not stored) |
-| Observability metrics | Customer ClickHouse | Proxied via DataProxy | Relayed in-memory (not stored) |
+| Task logs | Customer log aggregator | Direct-to-DataPlane tunnel | No — served directly from data plane |
+| Secrets | Customer secrets backend | Injected at runtime | Relayed during create (not stored)* |
+| Observability metrics | Customer ClickHouse | Direct-to-DataPlane tunnel | No — served directly from data plane |
 | User identity / RBAC | Control plane DB | ConnectRPC | Yes |
 | Cluster state | Control plane DB | Internal | Yes |
+
+> [!NOTE] Information needed
+> *The zero-trust architecture eliminates all data transit through the control plane for visualization and retrieval. Whether the secret creation relay is also changing under the zero-trust model has not yet been confirmed.

--- a/content/security/data-residency-summary.md
+++ b/content/security/data-residency-summary.md
@@ -6,6 +6,12 @@ variants: -flyte +union
 
 # Data residency summary
 
+> [!TIP] Updated for zero-trust architecture
+> The "Accessed Via" and "Transits Control Plane?" columns have been updated for logs and metrics.
+
+{{< tabs >}}
+{{< tab "Zero-trust (current)" >}}
+{{< markdown >}}
 | Data | Stored In | Accessed Via | Transits Control Plane? |
 | --- | --- | --- | --- |
 | Task definitions (spec metadata) | Control plane DB | ConnectRPC | Yes — metadata only |
@@ -23,3 +29,24 @@ variants: -flyte +union
 
 > [!NOTE] Information needed
 > *The zero-trust architecture eliminates all data transit through the control plane for visualization and retrieval. Whether the secret creation relay is also changing under the zero-trust model has not yet been confirmed.
+{{< /markdown >}}
+{{< /tab >}}
+{{< tab "Previous architecture" >}}
+{{< markdown >}}
+| Data | Stored In | Accessed Via | Transits Control Plane? |
+| --- | --- | --- | --- |
+| Task definitions (spec metadata) | Control plane DB | ConnectRPC | Yes — metadata only |
+| Run metadata (phase, timestamps) | Control plane DB | ConnectRPC | Yes |
+| Action metadata (phase, attempts) | Control plane DB | ConnectRPC | Yes |
+| Task inputs/outputs | Customer object store | Presigned URL | No — direct client ↔ object store |
+| Code bundles | Customer object store | Presigned URL | No — direct client ↔ object store |
+| Reports (HTML) | Customer object store | Presigned URL | No — direct client ↔ object store |
+| Container images | Customer container registry | Pulled by K8s | No — stays in customer infra |
+| Task logs | Customer log aggregator | Streamed via tunnel | Relayed in-memory (not stored) |
+| Secrets | Customer secrets backend | Injected at runtime | Relayed during create (not stored) |
+| Observability metrics | Customer ClickHouse | Proxied via DataProxy | Relayed in-memory (not stored) |
+| User identity / RBAC | Control plane DB | ConnectRPC | Yes |
+| Cluster state | Control plane DB | Internal | Yes |
+{{< /markdown >}}
+{{< /tab >}}
+{{< /tabs >}}

--- a/content/security/deployment-models.md
+++ b/content/security/deployment-models.md
@@ -6,6 +6,9 @@ variants: -flyte +union
 
 # Deployment models and security tiers
 
+> [!TIP] New in zero-trust architecture
+> This page was introduced as part of the zero-trust security architecture.
+
 ## Overview
 
 Union.ai deployments have two independent dimensions:

--- a/content/security/deployment-models.md
+++ b/content/security/deployment-models.md
@@ -1,0 +1,80 @@
+---
+title: Deployment models and security tiers
+weight: 13
+variants: -flyte +union
+---
+
+# Deployment models and security tiers
+
+## Overview
+
+Union.ai deployments have two independent dimensions:
+
+* **Security tier** determines how data is accessed and who can see it.
+* **Operational model** determines who manages the data plane infrastructure.
+
+These dimensions are orthogonal: any security tier can be combined with any operational model.
+This page describes the security tiers in detail.
+For operational model differences, see [BYOC deployment differences](./byoc-differences).
+
+## Security tiers
+
+Union.ai offers two security tiers that control how data flows between the data plane and end users.
+Both tiers enforce the same zero-trust guarantee: no customer data, metadata, or logs ever transit through the Union.ai control plane.
+The tiers differ in how clients connect to the data plane and who can access data through the UI.
+
+### Default
+
+The Default tier uses the Direct-to-DataPlane tunnel via Cloudflare to serve all data directly from the customer's VPC.
+This is the standard configuration for all Union.ai plans (Starter, Team, and Enterprise).
+
+Key characteristics:
+
+* All data visualization, logs, metrics, and task inputs/outputs are served from the data plane via the Cloudflare tunnel.
+* No customer data transits the control plane. This is a contractual guarantee.
+* The `dataproxy` service runs entirely within the customer's VPC, handling presigned URL generation and data streaming.
+* An Envoy router within the data plane handles authentication and RBAC enforcement.
+* No additional infrastructure is required from the customer beyond the standard data plane setup.
+
+### Enterprise 1: Enhanced security
+
+The Enterprise 1 tier adds VPN-restricted access on top of all Default tier guarantees.
+The customer's SRE/DevOps team provisions a load balancer within their VPC that is routable only from within their corporate VPN.
+This ensures that only VPN-connected users in the customer's organization can access data plane endpoints.
+
+Key characteristics:
+
+* No Union.ai employee can ever see customer data, because data plane access requires VPN connectivity.
+* Union.ai RBAC and SSO continue to work as in the Default tier.
+* Recommended for organizations with the strictest data access requirements and for high-scale model serving within their cloud.
+* Available on Enterprise plans only.
+
+> [!NOTE] Information needed
+> The exact load balancer configuration requirements, supported types, and DNS setup steps are not yet documented.
+
+> [!NOTE] Information needed
+> "Enterprise 1" is an internal codename. The final product name for this tier has not been confirmed.
+
+## Comparison matrix
+
+| Feature | Default | Enterprise 1 |
+| --- | --- | --- |
+| Data transit through control plane | No | No |
+| Who can see data in UI | Authenticated users via SSO | VPN-connected users only |
+| Union employee data visibility | No -- data served from data plane | No -- VPN restricts all access |
+| Network requirements | Cloudflare egress | Customer-managed LB + VPN |
+| Available plans | All (Starter, Team, Enterprise) | Enterprise only |
+| Configuration complexity | None -- default setup | Customer provisions LB |
+
+## Operational models
+
+The operational model is an independent dimension from the security tier.
+It determines who manages the data plane infrastructure:
+
+* **BYOC (Bring Your Own Cloud):** Union.ai manages the Kubernetes cluster in the customer's cloud account via private connectivity (PrivateLink/PSC). Union.ai handles upgrades, monitoring, and provisioning while maintaining strict separation from customer data, secrets, and logs.
+* **Self-Managed:** The customer operates their data plane independently. Union.ai has zero access to the customer's infrastructure, with the Cloudflare tunnel as the only connection between the control plane and data plane.
+
+Both operational models work with either security tier.
+The core security architecture -- encryption, RBAC, tenant isolation, presigned URL data access, and audit logging -- is identical across all combinations.
+
+For a detailed comparison of operational models, see [BYOC deployment differences](./byoc-differences).

--- a/content/security/identity-and-access-management.md
+++ b/content/security/identity-and-access-management.md
@@ -71,11 +71,33 @@ Union.ai operates a zero-trust architecture in which data visualization (logs, i
 
 ### Default deployment
 
+{{< tabs >}}
+{{< tab "Zero-trust (current)" >}}
+{{< markdown >}}
 In the default deployment, all data visualization traffic flows through the Direct-to-DataPlane tunnel from the customer's data plane directly to the client. Union.ai personnel accessing a customer's tenant see only orchestration metadata (workflow definitions, run status, scheduling configuration). Customer data (logs, inputs/outputs, metrics, reports) is served from the data plane and does not transit the control plane, so it is not visible to Union.ai personnel through the control plane UI.
+{{< /markdown >}}
+{{< /tab >}}
+{{< tab "Previous architecture" >}}
+{{< markdown >}}
+This section did not exist in the previous architecture. Union.ai personnel could view logs relayed through the control plane tunnel.
+{{< /markdown >}}
+{{< /tab >}}
+{{< /tabs >}}
 
 ### Enterprise 1: VPN-restricted access
 
+{{< tabs >}}
+{{< tab "Zero-trust (current)" >}}
+{{< markdown >}}
 For organizations requiring the highest assurance, the Enterprise 1 configuration restricts all data visualization to users connected to the organization's corporate VPN. A customer-managed load balancer within the VPC replaces the Cloudflare-terminated Direct-to-DataPlane tunnel. No Union.ai employee can ever see customer data under this configuration. Union.ai's RBAC and SSO continue to function. See [Deployment models and security tiers](./deployment-models) for configuration details.
+{{< /markdown >}}
+{{< /tab >}}
+{{< tab "Previous architecture" >}}
+{{< markdown >}}
+This section did not exist in the previous architecture.
+{{< /markdown >}}
+{{< /tab >}}
+{{< /tabs >}}
 
 ### Access scope and limitations
 

--- a/content/security/identity-and-access-management.md
+++ b/content/security/identity-and-access-management.md
@@ -16,7 +16,7 @@ Union.ai supports three authentication methods to accommodate different usage pa
 | API Keys | Human user (delegated) | Static bearer token | CI/CD scripts, simple automation |
 | Service Accounts | Application identity | OAuth2 client_id + client_secret → short-lived token | Production pipelines, multi-service systems |
 
-API keys are issued per user and inherit the user’s RBAC permissions.
+API keys are issued per user and inherit the user's RBAC permissions.
 They can be created and revoked via the UI or CLI.
 Service accounts are provisioned through the Identity Service, creating OAuth2 applications with distinct, auditable identities independent of any human user.
 
@@ -32,7 +32,7 @@ Union.ai implements a policy-based Role-Based Access Control (RBAC) system with 
 | Custom Policies | Custom policies bind roles (built-in or custom) to resources scoped at org-wide, domain, or project+domain level using composable YAML bindings via `uctl` | Giving contributor access to a specific project's development and staging domains, but only viewer access in production |
 
 RBAC policies are enforced at the service layer.
-Every API request is authenticated and authorized against the user’s role assignments before any data access occurs.
+Every API request is authenticated and authorized against the user's role assignments before any data access occurs.
 Users have the ability to create custom policies to further refine access control.
 
 ## Organization isolation
@@ -59,16 +59,24 @@ Tenant isolation controls are covered by Union.ai's SOC 2 Type II audit scope. T
 
 Union.ai maintains controls governing how its personnel interact with customer environments.
 
-### Current access model
+### Access model
 
-Union.ai support and engineering personnel may access a customer's Union.ai tenant (the control plane UI and API for that organization) for the purposes of onboarding, troubleshooting, and operational support. This access is authenticated through the same OIDC/SSO mechanisms as customer users and is subject to RBAC policies. Personnel access the customer's tenant, not the customer's data plane infrastructure directly. Union.ai personnel do not have IAM credentials for the customer's cloud account and cannot directly access the customer's object stores, secrets backends, or container registries.
+Union.ai operates a zero-trust architecture in which data visualization (logs, inputs/outputs, metrics) is served directly from the customer's data plane via the Direct-to-DataPlane tunnel. Union.ai personnel who access a customer's tenant can view orchestration metadata but cannot see customer data, because customer data is never routed through the control plane. Personnel access is authenticated through the same OIDC/SSO mechanisms as customer users and is subject to RBAC policies. Personnel access the customer's tenant, not the customer's data plane infrastructure directly. Union.ai personnel do not have IAM credentials for the customer's cloud account and cannot directly access the customer's object stores, secrets backends, or container registries.
 
 > [!NOTE]
 > In BYOC deployments, Union.ai personnel additionally have K8s cluster management access. See [BYOC deployment differences: Human access](./byoc-differences#human-access-to-customer-environments) for details.
 
+### Default deployment
+
+In the default deployment, all data visualization traffic flows through the Direct-to-DataPlane tunnel from the customer's data plane directly to the client. Union.ai personnel accessing a customer's tenant see only orchestration metadata (workflow definitions, run status, scheduling configuration). Customer data (logs, inputs/outputs, metrics, reports) is served from the data plane and does not transit the control plane, so it is not visible to Union.ai personnel through the control plane UI.
+
+### Enterprise 1: VPN-restricted access
+
+For organizations requiring the highest assurance, the Enterprise 1 configuration restricts all data visualization to users connected to the organization's corporate VPN. A customer-managed load balancer within the VPC replaces the Cloudflare-terminated Direct-to-DataPlane tunnel. No Union.ai employee can ever see customer data under this configuration. Union.ai's RBAC and SSO continue to function. See [Deployment models and security tiers](./deployment-models) for configuration details.
+
 ### Access scope and limitations
 
-When Union.ai personnel access a customer's tenant, they can view orchestration metadata (workflow definitions, run status, scheduling configuration), view logs relayed through the tunnel (but cannot access the customer's log aggregator directly), and perform administrative operations (cluster configuration, namespace provisioning) as authorized by the customer's RBAC policy. Personnel cannot read secret values (the API is write-only for values), cannot access raw data in the customer's object stores (presigned URLs are generated per-request and are not retained), and cannot access the customer's cloud account or IAM roles. In BYOC deployments, administrative operations [extend to direct K8s cluster management](./byoc-differences#human-access-to-customer-environments).
+When Union.ai personnel access a customer's tenant, they can view orchestration metadata (workflow definitions, run status, scheduling configuration) and perform administrative operations (cluster configuration, namespace provisioning) as authorized by the customer's RBAC policy. Personnel cannot see customer data in the UI (data is served from the data plane, not the control plane), cannot read secret values (the API is write-only for values), cannot access raw data in the customer's object stores (presigned URLs are generated per-request and are not retained), and cannot access the customer's cloud account or IAM roles. In BYOC deployments, administrative operations [extend to direct K8s cluster management](./byoc-differences#human-access-to-customer-environments).
 
 ### Audit trail
 

--- a/content/security/identity-and-access-management.md
+++ b/content/security/identity-and-access-management.md
@@ -6,6 +6,9 @@ variants: -flyte +union
 
 # Identity and access management
 
+> [!TIP] Updated for zero-trust architecture
+> The human access model has been updated to reflect the Default and Enterprise 1 security tiers.
+
 ## Authentication
 
 Union.ai supports three authentication methods to accommodate different usage patterns:

--- a/content/security/infrastructure-security.md
+++ b/content/security/infrastructure-security.md
@@ -37,14 +37,15 @@ Two IAM roles are provisioned per data plane, each with narrowly scoped permissi
 
 | Role | Permissions | Assumed By | Mechanism |
 | --- | --- | --- | --- |
-| Admin Role (`adminflyterole`) | R/W to object store buckets, secrets manager access, persisted logs read | Platform services: Executor, Object Store Service, DataProxy | Workload identity federation |
+| Admin Role (`adminflyterole`) | R/W to object store buckets, secrets manager access, persisted logs read | Platform services: Executor, Object Store Service, DataProxy (all on data plane) | Workload identity federation |
 | User Role (`userflyterole`) | R/W to object store buckets | Task pods (user workloads) | Workload identity via K8s service account annotation |
 
 These roles use cloud-native workload identity federation (IAM Roles for Service Accounts on AWS, Workload Identity on GCP, Azure Workload Identity on Azure), eliminating the need for static credential storage.
 
 ## Control plane infrastructure
 
-The Union.ai control plane is hosted on AWS with enterprise-grade infrastructure security:
+The Union.ai control plane is hosted on AWS with enterprise-grade infrastructure security.
+Under the zero-trust architecture, the control plane handles only orchestration metadata — the DataProxy service has been relocated to the data plane, reducing the control plane's attack surface.
 
 * Managed PostgreSQL (AWS RDS) with AES-256 encryption at rest
 * Network isolation via VPC with restricted security groups

--- a/content/security/kubernetes-rbac-control-plane.md
+++ b/content/security/kubernetes-rbac-control-plane.md
@@ -1,6 +1,6 @@
 ---
 title: "Kubernetes RBAC: Control plane"
-weight: 16
+weight: 18
 variants: -flyte +union
 ---
 
@@ -17,7 +17,7 @@ variants: -flyte +union
 | `console-clusterrole` | Read-only access for Union Console UI to display namespaces, workflows, and pod logs | ""(core) `flyte.lyft.com` | `namespaces flyteworkflows pods pods/log` | `get list watch` |
 | `authorizer-clusterrole` | Authorizer service reads namespaces for authorization decisions | ""(core) | `namespaces` | `get list watch` |
 | `cluster-clusterrole` | Cluster management service monitors cluster state for health and capacity | ""(core) `apps` | `namespaces nodes replicasets deployments` | `get list watch` |
-| `dataproxy-clusterrole` | DataProxy service reads secrets for presigned URL generation and data relay configuration | ""(core) | `secrets` | `get list watch` |
+| `dataproxy-clusterrole` | **Relocated to data plane under zero-trust architecture.** Previously handled presigned URL generation and data relay on the control plane. See [Kubernetes RBAC: data plane](./kubernetes-rbac-data-plane). | — | — | — |
 | `executions-clusterrole` | Executions service reads workflow state for execution management and status tracking | ""(core) `flyte.lyft.com` | `namespaces configmaps flyteworkflows` | `get list watch` |
 | `queue-clusterrole` | Queue service reads namespaces for task queue routing | ""(core) | `namespaces` | `get list watch` |
 | `run-scheduler-clusterrole` | Run Scheduler reads namespaces to determine scheduling scope for workflows | ""(core) | `namespaces` | `get list watch` |

--- a/content/security/kubernetes-rbac-data-plane.md
+++ b/content/security/kubernetes-rbac-data-plane.md
@@ -1,6 +1,6 @@
 ---
 title: "Kubernetes RBAC: Data plane"
-weight: 17
+weight: 19
 variants: -flyte +union
 ---
 
@@ -19,6 +19,9 @@ variants: -flyte +union
 | `proxy-system-secret` | Manages proxy service secrets within the union namespace for tunnel authentication and configuration | Role | "*" | union namespace | `secrets` | `get list create update delete` |
 | `operator-system` (ns) | Operator manages its own secrets and deployments within the union namespace | Role | "*" | union namespace | `secrets deployments` | `get list watch create update` |
 | `union-operator-admission` | Webhook admission controller reads/creates TLS secrets for webhook serving certificates | Role | ""(core) | union namespace | `secrets` | `get create` |
+
+> [!NOTE] Information needed
+> Under the zero-trust architecture, the DataProxy service has been relocated from the control plane to the data plane. The exact Kubernetes RBAC roles and permissions for DataProxy running on the data plane are not yet documented. This table will be updated when the DataProxy DP RBAC specification is available.
 
 ## Observability and monitoring
 

--- a/content/security/logging-monitoring-and-audit.md
+++ b/content/security/logging-monitoring-and-audit.md
@@ -8,7 +8,7 @@ variants: -flyte +union
 
 ## Task logging
 
-Logs are collected by `fluentbit` (deployed as a `DaemonSet` on the data plane) and shipped to the customer’s cloud-native log service:
+Logs are collected by `fluentbit` (deployed as a `DaemonSet` on the data plane) and shipped to the customer's cloud-native log service:
 
 | Cloud Provider | Log Service | Integration |
 | --- | --- | --- |
@@ -17,13 +17,16 @@ Logs are collected by `fluentbit` (deployed as a `DaemonSet` on the data plane) 
 | Azure | Azure Monitor / Log Analytics | Fluent Bit → Azure Monitor |
 
 The data plane log provider serves logs from two sources: live logs streamed directly from the Kubernetes API while a task is running, and persisted logs read from the cloud log aggregator after a pod terminates.
-Log data is never stored in the control plane—it is streamed from the customer’s data plane through the Cloudflare tunnel and relayed to the client as a stateless pass-through.
+Under the zero-trust architecture, log data is served directly from the customer's data plane to the client via the [Direct-to-DataPlane tunnel](./network-security#direct-to-dataplane-tunnel). Logs never transit the control plane. The DataProxy service, running on the data plane, handles log retrieval requests authenticated by the Envoy router.
 
 ## Observability metrics
 
 A per-cluster instance (Prometheus and/or ClickHouse) stores time-series observability metrics including resource utilization and cost data.
-Queries are proxied through the DataProxy service to the customer’s instance.
-Metrics data never leaves the customer’s infrastructure. In BYOC deployments, Union.ai [deploys and manages the monitoring stack](./byoc-differences#infrastructure-management).
+The DataProxy service, running on the data plane, serves metric queries directly to clients via the [Direct-to-DataPlane tunnel](./network-security#direct-to-dataplane-tunnel).
+Metrics data never leaves the customer's infrastructure and never transits the control plane. In BYOC deployments, Union.ai [deploys and manages the monitoring stack](./byoc-differences#infrastructure-management).
+
+> [!NOTE] Information needed
+> The zero-trust architecture transitions observability to a push-based model where the data plane pushes metrics rather than the control plane pulling them. The exact mechanism and implementation status are not yet documented.
 
 ## Audit trail
 
@@ -40,4 +43,4 @@ Union.ai maintains comprehensive audit capabilities:
 
 Union.ai maintains documented incident response procedures aligned with SOC 2 Type II requirements.
 These include defined escalation paths, communication protocols, containment procedures, and post-incident review processes.
-The control plane’s stateless handling of customer data limits the potential impact of any control plane incident.
+Under the zero-trust architecture, the control plane handles no customer data at all, further limiting the potential impact of any control plane incident to orchestration metadata only.

--- a/content/security/logging-monitoring-and-audit.md
+++ b/content/security/logging-monitoring-and-audit.md
@@ -6,6 +6,9 @@ variants: -flyte +union
 
 # Logging, monitoring, and audit
 
+> [!TIP] Updated for zero-trust architecture
+> The task logging and observability metrics sections have been updated to reflect the zero-trust security architecture. Tabbed comparisons below highlight key changes.
+
 ## Task logging
 
 Logs are collected by `fluentbit` (deployed as a `DaemonSet` on the data plane) and shipped to the customer's cloud-native log service:
@@ -17,16 +20,40 @@ Logs are collected by `fluentbit` (deployed as a `DaemonSet` on the data plane) 
 | Azure | Azure Monitor / Log Analytics | Fluent Bit → Azure Monitor |
 
 The data plane log provider serves logs from two sources: live logs streamed directly from the Kubernetes API while a task is running, and persisted logs read from the cloud log aggregator after a pod terminates.
+{{< tabs >}}
+{{< tab "Zero-trust (current)" >}}
+{{< markdown >}}
 Under the zero-trust architecture, log data is served directly from the customer's data plane to the client via the [Direct-to-DataPlane tunnel](./network-security#direct-to-dataplane-tunnel). Logs never transit the control plane. The DataProxy service, running on the data plane, handles log retrieval requests authenticated by the Envoy router.
+{{< /markdown >}}
+{{< /tab >}}
+{{< tab "Previous architecture" >}}
+{{< markdown >}}
+Log data is never stored in the control plane—it is streamed from the customer's data plane through the Cloudflare tunnel and relayed to the client as a stateless pass-through.
+{{< /markdown >}}
+{{< /tab >}}
+{{< /tabs >}}
 
 ## Observability metrics
 
+{{< tabs >}}
+{{< tab "Zero-trust (current)" >}}
+{{< markdown >}}
 A per-cluster instance (Prometheus and/or ClickHouse) stores time-series observability metrics including resource utilization and cost data.
 The DataProxy service, running on the data plane, serves metric queries directly to clients via the [Direct-to-DataPlane tunnel](./network-security#direct-to-dataplane-tunnel).
 Metrics data never leaves the customer's infrastructure and never transits the control plane. In BYOC deployments, Union.ai [deploys and manages the monitoring stack](./byoc-differences#infrastructure-management).
 
 > [!NOTE] Information needed
 > The zero-trust architecture transitions observability to a push-based model where the data plane pushes metrics rather than the control plane pulling them. The exact mechanism and implementation status are not yet documented.
+{{< /markdown >}}
+{{< /tab >}}
+{{< tab "Previous architecture" >}}
+{{< markdown >}}
+A per-cluster instance (Prometheus and/or ClickHouse) stores time-series observability metrics including resource utilization and cost data.
+Queries are proxied through the DataProxy service to the customer's instance.
+Metrics data never leaves the customer's infrastructure. In BYOC deployments, Union.ai [deploys and manages the monitoring stack](./byoc-differences#infrastructure-management).
+{{< /markdown >}}
+{{< /tab >}}
+{{< /tabs >}}
 
 ## Audit trail
 

--- a/content/security/multi-cloud-and-region-support.md
+++ b/content/security/multi-cloud-and-region-support.md
@@ -25,5 +25,6 @@ Customers choose the region for their data plane deployment, ensuring that all c
 
 ## Consistent security across clouds
 
-Regardless of the cloud provider selected, Union.ai enforces consistent security guarantees through its architecture: the same control plane/data plane separation, the same presigned URL model, the same tunnel-based connectivity, the same RBAC framework, and the same encryption standards.
+Regardless of the cloud provider selected, Union.ai enforces consistent security guarantees through its architecture: the same control plane/data plane separation, the same zero-trust data isolation (no customer data transits the control plane), the same presigned URL model, the same Direct-to-DataPlane tunnel connectivity, the same RBAC framework, and the same encryption standards.
+The [Default and Enterprise 1 security tiers](./deployment-models) are available across all supported cloud providers.
 Cloud-specific implementations (IAM roles, encryption services, log aggregators) are abstracted by the platform while maintaining native integration with each provider’s security services.

--- a/content/security/network-security.md
+++ b/content/security/network-security.md
@@ -1,0 +1,158 @@
+---
+title: Network security and connectivity
+weight: 14
+variants: -flyte +union
+---
+
+# Network security and connectivity
+
+This page provides a detailed reference for Union.ai's network security architecture, covering all tunnels, communication paths, and connectivity options.
+
+## Network architecture overview
+
+Union.ai uses two separate outbound-only tunnels to connect the customer's data plane to the outside world:
+
+1. **Control plane tunnel** -- carries orchestration commands between the control plane and data plane. No customer data flows through this tunnel.
+2. **Direct-to-DataPlane tunnel** -- carries all data access (logs, inputs/outputs, metrics, presigned URLs, apps, auxiliary UIs) directly between clients and the data plane. The control plane is never in this path.
+
+Both tunnels are outbound-only from the customer's cluster, meaning no inbound firewall rules are required on the customer's network.
+
+![Network security](../_static/images/security/network-security.png)
+
+> [!NOTE]
+> This diagram needs updating to reflect the current Direct-to-DataPlane architecture.
+
+## Control plane tunnel
+
+The control plane tunnel carries orchestration traffic between the Union.ai control plane and the customer's data plane. This includes:
+
+* TaskAction delivery (scheduling commands)
+* State transitions (phase updates, completions, failures)
+* Health checks
+* DNS reconciliation
+
+This tunnel is outbound-only from the customer's cluster, initiated by the Tunnel Service running on the data plane. All traffic uses mutual TLS (mTLS) encryption via Cloudflare's edge network. No customer data flows through this tunnel -- only orchestration metadata.
+
+### Regional endpoints
+
+Union.ai operates regional control plane endpoints:
+
+| Area | Region | Endpoint |
+| --- | --- | --- |
+| US | us-east-2 | hosted.unionai.cloud |
+| US | us-west-2 | us-west-2.unionai.cloud |
+| Europe | eu-west-1 | eu-west-1.unionai.cloud |
+| Europe | eu-west-2 | eu-west-2.unionai.cloud |
+| Europe | eu-central-1 | eu-central-1.unionai.cloud |
+
+In locked-down environments, networking teams can limit egress to published Cloudflare CIDR blocks, and further restrict to specific regions in coordination with the Union.ai networking team.
+
+## Direct-to-DataPlane tunnel
+
+The Direct-to-DataPlane tunnel provides a dedicated path for all data access between clients and the data plane. This tunnel serves:
+
+* Task logs (live and persisted)
+* Task inputs and outputs (via presigned URLs)
+* Observability metrics
+* Presigned URL generation
+* App Serving endpoints
+* Auxiliary UIs (Ray dashboard, Spark UI, etc.)
+
+This tunnel is also outbound-only from the customer's cluster and terminates at Cloudflare's edge network. Traffic is routed to an Envoy router (Kourier gateway) running on the customer's cluster.
+
+### Envoy router responsibilities
+
+The Envoy router on the data plane performs:
+
+* **Interception** -- all incoming traffic through the tunnel is intercepted by the Envoy router
+* **Authentication and RBAC verification** -- each request is authenticated and checked against Union.ai RBAC policies before proceeding
+* **Forwarding** -- approved traffic is forwarded to the appropriate service (DataProxy for presigned URLs, app containers for App Serving, etc.)
+* **Backpressure management** -- manages backpressure for scale-from-zero scenarios, holding requests while containers start up
+
+### Subdomain pattern
+
+The Direct-to-DataPlane tunnel uses the subdomain pattern:
+
+```
+*.apps.<org>.hosted.unionai.cloud
+```
+
+where `<org>` is the customer's organization identifier.
+
+### DDoS protection
+
+Because the tunnel terminates at Cloudflare's edge network, all traffic benefits from Cloudflare's DDoS protection before reaching the customer's infrastructure.
+
+### Shared infrastructure with App Serving
+
+The Direct-to-DataPlane tunnel is the same infrastructure used for Union.ai's App Serving feature. Apps, data visualization, and all data retrieval share this tunnel.
+
+## Enterprise: VPN-routable access
+
+For organizations requiring maximum network security, the Direct-to-DataPlane tunnel can be replaced with a customer-managed load balancer within their VPC. In this configuration:
+
+* The load balancer is routable only from the customer's corporate VPN
+* Union.ai RBAC and SSO enforcement remain fully active on the data plane
+* No Union.ai employee can access customer data (the same guarantee as the default tier)
+* The Cloudflare dependency for data access is eliminated
+
+This is Union.ai's Enterprise deployment tier and is available for organizations with strict network perimeter requirements.
+
+> [!NOTE] Information needed
+> Exact load balancer configuration requirements for the Enterprise tier need to be documented.
+
+> [!NOTE] Information needed
+> Supported load balancer types (ALB, NLB, etc.) and any cloud-specific requirements need to be confirmed.
+
+> [!NOTE] Information needed
+> DNS configuration steps for pointing the Direct-to-DataPlane subdomain to the customer's load balancer need to be documented.
+
+> [!NOTE] Information needed
+> Whether the Enterprise tier introduces different egress requirements compared to the default Cloudflare-based setup needs to be clarified.
+
+## BYOC management connection
+
+In BYOC deployments, Union.ai maintains a private management connection to the customer's Kubernetes cluster. This connection is separate from both the control plane tunnel and the Direct-to-DataPlane tunnel.
+
+| Cloud Provider | Technology |
+| --- | --- |
+| AWS | AWS PrivateLink |
+| GCP | GCP Private Service Connect |
+| Azure | Azure Private Link |
+
+This connection is used exclusively for cluster management operations:
+
+* Kubernetes version upgrades
+* Node pool provisioning
+* Helm chart updates
+* Health monitoring and troubleshooting
+
+The Kubernetes API endpoint is never exposed to the public Internet. No customer data flows through this connection.
+
+See [BYOC deployment differences: Network architecture](./byoc-differences#network-architecture) for full details.
+
+## Communication paths
+
+The following table lists all communication paths in a Union.ai deployment:
+
+| Communication Path | Protocol | Encryption |
+| --- | --- | --- |
+| Client to Control Plane | ConnectRPC (gRPC-Web) over HTTPS | TLS 1.2+ |
+| Client to Data Plane (Direct-to-DataPlane) | HTTPS via Cloudflare Tunnel | TLS 1.2+ (Envoy-terminated) |
+| Control Plane to Data Plane (control tunnel) | Cloudflare Tunnel (outbound-initiated) | mTLS |
+| Client to Object Store (presigned URL) | HTTPS | TLS 1.2+ (cloud provider enforced) |
+| Fluent Bit to Log Aggregator | Cloud provider SDK | TLS (cloud-native) |
+| Task Pods to Object Store | Cloud provider SDK | TLS (cloud-native) |
+| Union.ai to Customer K8s API (BYOC only) | PrivateLink / PSC | mTLS |
+
+## Firewall and egress requirements
+
+Both the control plane tunnel and the Direct-to-DataPlane tunnel require the customer to allow outbound HTTPS traffic to Cloudflare's edge network. No inbound firewall rules are required.
+
+In locked-down environments, egress can be restricted to:
+
+* Published Cloudflare CIDR blocks
+* Specific Cloudflare regions (in coordination with the Union.ai networking team)
+
+> [!NOTE] Information needed
+> Detailed Cloudflare CIDR blocks and region-specific restrictions should be obtained from the Union.ai networking team.

--- a/content/security/network-security.md
+++ b/content/security/network-security.md
@@ -6,6 +6,9 @@ variants: -flyte +union
 
 # Network security and connectivity
 
+> [!TIP] New in zero-trust architecture
+> This page was introduced as part of the zero-trust security architecture.
+
 This page provides a detailed reference for Union.ai's network security architecture, covering all tunnels, communication paths, and connectivity options.
 
 ## Network architecture overview

--- a/content/security/presigned-url-data-types.md
+++ b/content/security/presigned-url-data-types.md
@@ -1,6 +1,6 @@
 ---
 title: Presigned URL data types
-weight: 15
+weight: 17
 variants: -flyte +union
 ---
 

--- a/content/security/security-architecture.md
+++ b/content/security/security-architecture.md
@@ -6,8 +6,28 @@ variants: -flyte +union
 
 # Security architecture
 
-Union.ai’s security architecture is founded on the principle of strict separation between orchestration (control plane) and execution (data plane).
-This architectural decision ensures that customer data remains within the customer’s own cloud infrastructure at all times.
+Union.ai's security architecture is founded on the principle of strict separation between orchestration (control plane) and execution (data plane).
+This architectural decision ensures that customer data remains within the customer's own cloud infrastructure at all times.
+
+## Zero-trust data isolation
+
+Union.ai enforces a zero-trust data isolation model: **no customer data, metadata, or logs ever transit through the Union.ai control plane**.
+
+This guarantee is achieved through two architectural decisions:
+
+1. **DataProxy runs on the data plane.** The `dataproxy` service, which generates presigned URLs and serves data to clients, runs entirely within the customer's VPC. It never runs on or communicates through the control plane.
+2. **Direct-to-DataPlane tunnel.** A dedicated Cloudflare tunnel connects clients (browsers, SDK) directly to the data plane for all data access. This tunnel is separate from the control plane tunnel used for orchestration. All data, logs, metrics, app serving endpoints, and presigned URLs are served through this direct path.
+
+The result is that the control plane handles only orchestration metadata (task definitions, run status, timestamps, RBAC). All customer data access flows directly between the client and the customer's data plane.
+
+Union.ai offers two deployment tiers for the Direct-to-DataPlane tunnel:
+
+* **Default** -- Direct-to-DataPlane via Cloudflare. The tunnel terminates at Cloudflare's edge network, which routes traffic to the data plane in the customer's VPC.
+* **Enterprise** -- Customer-managed VPN-routable load balancer. The customer provisions their own load balancer for the data plane endpoint, eliminating the Cloudflare dependency for data access.
+
+See [Deployment models](./deployment-models) for full details on each tier.
+
+This zero-trust data isolation is a contractual guarantee, not merely an implementation detail.
 
 ## Control plane / data plane separation
 
@@ -16,29 +36,30 @@ The control plane and data plane serve fundamentally different purposes and hand
 ### Control plane (Union.ai hosted)
 
 The control plane is responsible for workflow orchestration, user management, and providing the web interface.
-It runs within Union.ai’s AWS account and stores only orchestration metadata in a managed PostgreSQL database.
+It runs within Union.ai's AWS account and stores only orchestration metadata in a managed PostgreSQL database.
 This metadata includes task definitions (image references, resource requirements, typed interfaces), run and action metadata (identifiers, phase, timestamps, error information), user identity and RBAC records, cluster configuration and health records, and trigger/schedule definitions.
-The control plane never stores customer data payloads.
-It stores only references (URIs) to data in the customer’s object store, no data.
-When data must be surfaced to a client, the control plane either proxies a signing request to generate a presigned URL or relays a data stream from the data plane without persisting it.
+
+The control plane never stores, proxies, relays, or otherwise handles customer data payloads.
+It stores only references (URIs) to data in the customer's object store.
+All data access is performed directly between the client and the data plane via the Direct-to-DataPlane tunnel.
 
 **See comprehensive list of control plane roles and permissions in [Kubernetes RBAC: control plane](./kubernetes-rbac-control-plane).**
 
 ### Data plane (customer hosted)
 
-The data plane runs inside the customer’s own cloud account on their own Kubernetes cluster.
+The data plane runs inside the customer's own cloud account on their own Kubernetes cluster.
 All customer data resides here, including:
 
 | Data Type | Storage Technology | Access Pattern |
 | --- | --- | --- |
-| Task inputs/outputs | Object Store | Read/write by task pods via IAM roles |
-| Code bundles (TGZ) | Object Store (fast-registration bucket) | Write via presigned URL; read by task pods and presigned URL by the browser |
+| Task inputs/outputs | Object Store | Read/write by task pods via IAM roles; served to clients via presigned URLs generated on the data plane |
+| Code bundles (TGZ) | Object Store (fast-registration bucket) | Write via presigned URL; read by task pods and served to clients via presigned URL generated on the data plane |
 | Container images | Container Registry | Built on-cluster; pulled by K8s |
-| Task logs | Cloud Log Aggregator + live K8s API | Streamed via tunnel (never stored in CP) |
+| Task logs | Cloud Log Aggregator + live K8s API | Served directly from data plane via Direct-to-DataPlane tunnel |
 | Secrets | K8s Secrets, Vault, or Cloud Secrets Manager | Injected into pods at runtime |
-| Observability metrics | Prometheus (in-cluster / customer managed) | Proxied queries via DataProxy |
-| Reports (HTML) | Object Store (S3/GCS/Azure Blob) | Accessed by the browser via presigned URL |
-| Cluster events | K8s API (ephemeral) | Live from K8s API |
+| Observability metrics | Prometheus (in-cluster / customer managed) | Served directly from data plane via Direct-to-DataPlane tunnel |
+| Reports (HTML) | Object Store (S3/GCS/Azure Blob) | Served to clients via presigned URL generated on the data plane |
+| Cluster events | K8s API (ephemeral) | Served directly from data plane via Direct-to-DataPlane tunnel |
 
 **See comprehensive list of data plane roles and permissions in [Kubernetes RBAC: data plane](./kubernetes-rbac-data-plane).**
 
@@ -51,19 +72,19 @@ Network security is enforced through multiple layers:
 > [!NOTE]
 > In BYOC deployments, Union.ai additionally maintains a private management connection to the customer's K8s cluster. See [BYOC deployment differences: Network architecture](./byoc-differences#network-architecture) for details.
 
-### Cloudflare tunnel (outbound-only)
-
-The data plane connects to the control plane via a Cloudflare Tunnel—an outbound-only encrypted connection initiated from the customer’s cluster.
-This architecture provides several critical security benefits:
-
-* No inbound firewall rules are required on the customer’s network
-* All traffic through the tunnel uses mutual TLS (mTLS) encryption
-* The Tunnel Service performs periodic health checks and state reconciliation
-* Connection is initiated outward to Cloudflare’s edge network, from the data plane, which then connects to the control plane
-
 ### Control plane tunnel (outbound only)
 
-The data plane reaches out to the control plane to establish a bidirectional, encrypted and authenticated, outbound-only tunnel.
+The data plane connects to the control plane via a Cloudflare Tunnel -- an outbound-only encrypted connection initiated from the customer's cluster.
+This tunnel carries only orchestration traffic (task scheduling, status updates, metadata queries).
+It does not carry customer data.
+
+This architecture provides several critical security benefits:
+
+* No inbound firewall rules are required on the customer's network
+* All traffic through the tunnel uses mutual TLS (mTLS) encryption
+* The Tunnel Service performs periodic health checks and state reconciliation
+* Connection is initiated outward to Cloudflare's edge network, from the data plane, which then connects to the control plane
+
 Union.ai operates regional control plane endpoints:
 
 | Area | Region | Endpoint |
@@ -76,12 +97,25 @@ Union.ai operates regional control plane endpoints:
 
 In locked-down environments, networking teams can limit egress access to published Cloudflare CIDR blocks, and further restrict to specific regions in coordination with the Union networking team.
 
+### Direct-to-DataPlane tunnel (outbound only)
+
+The Direct-to-DataPlane tunnel provides a separate, dedicated path for all data access between clients and the data plane.
+This tunnel is distinct from the control plane tunnel and carries all customer data, logs, metrics, and presigned URL traffic.
+
+In the Default deployment tier, this tunnel uses Cloudflare's edge network. An Envoy router on the data plane authenticates incoming requests and enforces RBAC checks before serving data.
+
+> [!NOTE] Information needed
+> Specific Envoy authentication mechanism details (JWT validation, token exchange flow) to be documented.
+
+In the Enterprise deployment tier, the customer provisions their own VPN-routable load balancer, replacing the Cloudflare dependency for data access while maintaining the same Envoy-based authentication and RBAC enforcement on the data plane.
+
 ### Communication paths
 
 | Communication Path | Protocol | Encryption |
 | --- | --- | --- |
 | Client → Control Plane | ConnectRPC (gRPC-Web) over HTTPS | TLS 1.2+ |
 | Control Plane ↔ Data Plane | Cloudflare Tunnel (outbound-initiated) | mTLS |
+| Client → Data Plane (Direct-to-DataPlane) | HTTPS via Cloudflare Tunnel or customer LB | TLS 1.2+ |
 | Client → Object Store (presigned URL) | HTTPS | TLS 1.2+ (cloud provider enforced) |
 | Fluent Bit → Log Aggregator | Cloud provider SDK | TLS (cloud-native) |
 | Task Pods → Object Store | Cloud provider SDK | TLS (cloud-native) |
@@ -91,44 +125,59 @@ In locked-down environments, networking teams can limit egress access to publish
 
 ## Data flow architecture
 
-Union.ai implements two primary data access patterns, both designed to keep customer data out of the control plane:
+All data access in Union.ai flows directly between the client and the customer's data plane. The control plane is never in the data path.
 
 ### Presigned URL pattern
 
-For task inputs, outputs, code bundles, and reports, the control plane proxies signing requests to the data plane, which generates time-limited presigned URLs using customer-managed credentials.
-The client fetches data directly from the customer’s object store—the data never transits the control plane.
+For task inputs, outputs, code bundles, and reports, the data plane's `dataproxy` service generates time-limited presigned URLs using customer-managed credentials.
+The client obtains these URLs via the Direct-to-DataPlane tunnel and then fetches or uploads data directly to the customer's object store. The control plane is not involved at any point in this flow.
+
 Presigned URLs generated on the data plane are single-object scope, operation-specific (GET or PUT), time-limited (default 1 hour maximum), and transport-encrypted at every hop.
 
 Union.ai applies several controls:
 
-* **TTL enforcement** — URLs expire after a configurable window (default 1 hour, configurable shorter)
-* **Single-object scope** — each URL grants access to exactly one object, not a bucket or prefix
-* **Operation specificity** — each URL is locked to a single operation (GET or PUT)
-* **Transport encryption** — URLs are transmitted only over TLS-encrypted channels
-* **No URL logging** — presigned URLs are not persisted in control plane logs or databases
+* **TTL enforcement** -- URLs expire after a configurable window (default 1 hour, configurable shorter)
+* **Single-object scope** -- each URL grants access to exactly one object, not a bucket or prefix
+* **Operation specificity** -- each URL is locked to a single operation (GET or PUT)
+* **Transport encryption** -- URLs are transmitted only over TLS-encrypted channels
+* **No URL logging** -- presigned URLs are not persisted in any logs or databases outside the data plane
 
 Organizations with stricter requirements can configure shorter TTLs. The presigned URL model was chosen because it eliminates the need for the control plane to hold persistent cloud IAM credentials, which would represent a larger and more persistent attack surface than time-limited bearer URLs.
 
-### Streaming relay pattern
+### Direct data serving pattern
 
-For logs and observability metrics, the control plane acts as a stateless relay—streaming data from the data plane through the Cloudflare tunnel to the client in real time.
-The data passes through the control plane’s memory as a TLS encrypted stream with a termination point in the cloud.
-It is never written to disk, cached, or stored.
+For logs, observability metrics, and Kubernetes events, the data plane serves data directly to the client through the Direct-to-DataPlane tunnel. An Envoy router on the data plane authenticates each request and enforces RBAC checks before returning data. The data is never relayed through, cached in, or written to disk on the control plane.
+
+This pattern replaces the previous streaming relay architecture. Data now flows:
+
+1. Client sends authenticated request through Direct-to-DataPlane tunnel
+2. Envoy router on the data plane validates the request and checks RBAC permissions
+3. Data plane service retrieves the data (from the log aggregator, Prometheus, or K8s API)
+4. Data is returned directly to the client through the tunnel
+
+### SDK direct upload (planned)
+
+> [!NOTE] Information needed
+> SDK direct upload for task inputs is planned. In this pattern, the SDK retrieves a signed URL directly from the data plane and uploads input data to the customer's object store without involving the control plane. Specific timeline and implementation details to be documented.
 
 ### Execution flow diagram
 
 ![Execution flow](../_static/images/security/execution-flow.png)
+
+> [!NOTE] Information needed
+> The execution flow diagram above predates the zero-trust architecture and may not accurately reflect the current Direct-to-DataPlane data flow. An updated diagram is needed.
 
 ### Data in the UI
 
 | Field | What is it? | Where is it stored? | How is it retrieved? |
 | --- | --- | --- | --- |
 | Task names | Python function and module names | Control Plane | CP API |
-| Users’ names | First and last names of users on the platform | IDP | Cached in memory in CP, otherwise retrieved directly from IDP |
-| Inputs/Outputs | Primitive inputs/outputs returned by tasks (e.g. return 5) | Dataplane’s S3 bucket | Cloudflare Tunnel |
-| Logs | Runtime logs written by the task code/SDK | Dataplane K8s for live logs, dataplane S3/Cloudwatch/Stackdriver for persistent logs | Cloudflare Tunnel |
-| K8s Events | Pod autoscaling events explaining whether a node is found or the cluster needs to scale up… etc. | Dataplane K8s | Cloudflare Tunnel |
-| Report | Reports produced by the task code in HTML | Dataplane’s S3 bucket | A signed URL is generated through the tunnel, then the browser renders it in iframe |
-| Code explorer | Code bundled when the task was kicked off, that contains the task code and surrounding dependencies/functions it calls| Dataplane’s S3 bucket | A signed URL is generated through the tunnel, then JS in the browser downloads and unzips the bundle to render |
-| Timeline timestamps | Showing when did a task start, when it moved from queued to running to completed | Control Plane | CP API |
+| Users' names | First and last names of users on the platform | IDP | Cached in memory in CP, otherwise retrieved directly from IDP |
+| Inputs/Outputs | Primitive inputs/outputs returned by tasks (e.g. return 5) | Data plane's object store | Direct-to-DataPlane tunnel (presigned URL generated on data plane, browser fetches from object store) |
+| Logs | Runtime logs written by the task code/SDK | Data plane K8s for live logs, data plane log aggregator for persistent logs | Direct-to-DataPlane tunnel (served directly from data plane) |
+| K8s Events | Pod autoscaling events explaining whether a node is found or the cluster needs to scale up, etc. | Data plane K8s | Direct-to-DataPlane tunnel (served directly from data plane) |
+| Report | Reports produced by the task code in HTML | Data plane's object store | Direct-to-DataPlane tunnel (presigned URL generated on data plane, browser renders in iframe) |
+| Code explorer | Code bundled when the task was kicked off, containing the task code and surrounding dependencies/functions it calls | Data plane's object store | Direct-to-DataPlane tunnel (presigned URL generated on data plane, JS in browser downloads and unzips the bundle to render) |
+| Timeline timestamps | Showing when a task started, when it moved from queued to running to completed | Control Plane | CP API |
 | Errors | Showing the failure message written into stderr or raised exceptions for a task attempt | Control Plane | CP API |
+| Observability metrics | Prometheus metrics for task and workflow performance | Data plane Prometheus | Direct-to-DataPlane tunnel (served directly from data plane) |

--- a/content/security/security-architecture.md
+++ b/content/security/security-architecture.md
@@ -14,6 +14,9 @@ This architectural decision ensures that customer data remains within the custom
 
 ## Zero-trust data isolation
 
+{{< tabs >}}
+{{< tab "Zero-trust (current)" >}}
+{{< markdown >}}
 Union.ai enforces a zero-trust data isolation model: **no customer data, metadata, or logs ever transit through the Union.ai control plane**.
 
 This guarantee is achieved through two architectural decisions:
@@ -31,6 +34,14 @@ Union.ai offers two deployment tiers for the Direct-to-DataPlane tunnel:
 See [Deployment models](./deployment-models) for full details on each tier.
 
 This zero-trust data isolation is a contractual guarantee, not merely an implementation detail.
+{{< /markdown >}}
+{{< /tab >}}
+{{< tab "Previous architecture" >}}
+{{< markdown >}}
+This section did not exist in the previous architecture.
+{{< /markdown >}}
+{{< /tab >}}
+{{< /tabs >}}
 
 ## Control plane / data plane separation
 
@@ -102,6 +113,9 @@ In locked-down environments, networking teams can limit egress access to publish
 
 ### Direct-to-DataPlane tunnel (outbound only)
 
+{{< tabs >}}
+{{< tab "Zero-trust (current)" >}}
+{{< markdown >}}
 The Direct-to-DataPlane tunnel provides a separate, dedicated path for all data access between clients and the data plane.
 This tunnel is distinct from the control plane tunnel and carries all customer data, logs, metrics, and presigned URL traffic.
 
@@ -111,6 +125,14 @@ In the Default deployment tier, this tunnel uses Cloudflare's edge network. An E
 > Specific Envoy authentication mechanism details (JWT validation, token exchange flow) to be documented.
 
 In the Enterprise deployment tier, the customer provisions their own VPN-routable load balancer, replacing the Cloudflare dependency for data access while maintaining the same Envoy-based authentication and RBAC enforcement on the data plane.
+{{< /markdown >}}
+{{< /tab >}}
+{{< tab "Previous architecture" >}}
+{{< markdown >}}
+This section did not exist in the previous architecture. All tunnel traffic flowed through a single Cloudflare Tunnel shared between orchestration and data relay.
+{{< /markdown >}}
+{{< /tab >}}
+{{< /tabs >}}
 
 ### Communication paths
 
@@ -149,6 +171,9 @@ Organizations with stricter requirements can configure shorter TTLs. The presign
 
 ### Direct data serving pattern
 
+{{< tabs >}}
+{{< tab "Zero-trust (current)" >}}
+{{< markdown >}}
 For logs, observability metrics, and Kubernetes events, the data plane serves data directly to the client through the Direct-to-DataPlane tunnel. An Envoy router on the data plane authenticates each request and enforces RBAC checks before returning data. The data is never relayed through, cached in, or written to disk on the control plane.
 
 This pattern replaces the previous streaming relay architecture. Data now flows:
@@ -157,11 +182,30 @@ This pattern replaces the previous streaming relay architecture. Data now flows:
 2. Envoy router on the data plane validates the request and checks RBAC permissions
 3. Data plane service retrieves the data (from the log aggregator, Prometheus, or K8s API)
 4. Data is returned directly to the client through the tunnel
+{{< /markdown >}}
+{{< /tab >}}
+{{< tab "Previous architecture" >}}
+{{< markdown >}}
+For logs and observability metrics, the control plane acted as a stateless relay — streaming data from the data plane through the Cloudflare tunnel to the client in real time. The data passed through the control plane's memory as a TLS encrypted stream. It was never written to disk, cached, or stored.
+{{< /markdown >}}
+{{< /tab >}}
+{{< /tabs >}}
 
 ### SDK direct upload (planned)
 
+{{< tabs >}}
+{{< tab "Zero-trust (current)" >}}
+{{< markdown >}}
 > [!NOTE] Information needed
 > SDK direct upload for task inputs is planned. In this pattern, the SDK retrieves a signed URL directly from the data plane and uploads input data to the customer's object store without involving the control plane. Specific timeline and implementation details to be documented.
+{{< /markdown >}}
+{{< /tab >}}
+{{< tab "Previous architecture" >}}
+{{< markdown >}}
+This section did not exist in the previous architecture. Input data was uploaded through the control plane.
+{{< /markdown >}}
+{{< /tab >}}
+{{< /tabs >}}
 
 ### Execution flow diagram
 

--- a/content/security/security-architecture.md
+++ b/content/security/security-architecture.md
@@ -6,6 +6,9 @@ variants: -flyte +union
 
 # Security architecture
 
+> [!TIP] Updated for zero-trust architecture
+> This page has been substantially revised to reflect the zero-trust security architecture. Tabbed comparisons below highlight key changes.
+
 Union.ai's security architecture is founded on the principle of strict separation between orchestration (control plane) and execution (data plane).
 This architectural decision ensures that customer data remains within the customer's own cloud infrastructure at all times.
 
@@ -169,6 +172,9 @@ This pattern replaces the previous streaming relay architecture. Data now flows:
 
 ### Data in the UI
 
+{{< tabs >}}
+{{< tab "Zero-trust (current)" >}}
+{{< markdown >}}
 | Field | What is it? | Where is it stored? | How is it retrieved? |
 | --- | --- | --- | --- |
 | Task names | Python function and module names | Control Plane | CP API |
@@ -181,3 +187,21 @@ This pattern replaces the previous streaming relay architecture. Data now flows:
 | Timeline timestamps | Showing when a task started, when it moved from queued to running to completed | Control Plane | CP API |
 | Errors | Showing the failure message written into stderr or raised exceptions for a task attempt | Control Plane | CP API |
 | Observability metrics | Prometheus metrics for task and workflow performance | Data plane Prometheus | Direct-to-DataPlane tunnel (served directly from data plane) |
+{{< /markdown >}}
+{{< /tab >}}
+{{< tab "Previous architecture" >}}
+{{< markdown >}}
+| Field | What is it? | Where is it stored? | How is it retrieved? |
+| --- | --- | --- | --- |
+| Task names | Python function and module names | Control Plane | CP API |
+| Users' names | First and last names of users on the platform | IDP | Cached in memory in CP, otherwise retrieved directly from IDP |
+| Inputs/Outputs | Primitive inputs/outputs returned by tasks (e.g. return 5) | Dataplane's S3 bucket | Cloudflare Tunnel |
+| Logs | Runtime logs written by the task code/SDK | Dataplane K8s for live logs, dataplane S3/Cloudwatch/Stackdriver for persistent logs | Cloudflare Tunnel |
+| K8s Events | Pod autoscaling events explaining whether a node is found or the cluster needs to scale up… etc. | Dataplane K8s | Cloudflare Tunnel |
+| Report | Reports produced by the task code in HTML | Dataplane's S3 bucket | A signed URL is generated through the tunnel, then the browser renders it in iframe |
+| Code explorer | Code bundled when the task was kicked off, that contains the task code and surrounding dependencies/functions it calls| Dataplane's S3 bucket | A signed URL is generated through the tunnel, then JS in the browser downloads and unzips the bundle to render |
+| Timeline timestamps | Showing when did a task start, when it moved from queued to running to completed | Control Plane | CP API |
+| Errors | Showing the failure message written into stderr or raised exceptions for a task attempt | Control Plane | CP API |
+{{< /markdown >}}
+{{< /tab >}}
+{{< /tabs >}}

--- a/content/security/security-best-practices.md
+++ b/content/security/security-best-practices.md
@@ -6,6 +6,9 @@ variants: -flyte +union
 
 # Security best practices
 
+> [!TIP] New in zero-trust architecture
+> This page was introduced as part of the zero-trust security architecture.
+
 This page provides recommendations for hardening your Union.ai deployment beyond the platform defaults.
 
 ## Recommended security configuration

--- a/content/security/security-best-practices.md
+++ b/content/security/security-best-practices.md
@@ -1,0 +1,51 @@
+---
+title: Security best practices
+weight: 15
+variants: -flyte +union
+---
+
+# Security best practices
+
+This page provides recommendations for hardening your Union.ai deployment beyond the platform defaults.
+
+## Recommended security configuration
+
+* **Choose Enterprise 1 for maximum data isolation** — The [Enterprise 1 security tier](./deployment-models#enterprise-1-enhanced-security) restricts all data visualization to users connected to your corporate VPN, ensuring no external access to customer data.
+* **Configure the shortest practical presigned URL TTL** — Presigned URLs default to a 1-hour expiration. Organizations with stricter requirements should configure shorter TTLs to minimize the exposure window.
+* **Use cloud-native secrets backends** — AWS Secrets Manager, GCP Secret Manager, or Azure Key Vault provide stronger isolation than the default Kubernetes Secrets backend.
+
+> [!NOTE] Information needed
+> Specific recommended TTL values and CMK (Customer Managed Key) configuration steps per cloud provider are not yet documented.
+
+## Network hardening
+
+* **Restrict egress to Cloudflare CIDR blocks** — In locked-down environments, limit outbound traffic to published Cloudflare CIDR blocks for both the control plane tunnel and the Direct-to-DataPlane tunnel.
+* **Configure VPN for Enterprise 1** — Deploy a VPN-routable load balancer within your VPC to restrict data access to corporate network users only.
+* **Apply Kubernetes network policies** — Use network policies to restrict pod-to-pod communication and limit egress from task pods.
+
+> [!NOTE] Information needed
+> Specific network policy templates, recommended firewall rules, and Cloudflare CIDR block details should be obtained from the Union.ai networking team.
+
+## IAM hardening
+
+* **Review IAM role permissions regularly** — Audit the admin and user IAM roles provisioned per data plane to ensure they follow least-privilege principles.
+* **Use workload identity federation** — Avoid static credentials on the data plane. Use cloud-native workload identity (IAM Roles for Service Accounts on AWS, Workload Identity on GCP, Azure Workload Identity on Azure).
+* **Scope secrets narrowly** — Use project and domain scoping to limit secret access to the workloads that need them.
+
+## Monitoring and detection
+
+* **Enable audit logging** — Ensure all API requests, RBAC changes, and secret operations are logged.
+* **Monitor tunnel health** — Set up alerts for tunnel connectivity issues, which may indicate network changes or potential interference.
+* **Set up alerts for anomalous access patterns** — Monitor for unusual API request volumes, unexpected user access, or failed authentication attempts.
+
+> [!NOTE] Information needed
+> Specific monitoring recommendations, alert templates, and integration guidance with customer SIEM systems are not yet documented.
+
+## Supply chain security
+
+* **Implement container image scanning** — Apply scanning policies to all container images before deployment to the customer registry.
+* **Use approved base image registries** — Configure Image Builder to pull base images only from customer-approved registries.
+* **Review third-party dependencies** — Union.ai's vendor management program is covered under the SOC 2 Type II audit. See [Third-party dependency risk](./vulnerability-and-risk-management#third-party-dependency-risk) for details.
+
+> [!NOTE] Information needed
+> Specific scanning tool recommendations, SBOM (Software Bill of Materials) availability, signed build verification, and Union.ai's own supply chain security practices for data plane components are not yet documented.

--- a/content/security/vulnerability-and-risk-management.md
+++ b/content/security/vulnerability-and-risk-management.md
@@ -6,6 +6,9 @@ variants: -flyte +union
 
 # Vulnerability and risk management
 
+> [!TIP] Updated for zero-trust architecture
+> The threat model has been strengthened to reflect that no customer data flows through the control plane.
+
 ## Vulnerability assessment
 
 Union.ai maintains a comprehensive vulnerability management program that includes dependency analysis and automated alerts for known CVEs in software dependencies, container image scanning for both platform and customer-facing components, and periodic third-party penetration testing to identify potential attack vectors.

--- a/content/security/vulnerability-and-risk-management.md
+++ b/content/security/vulnerability-and-risk-management.md
@@ -42,6 +42,9 @@ The Direct-to-DataPlane tunnel also uses mTLS via Cloudflare. This tunnel carrie
 
 ### Direct-to-DataPlane tunnel security
 
+{{< tabs >}}
+{{< tab "Zero-trust (current)" >}}
+{{< markdown >}}
 The Direct-to-DataPlane tunnel terminates at Cloudflare's edge and is routed to the Envoy router (Kourier gateway) on the customer's cluster.
 All requests are authenticated (SSO for browser, API key for programmatic) and authorized against Union's RBAC before forwarding.
 DDoS protection is provided by Cloudflare.
@@ -49,6 +52,14 @@ DDoS protection is provided by Cloudflare.
 In Enterprise 1 deployments, the tunnel is replaced by a VPN-routable customer-managed load balancer, further restricting access.
 
 The tunnel serves data only from the customer's infrastructure — no data is cached or stored at intermediate points.
+{{< /markdown >}}
+{{< /tab >}}
+{{< tab "Previous architecture" >}}
+{{< markdown >}}
+This section did not exist in the previous architecture. There was no separate data tunnel �� all traffic flowed through the single control plane tunnel.
+{{< /markdown >}}
+{{< /tab >}}
+{{< /tabs >}}
 
 ### Presigned URL leakage
 

--- a/content/security/vulnerability-and-risk-management.md
+++ b/content/security/vulnerability-and-risk-management.md
@@ -21,19 +21,31 @@ The control plane is updated independently of customer data planes, ensuring tha
 
 ## Threat modeling
 
-Union.ai’s architecture has been designed with the following threat model considerations:
+Union.ai's architecture has been designed with the following threat model considerations:
 
 ### Control plane compromise
 
-In the event of a control plane compromise, an attacker would gain access to orchestration metadata only.
-They would not obtain customer data payloads, secret values, code bundles, container images, or log content.
+In the event of a control plane compromise, an attacker would gain access to orchestration metadata only — task definitions, run/action state, user identity, and cluster records.
+Under the zero-trust architecture, no customer data flows through the control plane, further reducing the blast radius. The attacker would not obtain customer data payloads, secret values, code bundles, container images, log content, or observability metrics.
 The attacker could not initiate connections to customer data planes (outbound-only tunnel).
 Presigned URLs are generated on the data plane, so the attacker could not generate data access URLs.
+The control plane does not relay, cache, or store any customer data, leaving no data residue accessible to an attacker.
 
 ### Tunnel interception
 
-The Cloudflare Tunnel uses mTLS, making man-in-the-middle attacks infeasible.
-Even if an attacker could intercept tunnel traffic, customer data flowing through the tunnel (logs, secret creation requests) is encrypted in transit and is not cached or stored at any intermediate point.
+The control plane tunnel uses mTLS, making man-in-the-middle attacks infeasible. This tunnel carries only orchestration commands and state transitions — no customer data.
+
+The Direct-to-DataPlane tunnel also uses mTLS via Cloudflare. This tunnel carries customer data (logs, inputs/outputs, metrics) but terminates within the customer's domain infrastructure, not the Union control plane. Traffic is authenticated by the Envoy router with RBAC enforcement before reaching any data service.
+
+### Direct-to-DataPlane tunnel security
+
+The Direct-to-DataPlane tunnel terminates at Cloudflare's edge and is routed to the Envoy router (Kourier gateway) on the customer's cluster.
+All requests are authenticated (SSO for browser, API key for programmatic) and authorized against Union's RBAC before forwarding.
+DDoS protection is provided by Cloudflare.
+
+In Enterprise 1 deployments, the tunnel is replaced by a VPN-routable customer-managed load balancer, further restricting access.
+
+The tunnel serves data only from the customer's infrastructure — no data is cached or stored at intermediate points.
 
 ### Presigned URL leakage
 
@@ -44,11 +56,12 @@ Because presigned URLs are bearer tokens—possession alone grants access with n
 
 ## Security architecture benefits
 
-Union.ai’s architectural decisions provide inherent security benefits that reduce overall risk exposure:
+Union.ai's architectural decisions provide inherent security benefits that reduce overall risk exposure:
 
 | Architectural Decision | Security Benefit | Risk Mitigated |
 | --- | --- | --- |
 | Control plane stores no customer data | Minimizes blast radius of CP compromise | Data breach from CP attack |
+| Zero-trust data isolation | No customer data transits control plane | Data exposure from CP compromise or wire sniffing |
 | Outbound-only tunnel | No inbound attack surface on customer network | Network intrusion via open ports |
 | Presigned URLs for data access | No persistent data access credentials | Credential theft / lateral movement |
 | Write-only secrets API | Cannot exfiltrate secrets via API | Secret leakage via API abuse |

--- a/content/security/workflow-execution-security.md
+++ b/content/security/workflow-execution-security.md
@@ -6,8 +6,14 @@ variants: -flyte +union
 
 # Workflow execution security
 
+> [!TIP] Updated for zero-trust architecture
+> This page has been substantially revised to reflect the zero-trust security architecture. Tabbed comparisons below highlight key changes.
+
 This section traces the security controls applied at each stage of a workflow's lifecycle, from registration through execution and result retrieval.
 
+{{< tabs >}}
+{{< tab "Zero-trust (current)" >}}
+{{< markdown >}}
 ## Task registration
 
 * SDK serializes the task specification (container image reference, resource requirements, typed interface) into a protobuf message
@@ -36,3 +42,33 @@ This section traces the security controls applied at each stage of a workflow's 
 
 > [!NOTE]
 > Under the zero-trust architecture, no customer data transits the control plane at any stage of the workflow lifecycle. All data — code, inputs, outputs, logs, reports, and metrics — remains within the customer's infrastructure or travels directly between the client and the customer's data plane. The control plane handles only orchestration metadata.
+{{< /markdown >}}
+{{< /tab >}}
+{{< tab "Previous architecture" >}}
+{{< markdown >}}
+## Task registration
+
+* SDK serializes the task specification (container image reference, resource requirements, typed interface) into a protobuf message
+* Code bundle is uploaded directly to the customer's object store via presigned PUT URL—the code never touches the control plane
+* Only the specification metadata (including the object store URI) is stored in the control plane database
+
+## Run creation and execution
+
+* Input data is serialized and uploaded to the customer's object store; only the input URI is stored in the control plane
+* The control plane enqueues the action to the data plane via the Cloudflare tunnel
+* The Executor (a Kubernetes controller on the data plane) creates a pod that reads inputs from the customer's object store and writes outputs back to it
+* Secrets are injected into pods from the customer's secrets backend—they never traverse the control plane during runtime
+
+## Result retrieval
+
+* Outputs, reports, and code bundles are accessed via presigned URLs—the data flows directly from the customer's object store to the client
+* Logs are streamed from the data plane through the Cloudflare tunnel as a stateless relay
+* Metadata (run status, phase, errors) is served from the control plane database
+
+## Data flow summary
+
+> [!NOTE]
+> At every stage of the workflow lifecycle, customer data (code, inputs, outputs, images, secrets) stays within the customer's infrastructure or travels directly between the client and the customer's object store. Logs are relayed through the tunnel but never stored. The control plane handles only orchestration metadata.
+{{< /markdown >}}
+{{< /tab >}}
+{{< /tabs >}}

--- a/content/security/workflow-execution-security.md
+++ b/content/security/workflow-execution-security.md
@@ -6,28 +6,33 @@ variants: -flyte +union
 
 # Workflow execution security
 
-This section traces the security controls applied at each stage of a workflow’s lifecycle, from registration through execution and result retrieval.
+This section traces the security controls applied at each stage of a workflow's lifecycle, from registration through execution and result retrieval.
 
 ## Task registration
 
 * SDK serializes the task specification (container image reference, resource requirements, typed interface) into a protobuf message
-* Code bundle is uploaded directly to the customer’s object store via presigned PUT URL—the code never touches the control plane
+* Code bundle is uploaded directly to the customer's object store via a presigned PUT URL generated on the data plane — the code never touches the control plane
 * Only the specification metadata (including the object store URI) is stored in the control plane database
 
 ## Run creation and execution
 
-* Input data is serialized and uploaded to the customer’s object store; only the input URI is stored in the control plane
+* The SDK retrieves a presigned URL from the data plane via the Direct-to-DataPlane tunnel, uploads input data directly to the customer's object store, and creates the run by sending only the input URI to the control plane
+
+> [!NOTE] Information needed
+> The SDK direct upload flow may still be in progress. Confirm the current implementation status.
+
 * The control plane enqueues the action to the data plane via the Cloudflare tunnel
-* The Executor (a Kubernetes controller on the data plane) creates a pod that reads inputs from the customer’s object store and writes outputs back to it
-* Secrets are injected into pods from the customer’s secrets backend—they never traverse the control plane during runtime
+* The Executor (a Kubernetes controller on the data plane) creates a pod that reads inputs from the customer's object store and writes outputs back to it
+* Secrets are injected into pods from the customer's secrets backend—they never traverse the control plane during runtime
 
 ## Result retrieval
 
-* Outputs, reports, and code bundles are accessed via presigned URLs—the data flows directly from the customer’s object store to the client
-* Logs are streamed from the data plane through the Cloudflare tunnel as a stateless relay
+* Outputs, reports, and code bundles are accessed via presigned URLs generated on the data plane — the data flows directly from the customer's object store to the client without any control plane involvement
+* Logs are served directly from the data plane to the client via the Direct-to-DataPlane tunnel. Logs never transit the control plane.
+* Apps and auxiliary UIs (Ray dashboard, Spark history server) are served from the data plane via the Direct-to-DataPlane tunnel
 * Metadata (run status, phase, errors) is served from the control plane database
 
 ## Data flow summary
 
 > [!NOTE]
-> At every stage of the workflow lifecycle, customer data (code, inputs, outputs, images, secrets) stays within the customer’s infrastructure or travels directly between the client and the customer’s object store. Logs are relayed through the tunnel but never stored. The control plane handles only orchestration metadata.
+> Under the zero-trust architecture, no customer data transits the control plane at any stage of the workflow lifecycle. All data — code, inputs, outputs, logs, reports, and metrics — remains within the customer's infrastructure or travels directly between the client and the customer's data plane. The control plane handles only orchestration metadata.


### PR DESCRIPTION
## Summary
- Restructure all 19 security docs files + create 3 new files to reflect the zero-trust architecture where the `dataproxy` service moves from the control plane to the data plane
- Core change: no customer data, metadata, or logs ever transit through Union's control plane
- Introduces Direct-to-DataPlane tunnel, Default vs Enterprise 1 security tiers, and strengthened threat model
- 15 `[!NOTE] Information needed` callouts mark gaps requiring engineering input
- Source: zero-trust proposal at `task-tracker/zero-trust.md`

### Files changed (17 modified, 3 new)
**Major rewrites:** `security-architecture.md`, `components-architecture.md`, `_index.md`, `workflow-execution-security.md`
**New files:** `deployment-models.md`, `network-security.md`, `security-best-practices.md`
**Significant updates:** `data-protection.md`, `logging-monitoring-and-audit.md`, `identity-and-access-management.md`, `vulnerability-and-risk-management.md`, `data-residency-summary.md`, `kubernetes-rbac-control-plane.md`
**Minor updates:** `compliance-and-certifications.md`, `infrastructure-security.md`, `multi-cloud-and-region-support.md`, weight adjustments

## Test plan
- [x] `make dist` builds successfully for both flyte and union variants
- [ ] Review all 15 information-needed callouts with engineering
- [ ] Visual review of security section navigation ordering
- [ ] Content review by security/product team

🤖 Generated with [Claude Code](https://claude.com/claude-code)