### PR TITLE
Fix deploy-redirects workflow + backport Makefile improvements (v1)

### DIFF
--- a/.github/workflows/deploy-redirects.yml
+++ b/.github/workflows/deploy-redirects.yml
@@ -3,7 +3,7 @@ name: Deploy Redirects
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [main, v1]
     paths: ['unionai-docs-infra']
 
 jobs:
@@ -20,6 +20,7 @@ jobs:
       - name: Check if redirects.csv changed
         id: check-redirects
         run: |
+          set -euo pipefail
           # For workflow_dispatch, always deploy
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
@@ -35,6 +36,12 @@ jobs:
             echo "No submodule ref change detected, skipping."
             exit 0
           fi
+          # The submodule was checked out with submodules: true and only fetched
+          # the latest pointer. Fetch both refs explicitly so we can diff between
+          # them. Without this, the diff fails with "fatal: bad object" because
+          # OLD_REF isn't in the local clone.
+          echo "Fetching submodule commits $OLD_REF and $NEW_REF..."
+          git -C unionai-docs-infra fetch --depth=1 origin "$OLD_REF" "$NEW_REF"
           if git -C unionai-docs-infra diff --name-only "$OLD_REF" "$NEW_REF" | grep -q "^redirects.csv$"; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
             echo "redirects.csv changed, proceeding with deploy."

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ export PORT
 # Forward all known targets to unionai-docs-infra/Makefile.
 # These must be listed explicitly because Make's % pattern rule won't match
 # targets that correspond to existing files/directories (e.g., dist/).
-TARGETS := usage clean clean-generated base dist variant dev serve \
+TARGETS := usage help clean clean-generated base dist variant dev serve \
 	update-examples init-examples check-jupyter check-images validate-urls \
 	url-stats llm-docs update-redirects dry-run-redirects deploy-redirects \
 	check-deleted-pages check-links check-generated-content check-api-docs \
@@ -33,10 +33,22 @@ _check-infra:
 $(TARGETS): _check-infra
 	@$(MAKE) --no-print-directory -f unionai-docs-infra/Makefile $@
 
+.PHONY: init-infra
+init-infra:
+	git submodule update --init
+
 # Submodule update helpers (not forwarded to unionai-docs-infra/Makefile).
 .PHONY: update-infra
 update-infra:
 	git submodule update --remote unionai-docs-infra
 	@echo "unionai-docs-infra/ updated to latest. Review and commit the change."
+
+.PHONY: submodule
+submodule:
+	git submodule init && git submodule update
+
+.PHONY: update_submodule
+update_submodule:
+	git submodule update --init --recursive --remote
 
 .DEFAULT_GOAL := usage


### PR DESCRIPTION
## Summary

Backports from main (unionai/unionai-docs#899):

1. **Fix silent failure in deploy-redirects.yml**: the submodule diff step was failing silently with \`fatal: bad object <OLD_REF>\` whenever the submodule pointer changed. Add explicit fetch before diffing, plus \`set -euo pipefail\`.

2. **Watch v1 in addition to main**: the workflow only triggered on pushes to main. v1 also bumps the infra submodule and may include redirects.csv changes.

3. **Backport Makefile improvements**: add \`help\` target to TARGETS, plus \`init-infra\`, \`submodule\`, and \`update_submodule\` helpers. Skips the v2-only \`generate-helm-docs\` target.

After these merge, main and v1 will be aligned on all build infrastructure (only intentional content/version differences remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)