### PR TITLE
Activate walk-up 404 handler

### DIFF
--- a/content/404.md
+++ b/content/404.md
@@ -1,5 +1,6 @@
 ---
 title: 404 - Not Found
+layout: four-o-four
 variants: +flyte +union
 toc_enabled: false
 sidebar_enabled: false


### PR DESCRIPTION
## Summary

Activates the walk-up 404 handler that has existed in the codebase but was orphaned. When a user hits a non-existent page (whether by typing a bad URL or by switching variants on a page that doesn't exist in the new variant), the JavaScript walks up the URL one segment at a time until it finds a real page.

### What this changes
- Sets \`layout: four-o-four\` in \`content/404.md\` so Hugo uses the \`four-o-four.html\` template instead of falling back to \`single.html\` + \`no-content.html\` (\"Page in construction. Please come back later.\")
- Bumps the infra submodule to pick up the rewrite of \`four-o-four.html\` and the cross-variant banner support in \`baseof.html\`/\`404.js\`/\`Caddyfile\`

### Companion PR
unionai/unionai-docs-infra#71

### Test plan
- [x] Local build serves the new 404 page with walk-up JS
- [ ] Live preview: switch from a BYOC-only page to flyte → walk-up should land on flyte home with the cross-variant banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)