### PR TITLE
Replace v1 union CLI commands with v2 flyte CLI equivalents

### DIFF
--- a/content/deployment/byoc/data-retention-policy.md
+++ b/content/deployment/byoc/data-retention-policy.md
@@ -25,7 +25,7 @@ The retention policy system distinguishes three categories of data:
    - Artifact data.
    - Internal metadata used by {{< key product_name >}}.
 2. Fast-registered code:
-   - Local code artifacts that will be copied into the Flyte task container at runtime when using `union register` or `union run --remote --copy-all`.
+   - Local code artifacts that will be copied into the Flyte task container at runtime when using `flyte deploy` or `flyte run --copy-style all`.
 3. Flyte plugin metadata (for example, Spark history server data).
 
 Each category of data is stored in a separate {{< key product_name >}}-managed object store bucket and versioning is enabled on these buckets.

--- a/content/deployment/selfmanaged/cluster-recommendations.md
+++ b/content/deployment/selfmanaged/cluster-recommendations.md
@@ -48,7 +48,7 @@ As a {{< key product_name >}} administrator, you can specify retention policies 
 Union recommends the use of two S3 buckets:
 
 1. metadata bucket: contains workflow execution data such as Task inputs and outputs, etc
-2. fast registration bucket: contain local code artifacts that will be copied into the Flyte task container at runtime when using `union register` or `union run --remote --copy-all`.
+2. fast registration bucket: contain local code artifacts that will be copied into the Flyte task container at runtime when using `flyte deploy` or `flyte run --copy-style all`.
 
 Note: You can choose to use a single bucket in your dataplane
 

--- a/content/deployment/terraform/management.md
+++ b/content/deployment/terraform/management.md
@@ -62,7 +62,7 @@ export UNIONAI_API_KEY="your-api-key"
 Create an API key using the Flyte CLI:
 
 ```bash
-union create api-key admin --name "terraform-api-key"
+flyte create api-key --name "terraform-api-key"
 ```
 
 For more information on creating API keys, see the [Flyte CLI documentation](../../api-reference/flyte-cli#flyte-create-config).


### PR DESCRIPTION
## Summary
- Replaces leftover v1 `union` CLI commands with their v2 `flyte` CLI equivalents in three deployment docs files
- `union register` → `flyte deploy`
- `union run --remote --copy-all` → `flyte run --copy-style all`
- `union create api-key admin --name` → `flyte create api-key --name`

## Files changed
- `content/deployment/byoc/data-retention-policy.md`
- `content/deployment/selfmanaged/cluster-recommendations.md`
- `content/deployment/terraform/management.md`

## Test plan
- [ ] Verify `flyte deploy` and `flyte run --copy-style all` are the correct v2 equivalents
- [ ] Verify `flyte create api-key --name` syntax matches CLI reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)