### PR TITLE
Update README links to reflect two-variant structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Flyte and Union.ai documentation
 
 - **[Flyte Docs](https://www.union.ai/docs/flyte/user-guide/)**
-- **[Union BYOC](https://www.union.ai/docs/byoc/user-guide/)**
-- **[Union Serverless](https://www.union.ai/docs/serverless/tutorials/)**
+- **[Union Docs](https://www.union.ai/docs/v2/union/user-guide/)** (covers both BYOC and Self-managed deployments)
 
 This repository holds all documentation for the [Flyte OSS project](https://www.flyte.org) and the [Union.ai](https://www.union.ai) products.
 


### PR DESCRIPTION
## Summary
- Replace the top-of-README links to the now-stale `docs/byoc/...` and `docs/serverless/...` URLs with a single Union Docs link pointing at the current `docs/v2/union/...` path.
- Note that the Union variant covers both BYOC and Self-managed deployments (the old Serverless link is gone because Serverless is no longer a separate docs variant).

## Test plan
- [x] No build or runtime impact — README-only change.
- [ ] Reviewer: confirm the `docs/v2/union/user-guide/` link resolves (verified manually during authoring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)