### PR TITLE
Stop force-expanding sidebar sections by default

### DIFF
--- a/api-packages.toml
+++ b/api-packages.toml
@@ -59,7 +59,6 @@ include = "include/api.flyte-sdk.md"
 output_folder = "content/api-reference/flyte-sdk"
 version_file = "content/api-reference/flyte-sdk/_index.md"
 weight = 4
-expanded = true
 no_flatten = true
 variants = "+flyte +union"
 

--- a/content/api-reference/_index.md
+++ b/content/api-reference/_index.md
@@ -3,7 +3,6 @@ title: Reference
 weight: 3
 variants: +flyte +union
 top_menu: true
-sidebar_expanded: true
 ---
 
 # Reference

--- a/content/api-reference/flyte-sdk/_index.md
+++ b/content/api-reference/flyte-sdk/_index.md
@@ -4,7 +4,6 @@ version: 2.1.9
 variants: +flyte +union
 layout: py_api
 weight: 4
-sidebar_expanded: true
 ---
 
 # Flyte SDK

--- a/content/api-reference/flyte-sdk/classes/_index.md
+++ b/content/api-reference/flyte-sdk/classes/_index.md
@@ -3,7 +3,6 @@ title: Classes & Protocols
 version: 2.1.9
 variants: +flyte +union
 layout: py_api
-sidebar_expanded: true
 ---
 
 # Classes

--- a/content/api-reference/flyte-sdk/packages/_index.md
+++ b/content/api-reference/flyte-sdk/packages/_index.md
@@ -3,7 +3,6 @@ title: Packages
 version: 2.1.9
 variants: +flyte +union
 layout: py_api
-sidebar_expanded: true
 ---
 
 # Packages

--- a/content/api-reference/flyte-sdk/packages/flyte.app.extras/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app.extras/_index.md
@@ -3,7 +3,6 @@ title: flyte.app.extras
 version: 2.1.9
 variants: +flyte +union
 layout: py_api
-sidebar_expanded: true
 ---
 
 # flyte.app.extras

--- a/content/api-reference/flyte-sdk/packages/flyte.app/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app/_index.md
@@ -3,7 +3,6 @@ title: flyte.app
 version: 2.1.9
 variants: +flyte +union
 layout: py_api
-sidebar_expanded: true
 ---
 
 # flyte.app

--- a/content/api-reference/flyte-sdk/packages/flyte.config/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.config/_index.md
@@ -3,7 +3,6 @@ title: flyte.config
 version: 2.1.9
 variants: +flyte +union
 layout: py_api
-sidebar_expanded: true
 ---
 
 # flyte.config

--- a/content/api-reference/flyte-sdk/packages/flyte.connectors.utils/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.connectors.utils/_index.md
@@ -3,7 +3,6 @@ title: flyte.connectors.utils
 version: 2.1.9
 variants: +flyte +union
 layout: py_api
-sidebar_expanded: true
 ---
 
 # flyte.connectors.utils

--- a/content/api-reference/flyte-sdk/packages/flyte.connectors/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.connectors/_index.md
@@ -3,7 +3,6 @@ title: flyte.connectors
 version: 2.1.9
 variants: +flyte +union
 layout: py_api
-sidebar_expanded: true
 ---
 
 # flyte.connectors

--- a/content/api-reference/flyte-sdk/packages/flyte.durable/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.durable/_index.md
@@ -3,7 +3,6 @@ title: flyte.durable
 version: 2.1.9
 variants: +flyte +union
 layout: py_api
-sidebar_expanded: true
 ---
 
 # flyte.durable

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/_index.md
@@ -3,7 +3,6 @@ title: flyte.errors
 version: 2.1.9
 variants: +flyte +union
 layout: py_api
-sidebar_expanded: true
 ---
 
 # flyte.errors

--- a/content/api-reference/flyte-sdk/packages/flyte.extend/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extend/_index.md
@@ -3,7 +3,6 @@ title: flyte.extend
 version: 2.1.9
 variants: +flyte +union
 layout: py_api
-sidebar_expanded: true
 ---
 
 # flyte.extend

--- a/content/api-reference/flyte-sdk/packages/flyte.extras/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras/_index.md
@@ -3,7 +3,6 @@ title: flyte.extras
 version: 2.1.9
 variants: +flyte +union
 layout: py_api
-sidebar_expanded: true
 ---
 
 # flyte.extras

--- a/content/api-reference/flyte-sdk/packages/flyte.git/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.git/_index.md
@@ -3,7 +3,6 @@ title: flyte.git
 version: 2.1.9
 variants: +flyte +union
 layout: py_api
-sidebar_expanded: true
 ---
 
 # flyte.git

--- a/content/api-reference/flyte-sdk/packages/flyte.io.extend/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.io.extend/_index.md
@@ -3,7 +3,6 @@ title: flyte.io.extend
 version: 2.1.9
 variants: +flyte +union
 layout: py_api
-sidebar_expanded: true
 ---
 
 # flyte.io.extend

--- a/content/api-reference/flyte-sdk/packages/flyte.io/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.io/_index.md
@@ -3,7 +3,6 @@ title: flyte.io
 version: 2.1.9
 variants: +flyte +union
 layout: py_api
-sidebar_expanded: true
 ---
 
 # flyte.io

--- a/content/api-reference/flyte-sdk/packages/flyte.models/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.models/_index.md
@@ -3,7 +3,6 @@ title: flyte.models
 version: 2.1.9
 variants: +flyte +union
 layout: py_api
-sidebar_expanded: true
 ---
 
 # flyte.models

--- a/content/api-reference/flyte-sdk/packages/flyte.notify/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.notify/_index.md
@@ -3,7 +3,6 @@ title: flyte.notify
 version: 2.1.9
 variants: +flyte +union
 layout: py_api
-sidebar_expanded: true
 ---
 
 # flyte.notify

--- a/content/api-reference/flyte-sdk/packages/flyte.prefetch/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.prefetch/_index.md
@@ -3,7 +3,6 @@ title: flyte.prefetch
 version: 2.1.9
 variants: +flyte +union
 layout: py_api
-sidebar_expanded: true
 ---
 
 # flyte.prefetch

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/_index.md
@@ -3,7 +3,6 @@ title: flyte.remote
 version: 2.1.9
 variants: +flyte +union
 layout: py_api
-sidebar_expanded: true
 ---
 
 # flyte.remote

--- a/content/api-reference/flyte-sdk/packages/flyte.report/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.report/_index.md
@@ -3,7 +3,6 @@ title: flyte.report
 version: 2.1.9
 variants: +flyte +union
 layout: py_api
-sidebar_expanded: true
 ---
 
 # flyte.report

--- a/content/api-reference/flyte-sdk/packages/flyte.sandbox/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.sandbox/_index.md
@@ -3,7 +3,6 @@ title: flyte.sandbox
 version: 2.1.9
 variants: +flyte +union
 layout: py_api
-sidebar_expanded: true
 ---
 
 # flyte.sandbox

--- a/content/api-reference/flyte-sdk/packages/flyte.storage/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.storage/_index.md
@@ -3,7 +3,6 @@ title: flyte.storage
 version: 2.1.9
 variants: +flyte +union
 layout: py_api
-sidebar_expanded: true
 ---
 
 # flyte.storage

--- a/content/api-reference/flyte-sdk/packages/flyte.syncify/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.syncify/_index.md
@@ -3,7 +3,6 @@ title: flyte.syncify
 version: 2.1.9
 variants: +flyte +union
 layout: py_api
-sidebar_expanded: true
 ---
 
 # flyte.syncify

--- a/content/api-reference/flyte-sdk/packages/flyte.types/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.types/_index.md
@@ -3,7 +3,6 @@ title: flyte.types
 version: 2.1.9
 variants: +flyte +union
 layout: py_api
-sidebar_expanded: true
 ---
 
 # flyte.types

--- a/content/api-reference/flyte-sdk/packages/flyte/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/_index.md
@@ -3,7 +3,6 @@ title: flyte
 version: 2.1.9
 variants: +flyte +union
 layout: py_api
-sidebar_expanded: true
 ---
 
 # flyte

--- a/content/api-reference/integrations/_index.md
+++ b/content/api-reference/integrations/_index.md
@@ -2,7 +2,6 @@
 title: Integrations
 variants: +flyte +union
 weight: 5
-sidebar_expanded: true
 ---
 
 # Integrations

--- a/content/api-reference/migration/_index.md
+++ b/content/api-reference/migration/_index.md
@@ -2,7 +2,6 @@
 title: Migration from Flyte 1
 weight: 2
 variants: +flyte +union
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/api-reference/uctl-cli/_index.md
+++ b/content/api-reference/uctl-cli/_index.md
@@ -2,7 +2,6 @@
 title: Uctl CLI
 weight: 6
 variants: -flyte +union
-sidebar_expanded: true
 ---
 
 # Uctl CLI

--- a/content/community/_index.md
+++ b/content/community/_index.md
@@ -3,7 +3,6 @@ title: Community
 weight: 7
 variants: +flyte +union
 top_menu: true
-sidebar_expanded: true
 ---
 
 # Community

--- a/content/community/contributing-docs/_index.md
+++ b/content/community/contributing-docs/_index.md
@@ -2,7 +2,6 @@
 title: Contributing docs and examples
 weight: 3
 variants: +flyte +union
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/community/contributing-docs/authoring.md
+++ b/content/community/contributing-docs/authoring.md
@@ -85,7 +85,7 @@ weight: 3
 | Setting            | Type | Description                                                                       |
 | ------------------ | ---- | --------------------------------------------------------------------------------- |
 | `top_menu`         | bool | If `true` the item becomes a tab at the top and its hierarchy goes to the sidebar |
-| `sidebar_expanded` | bool | If `true` the section becomes expanded in the sidebar. Permanently.              |
+| `sidebar_expanded` | bool | If `true`, force this section to render expanded in the sidebar even when it is not on the active path. Use sparingly — by default sections collapse and only the active path expands automatically. |
 | `site_root`        | bool | If `true` indicates that the page is the site landing page                        |
 | `toc_max`          | int  | Maximum heading to incorporate in the right navigation table of contents.         |
 | `llm_readable_bundle` | bool | If `true`, generates a `section.md` bundle for this section. Requires `{{</* llm-bundle-note */>}}` shortcode. See [LLM-optimized documentation](./llm-docs). |

--- a/content/deployment/_index.md
+++ b/content/deployment/_index.md
@@ -4,7 +4,6 @@ weight: 5
 variants: -flyte +union
 top_menu: true
 mermaid: true
-sidebar_expanded: true
 secondary_topnav: -flyte +union
 ---
 

--- a/content/deployment/byoc/_index.md
+++ b/content/deployment/byoc/_index.md
@@ -2,7 +2,6 @@
 title: BYOC deployment
 weight: 1
 variants: -flyte +union
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/deployment/byoc/enabling-aws-resources/_index.md
+++ b/content/deployment/byoc/enabling-aws-resources/_index.md
@@ -2,7 +2,6 @@
 title: Enabling AWS resources
 weight: 9
 variants: -flyte +union
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/deployment/byoc/enabling-azure-resources/_index.md
+++ b/content/deployment/byoc/enabling-azure-resources/_index.md
@@ -2,7 +2,6 @@
 title: Enabling Azure resources
 weight: 11
 variants: -flyte +union
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/deployment/byoc/enabling-gcp-resources/_index.md
+++ b/content/deployment/byoc/enabling-gcp-resources/_index.md
@@ -2,7 +2,6 @@
 title: Enabling GCP resources
 weight: 10
 variants: -flyte +union
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/deployment/byoc/single-sign-on-setup/_index.md
+++ b/content/deployment/byoc/single-sign-on-setup/_index.md
@@ -2,7 +2,6 @@
 title: Single sign on setup
 weight: 12
 variants: -flyte +union
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/deployment/configuration-reference/_index.md
+++ b/content/deployment/configuration-reference/_index.md
@@ -2,7 +2,6 @@
 title: Configuration reference
 variants: -flyte -union
 weight: 17
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/deployment/flyte-configuration/_index.md
+++ b/content/deployment/flyte-configuration/_index.md
@@ -2,7 +2,6 @@
 title: Platform configuration
 variants: -flyte -union
 weight: 14
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/deployment/flyte-connectors/_index.md
+++ b/content/deployment/flyte-connectors/_index.md
@@ -2,7 +2,6 @@
 title: Connector setup
 weight: 15
 variants: -flyte -union
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/deployment/flyte-deployment/_index.md
+++ b/content/deployment/flyte-deployment/_index.md
@@ -2,7 +2,6 @@
 title: Flyte deployment
 variants: -flyte -union
 weight: 13
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/deployment/flyte-plugins/_index.md
+++ b/content/deployment/flyte-plugins/_index.md
@@ -2,7 +2,6 @@
 title: Plugins setup
 weight: 16
 variants: -flyte -union
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/deployment/selfmanaged/_index.md
+++ b/content/deployment/selfmanaged/_index.md
@@ -2,7 +2,6 @@
 title: Self-managed deployment
 weight: 2
 variants: -flyte +union
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/deployment/selfmanaged/architecture/_index.md
+++ b/content/deployment/selfmanaged/architecture/_index.md
@@ -2,7 +2,6 @@
 title: Architecture
 weight: 1
 variants: -flyte +union
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/deployment/selfmanaged/configuration/_index.md
+++ b/content/deployment/selfmanaged/configuration/_index.md
@@ -2,7 +2,6 @@
 title: Configuration
 weight: 7
 variants: -flyte +union
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/deployment/selfmanaged/helm-chart-reference/_index.md
+++ b/content/deployment/selfmanaged/helm-chart-reference/_index.md
@@ -2,7 +2,6 @@
 title: Helm chart reference
 variants: -flyte +union
 weight: 18
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/deployment/selfmanaged/selfmanaged-aws/_index.md
+++ b/content/deployment/selfmanaged/selfmanaged-aws/_index.md
@@ -2,7 +2,6 @@
 title: Data plane setup on AWS
 weight: 4
 variants: -flyte +union
-sidebar_expanded: true
 ---
 
 # Data plane setup on AWS

--- a/content/deployment/selfmanaged/selfmanaged-azure/_index.md
+++ b/content/deployment/selfmanaged/selfmanaged-azure/_index.md
@@ -2,7 +2,6 @@
 title: Data plane setup on Azure
 weight: 5
 variants: -flyte +union
-sidebar_expanded: true
 ---
 
 # Data plane setup on Azure

--- a/content/deployment/selfmanaged/selfmanaged-gcp/_index.md
+++ b/content/deployment/selfmanaged/selfmanaged-gcp/_index.md
@@ -2,7 +2,6 @@
 title: Data plane setup on GCP
 weight: 4
 variants: -flyte +union
-sidebar_expanded: true
 ---
 
 # Data plane setup on GKE (GCP)

--- a/content/deployment/selfmanaged/selfmanaged-generic/_index.md
+++ b/content/deployment/selfmanaged/selfmanaged-generic/_index.md
@@ -2,7 +2,6 @@
 title: Data plane setup on generic Kubernetes
 weight: 3
 variants: -flyte +union
-sidebar_expanded: true
 ---
 
 # Data plane setup on generic Kubernetes

--- a/content/deployment/selfmanaged/selfmanaged-oci/_index.md
+++ b/content/deployment/selfmanaged/selfmanaged-oci/_index.md
@@ -2,7 +2,6 @@
 title: Data plane setup on OCI
 weight: 6
 variants: -flyte +union
-sidebar_expanded: true
 ---
 
 # Data plane setup on OCI

--- a/content/deployment/terraform/_index.md
+++ b/content/deployment/terraform/_index.md
@@ -2,7 +2,6 @@
 title: Manage Union through Terraform
 weight: 8
 variants: -flyte +union
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/integrations/_index.md
+++ b/content/integrations/_index.md
@@ -3,7 +3,6 @@ title: Integrations
 weight: 4
 variants: +flyte +union
 top_menu: true
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/integrations/anthropic/_index.md
+++ b/content/integrations/anthropic/_index.md
@@ -2,7 +2,6 @@
 title: Anthropic
 weight: 1
 variants: +flyte +union
-sidebar_expanded: false
 ---
 
 # Anthropic

--- a/content/integrations/bigquery/_index.md
+++ b/content/integrations/bigquery/_index.md
@@ -2,7 +2,6 @@
 title: BigQuery
 weight: 1
 variants: +flyte +union
-sidebar_expanded: false
 ---
 
 # BigQuery

--- a/content/integrations/codegen/_index.md
+++ b/content/integrations/codegen/_index.md
@@ -2,7 +2,6 @@
 title: Code generation
 weight: 2
 variants: +flyte +union
-sidebar_expanded: false
 mermaid: true
 ---
 

--- a/content/integrations/dask/_index.md
+++ b/content/integrations/dask/_index.md
@@ -2,7 +2,6 @@
 title: Dask
 weight: 1
 variants: +flyte +union
-sidebar_expanded: false
 ---
 
 # Dask

--- a/content/integrations/databricks/_index.md
+++ b/content/integrations/databricks/_index.md
@@ -2,7 +2,6 @@
 title: Databricks
 weight: 1
 variants: +flyte +union
-sidebar_expanded: false
 ---
 
 # Databricks

--- a/content/integrations/gemini/_index.md
+++ b/content/integrations/gemini/_index.md
@@ -2,7 +2,6 @@
 title: Gemini
 weight: 1
 variants: +flyte +union
-sidebar_expanded: false
 ---
 
 # Gemini

--- a/content/integrations/mlflow/_index.md
+++ b/content/integrations/mlflow/_index.md
@@ -2,7 +2,6 @@
 title: MLflow
 weight: 2
 variants: +flyte +union
-sidebar_expanded: false
 ---
 
 # MLflow

--- a/content/integrations/openai/_index.md
+++ b/content/integrations/openai/_index.md
@@ -2,7 +2,6 @@
 title: OpenAI
 weight: 1
 variants: +flyte +union
-sidebar_expanded: false
 ---
 
 # OpenAI

--- a/content/integrations/openai/agent_tools.md
+++ b/content/integrations/openai/agent_tools.md
@@ -2,7 +2,6 @@
 title: Agent tools
 weight: 1
 variants: +flyte +union
-sidebar_expanded: true
 ---
 
 # Agent tools

--- a/content/integrations/pandera/_index.md
+++ b/content/integrations/pandera/_index.md
@@ -2,7 +2,6 @@
 title: Pandera
 weight: 1
 variants: +flyte +union
-sidebar_expanded: false
 ---
 
 # Pandera

--- a/content/integrations/pytorch/_index.md
+++ b/content/integrations/pytorch/_index.md
@@ -2,7 +2,6 @@
 title: PyTorch
 weight: 1
 variants: +flyte +union
-sidebar_expanded: false
 ---
 
 # PyTorch

--- a/content/integrations/ray/_index.md
+++ b/content/integrations/ray/_index.md
@@ -2,7 +2,6 @@
 title: Ray
 weight: 1
 variants: +flyte +union
-sidebar_expanded: false
 ---
 
 # Ray

--- a/content/integrations/snowflake/_index.md
+++ b/content/integrations/snowflake/_index.md
@@ -2,7 +2,6 @@
 title: Snowflake
 weight: 1
 variants: +flyte +union
-sidebar_expanded: false
 ---
 
 # Snowflake

--- a/content/integrations/spark/_index.md
+++ b/content/integrations/spark/_index.md
@@ -2,7 +2,6 @@
 title: Spark
 weight: 1
 variants: +flyte +union
-sidebar_expanded: false
 ---
 
 # Spark

--- a/content/integrations/wandb/_index.md
+++ b/content/integrations/wandb/_index.md
@@ -2,7 +2,6 @@
 title: Weights & Biases
 weight: 1
 variants: +flyte +union
-sidebar_expanded: false
 ---
 
 # Weights & Biases

--- a/content/integrations/wandb/constraints_and_best_practices.md
+++ b/content/integrations/wandb/constraints_and_best_practices.md
@@ -2,7 +2,6 @@
 title: Constraints and best practices
 weight: 4
 variants: +flyte +union
-sidebar_expanded: false
 ---
 
 # Constraints and best practices

--- a/content/integrations/wandb/distributed_training.md
+++ b/content/integrations/wandb/distributed_training.md
@@ -2,7 +2,6 @@
 title: Distributed training
 weight: 2
 variants: +flyte +union
-sidebar_expanded: false
 ---
 
 # Distributed training

--- a/content/integrations/wandb/downloading_logs.md
+++ b/content/integrations/wandb/downloading_logs.md
@@ -2,7 +2,6 @@
 title: Downloading logs
 weight: 3
 variants: +flyte +union
-sidebar_expanded: false
 ---
 
 # Downloading logs

--- a/content/integrations/wandb/experiments.md
+++ b/content/integrations/wandb/experiments.md
@@ -2,7 +2,6 @@
 title: Experiments
 weight: 1
 variants: +flyte +union
-sidebar_expanded: false
 ---
 
 # Experiments

--- a/content/integrations/wandb/manual.md
+++ b/content/integrations/wandb/manual.md
@@ -2,7 +2,6 @@
 title: Manual integration
 weight: 5
 variants: +flyte +union
-sidebar_expanded: false
 ---
 
 # Manual integration

--- a/content/integrations/wandb/sweeps.md
+++ b/content/integrations/wandb/sweeps.md
@@ -2,7 +2,6 @@
 title: Sweeps
 weight: 2
 variants: +flyte +union
-sidebar_expanded: false
 ---
 
 # Sweeps

--- a/content/release-notes/_index.md
+++ b/content/release-notes/_index.md
@@ -3,7 +3,6 @@ title: Release notes
 weight: 8
 variants: +union -flyte
 top_menu: true
-sidebar_expanded: true
 ---
 
 # Release notes

--- a/content/security/_index.md
+++ b/content/security/_index.md
@@ -3,7 +3,6 @@ title: Security
 weight: 6
 variants: -flyte +union
 top_menu: true
-sidebar_expanded: true
 ---
 
 # Security

--- a/content/tutorials/_index.md
+++ b/content/tutorials/_index.md
@@ -3,7 +3,6 @@ title: Tutorials
 weight: 2
 variants: +flyte +union
 top_menu: true
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/tutorials/auto_prompt_engineering/_index.md
+++ b/content/tutorials/auto_prompt_engineering/_index.md
@@ -2,7 +2,6 @@
 title: Automatic prompt engineering
 weight: 2
 variants: +flyte +union
-sidebar_expanded: true
 ---
 
 # Automatic prompt engineering

--- a/content/tutorials/climate-modeling/_index.md
+++ b/content/tutorials/climate-modeling/_index.md
@@ -2,7 +2,6 @@
 title: GPU-accelerated climate modeling
 weight: 1
 variants: +flyte +union
-sidebar_expanded: true
 ---
 
 # GPU-accelerated climate modeling

--- a/content/tutorials/code-agent/_index.md
+++ b/content/tutorials/code-agent/_index.md
@@ -2,7 +2,6 @@
 title: Run LLM-generated code
 weight: 1
 variants: +flyte +union
-sidebar_expanded: true
 ---
 
 # Run LLM-generated code

--- a/content/tutorials/deep-research/_index.md
+++ b/content/tutorials/deep-research/_index.md
@@ -2,7 +2,6 @@
 title: Deep research
 weight: 2
 variants: +flyte +union
-sidebar_expanded: true
 ---
 
 # Deep research

--- a/content/tutorials/distributed-pretraining/_index.md
+++ b/content/tutorials/distributed-pretraining/_index.md
@@ -2,7 +2,6 @@
 title: Distributed LLM pretraining
 weight: 1
 variants: +flyte +union
-sidebar_expanded: true
 ---
 
 # Distributed LLM pretraining

--- a/content/tutorials/hpo/_index.md
+++ b/content/tutorials/hpo/_index.md
@@ -2,7 +2,6 @@
 title: Hyperparameter optimization
 weight: 10
 variants: +flyte +union
-sidebar_expanded: true
 ---
 
 # Hyperparameter optimization

--- a/content/tutorials/mle-bot/_index.md
+++ b/content/tutorials/mle-bot/_index.md
@@ -2,7 +2,6 @@
 title: MLE Bot
 weight: 1
 variants: +flyte +union
-sidebar_expanded: true
 ---
 
 # MLE Bot: an autonomous ML engineer

--- a/content/tutorials/qwen-vl-finetuning/_index.md
+++ b/content/tutorials/qwen-vl-finetuning/_index.md
@@ -2,7 +2,6 @@
 title: Fine-tuning a vision-language model with a frozen backbone
 weight: 1
 variants: +flyte +union
-sidebar_expanded: true
 ---
 
 # Fine-tuning a vision-language model with a frozen backbone

--- a/content/tutorials/satellite_image_classification/_index.md
+++ b/content/tutorials/satellite_image_classification/_index.md
@@ -2,7 +2,6 @@
 title: Satellite Image Classification with EfficientNet
 weight: 2
 variants: -flyte +union
-sidebar_expanded: false
 ---
 
 # Satellite Image Classification with EfficientNet

--- a/content/tutorials/text_to_sql/_index.md
+++ b/content/tutorials/text_to_sql/_index.md
@@ -2,7 +2,6 @@
 title: Text-to-SQL
 weight: 1
 variants: +flyte +union
-sidebar_expanded: true
 ---
 
 # Text-to-SQL

--- a/content/tutorials/trading-agents/_index.md
+++ b/content/tutorials/trading-agents/_index.md
@@ -2,7 +2,6 @@
 title: Multi-agent trading simulation
 weight: 1
 variants: +flyte +union
-sidebar_expanded: true
 ---
 
 # Multi-agent trading simulation

--- a/content/user-guide/_index.md
+++ b/content/user-guide/_index.md
@@ -4,7 +4,6 @@ weight: 1
 variants: +flyte +union
 top_menu: true
 site_root: true
-sidebar_expanded: true
 ---
 
 {{< variant flyte >}}

--- a/content/user-guide/advanced-project/_index.md
+++ b/content/user-guide/advanced-project/_index.md
@@ -2,7 +2,6 @@
 title: Advanced project
 weight: 8
 variants: +flyte +union
-sidebar_expanded: false
 mermaid: true
 llm_readable_bundle: true
 ---

--- a/content/user-guide/build-agent/_index.md
+++ b/content/user-guide/build-agent/_index.md
@@ -2,7 +2,6 @@
 title: Build an agent
 weight: 18
 variants: +flyte +serverless +union
-sidebar_expanded: false
 mermaid: true
 llm_readable_bundle: true
 ---

--- a/content/user-guide/build-apps/_index.md
+++ b/content/user-guide/build-apps/_index.md
@@ -2,7 +2,6 @@
 title: Build apps
 weight: 16
 variants: +flyte +union
-sidebar_expanded: false
 llm_readable_bundle: true
 ---
 

--- a/content/user-guide/configure-apps/_index.md
+++ b/content/user-guide/configure-apps/_index.md
@@ -2,7 +2,6 @@
 title: Configure apps
 weight: 15
 variants: +flyte +union
-sidebar_expanded: false
 llm_readable_bundle: true
 ---
 

--- a/content/user-guide/core-concepts/_index.md
+++ b/content/user-guide/core-concepts/_index.md
@@ -2,7 +2,6 @@
 title: Core concepts
 weight: 3
 variants: +flyte +union
-sidebar_expanded: false
 llm_readable_bundle: true
 ---
 

--- a/content/user-guide/flyte-2/_index.md
+++ b/content/user-guide/flyte-2/_index.md
@@ -2,7 +2,6 @@
 title: From Flyte 1 to 2
 weight: 22
 variants: +flyte +union
-sidebar_expanded: false
 llm_readable_bundle: true
 ---
 

--- a/content/user-guide/project-patterns/_index.md
+++ b/content/user-guide/project-patterns/_index.md
@@ -2,7 +2,6 @@
 title: Project patterns
 weight: 13
 variants: +flyte +union
-sidebar_expanded: false
 ---
 
 # Project patterns

--- a/content/user-guide/quickstart.md
+++ b/content/user-guide/quickstart.md
@@ -2,7 +2,6 @@
 title: Quickstart
 weight: 2
 variants: +flyte +union
-sidebar_expanded: true
 ---
 
 # Quickstart

--- a/content/user-guide/run-modes/_index.md
+++ b/content/user-guide/run-modes/_index.md
@@ -2,7 +2,6 @@
 title: Run modes
 weight: 4
 variants: +flyte +union
-sidebar_expanded: false
 ---
 
 # Run modes

--- a/content/user-guide/run-scaling/_index.md
+++ b/content/user-guide/run-scaling/_index.md
@@ -2,7 +2,6 @@
 title: Scale your runs
 weight: 14
 variants: +flyte +union
-sidebar_expanded: false
 llm_readable_bundle: true
 ---
 

--- a/content/user-guide/sandboxing/_index.md
+++ b/content/user-guide/sandboxing/_index.md
@@ -2,7 +2,6 @@
 title: Sandboxing
 weight: 19
 variants: +flyte +union
-sidebar_expanded: false
 llm_readable_bundle: true
 ---
 

--- a/content/user-guide/sandboxing/code-mode.md
+++ b/content/user-guide/sandboxing/code-mode.md
@@ -2,7 +2,6 @@
 title: Programmatic tool calling for agents
 weight: 3
 variants: +flyte +union
-sidebar_expanded: false
 llm_readable_bundle: true
 ---
 

--- a/content/user-guide/sandboxing/code-sandboxing.md
+++ b/content/user-guide/sandboxing/code-sandboxing.md
@@ -2,7 +2,6 @@
 title: Code sandboxing
 weight: 4
 variants: +flyte +union
-sidebar_expanded: false
 llm_readable_bundle: true
 ---
 

--- a/content/user-guide/sandboxing/workflow-sandboxing-flyte.md
+++ b/content/user-guide/sandboxing/workflow-sandboxing-flyte.md
@@ -2,7 +2,6 @@
 title: Workflow sandboxing
 weight: 2
 variants: +flyte +union
-sidebar_expanded: false
 llm_readable_bundle: true
 mermaid: true
 ---

--- a/content/user-guide/serve-and-deploy-apps/_index.md
+++ b/content/user-guide/serve-and-deploy-apps/_index.md
@@ -2,7 +2,6 @@
 title: Serve and deploy apps
 weight: 17
 variants: +flyte +union
-sidebar_expanded: false
 llm_readable_bundle: true
 ---
 

--- a/content/user-guide/task-configuration/_index.md
+++ b/content/user-guide/task-configuration/_index.md
@@ -2,7 +2,6 @@
 title: Configure tasks
 weight: 10
 variants: +flyte +union
-sidebar_expanded: false
 llm_readable_bundle: true
 ---
 

--- a/content/user-guide/task-deployment/_index.md
+++ b/content/user-guide/task-deployment/_index.md
@@ -2,7 +2,6 @@
 title: Run and deploy tasks
 weight: 12
 variants: +flyte +union
-sidebar_expanded: false
 llm_readable_bundle: true
 ---
 

--- a/content/user-guide/task-deployment/deploy-command-options.md
+++ b/content/user-guide/task-deployment/deploy-command-options.md
@@ -2,7 +2,6 @@
 title: Deploy command options
 weight: 6
 variants: +flyte +union
-sidebar_expanded: true
 ---
 
 # Deploy command options

--- a/content/user-guide/task-deployment/deployment-patterns.md
+++ b/content/user-guide/task-deployment/deployment-patterns.md
@@ -2,7 +2,6 @@
 title: Deployment patterns
 weight: 9
 variants: +flyte +union
-sidebar_expanded: true
 ---
 
 # Deployment patterns

--- a/content/user-guide/task-deployment/how-task-deployment-works.md
+++ b/content/user-guide/task-deployment/how-task-deployment-works.md
@@ -2,7 +2,6 @@
 title: How task deployment works
 weight: 5
 variants: +flyte +union
-sidebar_expanded: true
 ---
 
 # How task deployment works

--- a/content/user-guide/task-deployment/how-task-run-works.md
+++ b/content/user-guide/task-deployment/how-task-run-works.md
@@ -2,7 +2,6 @@
 title: How task run works
 weight: 1
 variants: +flyte +union
-sidebar_expanded: true
 mermaid: true
 ---
 

--- a/content/user-guide/task-deployment/interacting-with-runs.md
+++ b/content/user-guide/task-deployment/interacting-with-runs.md
@@ -2,7 +2,6 @@
 title: Interact with runs and actions
 weight: 2
 variants: +flyte +union
-sidebar_expanded: true
 mermaid: true
 ---
 

--- a/content/user-guide/task-deployment/invoke-webhook.md
+++ b/content/user-guide/task-deployment/invoke-webhook.md
@@ -2,7 +2,6 @@
 title: Running Tasks via Webhooks
 weight: 8
 variants: -flyte +union
-sidebar_expanded: true
 ---
 
 # Running Tasks via Webhooks

--- a/content/user-guide/task-deployment/packaging.md
+++ b/content/user-guide/task-deployment/packaging.md
@@ -2,7 +2,6 @@
 title: Packaging
 weight: 7
 variants: +flyte +union
-sidebar_expanded: true
 ---
 
 # Code packaging for remote execution

--- a/content/user-guide/task-deployment/run-command-options.md
+++ b/content/user-guide/task-deployment/run-command-options.md
@@ -2,7 +2,6 @@
 title: Run command options
 weight: 4
 variants: +flyte +union
-sidebar_expanded: true
 ---
 
 # Run command options

--- a/content/user-guide/task-deployment/work-with-local-data.md
+++ b/content/user-guide/task-deployment/work-with-local-data.md
@@ -2,7 +2,6 @@
 title: Work with local data
 weight: 3
 variants: +flyte +union
-sidebar_expanded: true
 ---
 
 # Work with local data

--- a/content/user-guide/task-programming/_index.md
+++ b/content/user-guide/task-programming/_index.md
@@ -2,7 +2,6 @@
 title: Build tasks
 weight: 11
 variants: +flyte +union
-sidebar_expanded: false
 llm_readable_bundle: true
 ---
 

--- a/content/user-guide/task-programming/handling-custom-types.md
+++ b/content/user-guide/task-programming/handling-custom-types.md
@@ -2,7 +2,6 @@
 title: Custom types
 weight: 4
 variants: +flyte +union
-sidebar_expanded: true
 ---
 
 # Custom types


### PR DESCRIPTION
## Summary

Aligns the sidebar with how every modern docs site behaves: collapsed by default, active path expands automatically. The previous behavior force-expanded ~200 sidebar entries in the API reference because `sidebar_expanded: true` had been set on every package `_index.md` (and most other `_index.md` files), turning the sidebar into a wall of text.

The active-path logic in `section-tree-nav` already expands the section containing the current page — `sidebar_expanded: true` was layered on top of that and made the default behavior worse, not better. The original justification (discoverability + Ctrl+F) is now better served by the Algolia DocSearch bar that's already loaded site-wide.

## Changes

- **`api-packages.toml`**: drop `expanded = true` for the flyte SDK so the API generator no longer emits `sidebar_expanded: true` on package `_index.md` files.
- **Sweep 118 content files**: remove `sidebar_expanded: true` (forced expansion) and `sidebar_expanded: false` (no-op — `false` was already the default).
- **`contributing-docs/authoring.md`**: reframe the field as an opt-in escape hatch with guidance to use sparingly.

## Capability preserved

The `sidebar_expanded` field still works in `section-tree-nav` as an explicit override. An author who wants a small, intentional section always-expanded can still opt in. We just don't apply it by default anywhere.

## Verified

Built locally with `make dev`. Sidebar entry counts on a few representative pages:

| Page | Section titles | Collapsed | Expanded |
| - | - | - | - |
| `/user-guide/` (landing) | 14 | 14 | 0 |
| `/user-guide/core-concepts/tasks/` | 14 | 13 | 1 |
| `/api-reference/flyte-sdk/packages/flyte/` | 114 | 111 | 3 |
| `/tutorials/` | 12 | 12 | 0 |

Only the active path (ancestors of the current page) expands. Everything else collapses. Chevron click handlers from unionai/unionai-docs-infra#89 let users manually expand siblings.

## Depends on

- unionai/unionai-docs-infra#89 — fixes the chevron click handler that was broken by an unrelated bug. Without that PR, manual expansion still doesn't work even after this cleanup. Merge that first, then update the submodule pointer.

## Test plan

- [ ] Visit `/api-reference/flyte-sdk/packages/flyte/` — sidebar shows ancestors expanded, all other packages collapsed
- [ ] Click chevron on a sibling package — it expands in place
- [ ] Navigate to a page within that package — it stays expanded as the active path
- [ ] Visit `/user-guide/`, `/deployment/`, `/tutorials/` landing pages — sidebar fully collapsed
- [ ] Search bar (Algolia DocSearch) still finds content across all sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)