### PR TITLE
Stop force-expanding sidebar sections by default (v1)

### DIFF
--- a/content/api-reference/_index.md
+++ b/content/api-reference/_index.md
@@ -3,7 +3,6 @@ title: Reference
 weight: 3
 variants: +flyte +union
 top_menu: true
-sidebar_expanded: true
 ---
 
 # Reference

--- a/content/api-reference/flytectl-cli/_index.md
+++ b/content/api-reference/flytectl-cli/_index.md
@@ -2,7 +2,6 @@
 title: Flytectl CLI
 weight: 4
 variants: +flyte -union
-sidebar_expanded: true
 ---
 
 # {{< key ctl_name >}} CLI

--- a/content/api-reference/plugins/_index.md
+++ b/content/api-reference/plugins/_index.md
@@ -2,7 +2,6 @@
 title: FlyteKit Plugins
 variants: +flyte -union
 weight: 99
-sidebar_expanded: true
 ---
 
 # FlyteKit Plugins

--- a/content/api-reference/uctl-cli/_index.md
+++ b/content/api-reference/uctl-cli/_index.md
@@ -2,7 +2,6 @@
 title: Uctl CLI
 weight: 4
 variants: -flyte +union
-sidebar_expanded: true
 ---
 
 # Uctl CLI

--- a/content/architecture/_index.md
+++ b/content/architecture/_index.md
@@ -3,7 +3,6 @@ title: Architecture
 weight: 6
 variants: +flyte +union
 top_menu: true
-sidebar_expanded: true
 ---
 
 # Architecture

--- a/content/architecture/component-architecture/_index.md
+++ b/content/architecture/component-architecture/_index.md
@@ -2,7 +2,6 @@
 title: Component Architecture
 weight: 9
 variants: +flyte -union
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/architecture/control-plane/_index.md
+++ b/content/architecture/control-plane/_index.md
@@ -2,7 +2,6 @@
 title: Control Plane
 weight: 9
 variants: +flyte -union
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/architecture/extending-flyte/_index.md
+++ b/content/architecture/extending-flyte/_index.md
@@ -3,7 +3,6 @@ title: Extending Flyte
 weight: 10
 variants: +flyte -union
 mermaid: true
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/community/_index.md
+++ b/content/community/_index.md
@@ -3,7 +3,6 @@ title: Community
 weight: 7
 variants: +flyte +union
 top_menu: true
-sidebar_expanded: true
 ---
 
 # Community

--- a/content/community/contributing-docs/_index.md
+++ b/content/community/contributing-docs/_index.md
@@ -2,7 +2,6 @@
 title: Contributing docs and examples
 weight: 3
 variants: +flyte +union
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/community/contributing-docs/authoring.md
+++ b/content/community/contributing-docs/authoring.md
@@ -85,7 +85,7 @@ weight: 3
 | Setting            | Type | Description                                                                       |
 | ------------------ | ---- | --------------------------------------------------------------------------------- |
 | `top_menu`         | bool | If `true` the item becomes a tab at the top and its hierarchy goes to the sidebar |
-| `sidebar_expanded` | bool | If `true` the section becomes expanded in the sidebar. Permanently.              |
+| `sidebar_expanded` | bool | If `true`, force this section to render expanded in the sidebar even when it is not on the active path. Use sparingly — by default sections collapse and only the active path expands automatically. |
 | `site_root`        | bool | If `true` indicates that the page is the site landing page                        |
 | `toc_max`          | int  | Maximum heading to incorporate in the right navigation table of contents.         |
 

--- a/content/deployment/_index.md
+++ b/content/deployment/_index.md
@@ -5,7 +5,6 @@ variants: +flyte +union
 top_menu: true
 secondary_topnav: -flyte +union
 mermaid: true
-sidebar_expanded: true
 ---
 
 # Platform deployment

--- a/content/deployment/byoc/_index.md
+++ b/content/deployment/byoc/_index.md
@@ -2,7 +2,6 @@
 title: BYOC deployment
 weight: 1
 variants: -flyte +union
-sidebar_expanded: true
 ---
 
 # BYOC deployment

--- a/content/deployment/byoc/enabling-aws-resources/_index.md
+++ b/content/deployment/byoc/enabling-aws-resources/_index.md
@@ -2,7 +2,6 @@
 title: Enabling AWS resources
 weight: 9
 variants: -flyte +union
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/deployment/byoc/enabling-azure-resources/_index.md
+++ b/content/deployment/byoc/enabling-azure-resources/_index.md
@@ -2,7 +2,6 @@
 title: Enabling Azure resources
 weight: 11
 variants: -flyte +union
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/deployment/byoc/enabling-gcp-resources/_index.md
+++ b/content/deployment/byoc/enabling-gcp-resources/_index.md
@@ -2,7 +2,6 @@
 title: Enabling GCP resources
 weight: 10
 variants: -flyte +union
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/deployment/byoc/single-sign-on-setup/_index.md
+++ b/content/deployment/byoc/single-sign-on-setup/_index.md
@@ -2,7 +2,6 @@
 title: Single sign on setup
 weight: 12
 variants: -flyte +union
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/deployment/configuration-reference/_index.md
+++ b/content/deployment/configuration-reference/_index.md
@@ -2,7 +2,6 @@
 title: Configuration reference
 variants: +flyte -union
 weight: 17
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/deployment/flyte-configuration/_index.md
+++ b/content/deployment/flyte-configuration/_index.md
@@ -2,7 +2,6 @@
 title: Platform configuration
 variants: +flyte -union
 weight: 14
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/deployment/flyte-connectors/_index.md
+++ b/content/deployment/flyte-connectors/_index.md
@@ -2,7 +2,6 @@
 title: Connector setup
 weight: 15
 variants: +flyte -union
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/deployment/flyte-deployment/_index.md
+++ b/content/deployment/flyte-deployment/_index.md
@@ -2,7 +2,6 @@
 title: Flyte deployment
 variants: +flyte -union
 weight: 13
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/deployment/flyte-plugins/_index.md
+++ b/content/deployment/flyte-plugins/_index.md
@@ -2,7 +2,6 @@
 title: Plugins setup
 weight: 16
 variants: +flyte -union
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/deployment/selfmanaged/_index.md
+++ b/content/deployment/selfmanaged/_index.md
@@ -2,7 +2,6 @@
 title: Self-managed deployment
 weight: 2
 variants: -flyte +union
-sidebar_expanded: true
 ---
 
 # Self-managed deployment

--- a/content/deployment/selfmanaged/architecture/_index.md
+++ b/content/deployment/selfmanaged/architecture/_index.md
@@ -2,7 +2,6 @@
 title: Architecture
 weight: 1
 variants: -flyte +union
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/deployment/selfmanaged/byok-data-plane-setup-on-aws/_index.md
+++ b/content/deployment/selfmanaged/byok-data-plane-setup-on-aws/_index.md
@@ -2,7 +2,6 @@
 title: Data plane setup on AWS
 weight: 5
 variants: -flyte +union
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/deployment/selfmanaged/configuration/_index.md
+++ b/content/deployment/selfmanaged/configuration/_index.md
@@ -2,7 +2,6 @@
 title: Configuration
 weight: 7
 variants: -flyte +union
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/deployment/terraform/_index.md
+++ b/content/deployment/terraform/_index.md
@@ -2,7 +2,6 @@
 title: Terraform
 weight: 3
 variants: -flyte +union
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/integrations/_index.md
+++ b/content/integrations/_index.md
@@ -3,7 +3,6 @@ title: Integrations
 weight: 5
 variants: +flyte +union
 top_menu: true
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/integrations/connectors/_index.md
+++ b/content/integrations/connectors/_index.md
@@ -2,7 +2,6 @@
 title: Connectors
 weight: 1
 variants: +flyte +union
-sidebar_expanded: true
 ---
 
 # Connectors

--- a/content/integrations/connectors/airflow-connector/_index.md
+++ b/content/integrations/connectors/airflow-connector/_index.md
@@ -2,7 +2,6 @@
 title: Airflow connector
 weight: 1
 variants: +flyte +union
-sidebar_expanded: false
 ---
 
 # Airflow connector

--- a/content/integrations/connectors/bigquery-connector/_index.md
+++ b/content/integrations/connectors/bigquery-connector/_index.md
@@ -2,7 +2,6 @@
 title: BigQuery connector
 weight: 1
 variants: +flyte +union
-sidebar_expanded: false
 ---
 
 # BigQuery connector

--- a/content/integrations/connectors/chatgpt-connector/_index.md
+++ b/content/integrations/connectors/chatgpt-connector/_index.md
@@ -2,7 +2,6 @@
 title: ChatGPT connector
 weight: 1
 variants: +flyte +union
-sidebar_expanded: false
 ---
 
 # ChatGPT connector

--- a/content/integrations/connectors/databricks-connector/_index.md
+++ b/content/integrations/connectors/databricks-connector/_index.md
@@ -2,7 +2,6 @@
 title: Databricks connector
 weight: 1
 variants: +flyte +union
-sidebar_expanded: false
 ---
 
 # Databricks connector

--- a/content/integrations/connectors/mmcloud-connector/_index.md
+++ b/content/integrations/connectors/mmcloud-connector/_index.md
@@ -2,7 +2,6 @@
 title: Memory Machine Cloud connector
 weight: 1
 variants: +flyte +union
-sidebar_expanded: false
 ---
 
 # Memory Machine Cloud connector

--- a/content/integrations/connectors/openai-batch-connector/_index.md
+++ b/content/integrations/connectors/openai-batch-connector/_index.md
@@ -2,7 +2,6 @@
 title: OpenAI Batch connector
 weight: 1
 variants: +flyte +union
-sidebar_expanded: false
 ---
 
 # OpenAI Batch connector

--- a/content/integrations/connectors/perian-connector/_index.md
+++ b/content/integrations/connectors/perian-connector/_index.md
@@ -2,7 +2,6 @@
 title: Perian connector
 weight: 1
 variants: +flyte +union
-sidebar_expanded: false
 ---
 
 # Perian connector

--- a/content/integrations/connectors/sagemaker-inference-connector/_index.md
+++ b/content/integrations/connectors/sagemaker-inference-connector/_index.md
@@ -2,7 +2,6 @@
 title: SageMaker connector
 weight: 1
 variants: +flyte +union
-sidebar_expanded: false
 ---
 
 # SageMaker connector

--- a/content/integrations/connectors/sensor/_index.md
+++ b/content/integrations/connectors/sensor/_index.md
@@ -2,7 +2,6 @@
 title: Sensor connectror
 weight: 1
 variants: +flyte +union
-sidebar_expanded: false
 ---
 
 # Sensor connector

--- a/content/integrations/connectors/slurm-connector/_index.md
+++ b/content/integrations/connectors/slurm-connector/_index.md
@@ -2,7 +2,6 @@
 title: Slurm connector
 weight: 1
 variants: +flyte +union
-sidebar_expanded: false
 ---
 
 # Slurm connector

--- a/content/integrations/connectors/snowflake-connector/_index.md
+++ b/content/integrations/connectors/snowflake-connector/_index.md
@@ -2,7 +2,6 @@
 title: Snowflake connector
 weight: 1
 variants: +flyte +union
-sidebar_expanded: false
 ---
 
 # Snowflake connector

--- a/content/integrations/deprecated-integrations/_index.md
+++ b/content/integrations/deprecated-integrations/_index.md
@@ -2,7 +2,6 @@
 title: Deprecated integrations
 weight: 6
 variants: +flyte -union
-sidebar_expanded: true
 ---
 
 # Deprecated integrations

--- a/content/integrations/deprecated-integrations/bigquery-plugin/_index.md
+++ b/content/integrations/deprecated-integrations/bigquery-plugin/_index.md
@@ -2,7 +2,6 @@
 title: BigQuery plugin
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # BigQuery plugin

--- a/content/integrations/deprecated-integrations/databricks-plugin/_index.md
+++ b/content/integrations/deprecated-integrations/databricks-plugin/_index.md
@@ -2,7 +2,6 @@
 title: Databricks plugin
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # Databricks plugin

--- a/content/integrations/deprecated-integrations/k8s-pod-plugin/_index.md
+++ b/content/integrations/deprecated-integrations/k8s-pod-plugin/_index.md
@@ -2,7 +2,6 @@
 title: Kubernetes Pods
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # Kubernetes Pods

--- a/content/integrations/deprecated-integrations/snowflake-plugin/_index.md
+++ b/content/integrations/deprecated-integrations/snowflake-plugin/_index.md
@@ -2,7 +2,6 @@
 title: Snowflake plugin
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # Snowflake plugin

--- a/content/integrations/external-service-backend-plugins/_index.md
+++ b/content/integrations/external-service-backend-plugins/_index.md
@@ -2,7 +2,6 @@
 title: External service backend plugins
 weight: 4
 variants: +flyte -union
-sidebar_expanded: true
 ---
 
 # External service backend plugins

--- a/content/integrations/external-service-backend-plugins/athena-plugin/_index.md
+++ b/content/integrations/external-service-backend-plugins/athena-plugin/_index.md
@@ -2,7 +2,6 @@
 title: AWS Athena
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # AWS Athena

--- a/content/integrations/external-service-backend-plugins/aws-batch-plugin/_index.md
+++ b/content/integrations/external-service-backend-plugins/aws-batch-plugin/_index.md
@@ -2,7 +2,6 @@
 title: AWS Batch
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # AWS Batch

--- a/content/integrations/external-service-backend-plugins/flyteinteractive-plugin/_index.md
+++ b/content/integrations/external-service-backend-plugins/flyteinteractive-plugin/_index.md
@@ -2,7 +2,6 @@
 title: FlyteInteractive
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # FlyteInteractive

--- a/content/integrations/external-service-backend-plugins/hive-plugin/_index.md
+++ b/content/integrations/external-service-backend-plugins/hive-plugin/_index.md
@@ -2,7 +2,6 @@
 title: Hive
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # Hive

--- a/content/integrations/flyte-operators/_index.md
+++ b/content/integrations/flyte-operators/_index.md
@@ -2,7 +2,6 @@
 title: Flyte operators
 weight: 5
 variants: +flyte -union
-sidebar_expanded: true
 ---
 
 # Flyte operators

--- a/content/integrations/flyte-operators/airflow-plugin/_index.md
+++ b/content/integrations/flyte-operators/airflow-plugin/_index.md
@@ -2,7 +2,6 @@
 title: Airflow Provider
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # Airflow Provider

--- a/content/integrations/flytekit-plugins/_index.md
+++ b/content/integrations/flytekit-plugins/_index.md
@@ -2,7 +2,6 @@
 title: Flytekit plugins
 weight: 2
 variants: +flyte -union
-sidebar_expanded: true
 ---
 
 # Flytekit plugins

--- a/content/integrations/flytekit-plugins/comet-ml-plugin/_index.md
+++ b/content/integrations/flytekit-plugins/comet-ml-plugin/_index.md
@@ -2,7 +2,6 @@
 title: Comet ML
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # Comet ML

--- a/content/integrations/flytekit-plugins/dbt-plugin/_index.md
+++ b/content/integrations/flytekit-plugins/dbt-plugin/_index.md
@@ -2,7 +2,6 @@
 title: DBT
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # DBT

--- a/content/integrations/flytekit-plugins/dolt-plugin/_index.md
+++ b/content/integrations/flytekit-plugins/dolt-plugin/_index.md
@@ -2,7 +2,6 @@
 title: Dolt
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # Dolt

--- a/content/integrations/flytekit-plugins/duckdb-plugin/_index.md
+++ b/content/integrations/flytekit-plugins/duckdb-plugin/_index.md
@@ -2,7 +2,6 @@
 title: Slurm connector
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # DuckDB

--- a/content/integrations/flytekit-plugins/greatexpectations-plugin/_index.md
+++ b/content/integrations/flytekit-plugins/greatexpectations-plugin/_index.md
@@ -2,7 +2,6 @@
 title: Great Expectations
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # Great Expectations

--- a/content/integrations/flytekit-plugins/memray-plugin/_index.md
+++ b/content/integrations/flytekit-plugins/memray-plugin/_index.md
@@ -2,7 +2,6 @@
 title: Memray Profiling
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # Memray Profiling

--- a/content/integrations/flytekit-plugins/mlflow-plugin/_index.md
+++ b/content/integrations/flytekit-plugins/mlflow-plugin/_index.md
@@ -2,7 +2,6 @@
 title: MLflow
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # MLflow

--- a/content/integrations/flytekit-plugins/modin-plugin/_index.md
+++ b/content/integrations/flytekit-plugins/modin-plugin/_index.md
@@ -2,7 +2,6 @@
 title: Modin
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # Modin

--- a/content/integrations/flytekit-plugins/neptune-plugin/_index.md
+++ b/content/integrations/flytekit-plugins/neptune-plugin/_index.md
@@ -2,7 +2,6 @@
 title: Neptune plugin
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # Neptune

--- a/content/integrations/flytekit-plugins/nim-plugin/_index.md
+++ b/content/integrations/flytekit-plugins/nim-plugin/_index.md
@@ -2,7 +2,6 @@
 title: NIM
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # NIM

--- a/content/integrations/flytekit-plugins/ollama-plugin/_index.md
+++ b/content/integrations/flytekit-plugins/ollama-plugin/_index.md
@@ -2,7 +2,6 @@
 title: Ollama
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # Ollama

--- a/content/integrations/flytekit-plugins/onnx-plugin/_index.md
+++ b/content/integrations/flytekit-plugins/onnx-plugin/_index.md
@@ -2,7 +2,6 @@
 title: ONNX
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # ONNX

--- a/content/integrations/flytekit-plugins/pandera-plugin/_index.md
+++ b/content/integrations/flytekit-plugins/pandera-plugin/_index.md
@@ -2,7 +2,6 @@
 title: Pandera
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # Pandera

--- a/content/integrations/flytekit-plugins/papermill-plugin/_index.md
+++ b/content/integrations/flytekit-plugins/papermill-plugin/_index.md
@@ -2,7 +2,6 @@
 title: Papermill
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # Papermill

--- a/content/integrations/flytekit-plugins/sql-plugin/_index.md
+++ b/content/integrations/flytekit-plugins/sql-plugin/_index.md
@@ -2,7 +2,6 @@
 title: SQL
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # SQL

--- a/content/integrations/flytekit-plugins/wandb-plugin/_index.md
+++ b/content/integrations/flytekit-plugins/wandb-plugin/_index.md
@@ -2,7 +2,6 @@
 title: Weights and Biases
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # Weights and Biases

--- a/content/integrations/flytekit-plugins/whylogs-plugin/_index.md
+++ b/content/integrations/flytekit-plugins/whylogs-plugin/_index.md
@@ -2,7 +2,6 @@
 title: WhyLogs
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # WhyLogs

--- a/content/integrations/native-backend-plugins/_index.md
+++ b/content/integrations/native-backend-plugins/_index.md
@@ -2,7 +2,6 @@
 title: Native backend plugins
 weight: 3
 variants: +flyte -union
-sidebar_expanded: true
 ---
 
 # Native backend plugins

--- a/content/integrations/native-backend-plugins/k8s-dask-plugin/_index.md
+++ b/content/integrations/native-backend-plugins/k8s-dask-plugin/_index.md
@@ -2,7 +2,6 @@
 title: Dask
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # Dask

--- a/content/integrations/native-backend-plugins/k8s-spark-plugin/_index.md
+++ b/content/integrations/native-backend-plugins/k8s-spark-plugin/_index.md
@@ -2,7 +2,6 @@
 title: Spark
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # Spark

--- a/content/integrations/native-backend-plugins/kfmpi-plugin/_index.md
+++ b/content/integrations/native-backend-plugins/kfmpi-plugin/_index.md
@@ -2,7 +2,6 @@
 title: MPI
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # MPI

--- a/content/integrations/native-backend-plugins/kfpytorch-plugin/_index.md
+++ b/content/integrations/native-backend-plugins/kfpytorch-plugin/_index.md
@@ -2,7 +2,6 @@
 title: PyTorch Distributed
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # PyTorch Distributed

--- a/content/integrations/native-backend-plugins/kftensorflow-plugin/_index.md
+++ b/content/integrations/native-backend-plugins/kftensorflow-plugin/_index.md
@@ -2,7 +2,6 @@
 title: TensorFlow Distributed
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # TensorFlow Distributed

--- a/content/integrations/native-backend-plugins/ray-plugin/_index.md
+++ b/content/integrations/native-backend-plugins/ray-plugin/_index.md
@@ -2,7 +2,6 @@
 title: Ray
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # Ray

--- a/content/tutorials/_index.md
+++ b/content/tutorials/_index.md
@@ -3,7 +3,6 @@ title: Tutorials
 weight: 2
 variants: +flyte +union
 top_menu: true
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/tutorials/bioinformatics/_index.md
+++ b/content/tutorials/bioinformatics/_index.md
@@ -2,7 +2,6 @@
 title: Bioinformatics
 weight: 1
 variants: +flyte +union
-sidebar_expanded: true
 ---
 
 # Bioinformatics

--- a/content/tutorials/bioinformatics/blast/_index.md
+++ b/content/tutorials/bioinformatics/blast/_index.md
@@ -2,7 +2,6 @@
 title: Nucleotide Sequence Querying with BLASTX
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # Nucleotide Sequence Querying with BLASTX

--- a/content/tutorials/compound-ai-systems/_index.md
+++ b/content/tutorials/compound-ai-systems/_index.md
@@ -2,7 +2,6 @@
 title: Compound AI Systems
 weight: 1
 variants: -flyte +union
-sidebar_expanded: true
 ---
 
 # Compound AI Systems

--- a/content/tutorials/diffusion-models/_index.md
+++ b/content/tutorials/diffusion-models/_index.md
@@ -2,7 +2,6 @@
 title: Diffusion models
 weight: 1
 variants: -flyte +union
-sidebar_expanded: true
 ---
 
 # Diffusion models

--- a/content/tutorials/feature-engineering/_index.md
+++ b/content/tutorials/feature-engineering/_index.md
@@ -2,7 +2,6 @@
 title: Feature engineering
 weight: 1
 variants: +flyte -union
-sidebar_expanded: true
 ---
 
 # Feature engineering

--- a/content/tutorials/feature-engineering/exploratory-data-analysis/_index.md
+++ b/content/tutorials/feature-engineering/exploratory-data-analysis/_index.md
@@ -2,7 +2,6 @@
 title: EDA, Feature Engineering, and Modeling with Papermill
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # EDA, Feature Engineering, and Modeling With Papermill

--- a/content/tutorials/feature-engineering/feast-integration/_index.md
+++ b/content/tutorials/feature-engineering/feast-integration/_index.md
@@ -2,7 +2,6 @@
 title: Feast integration
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # Feast Integration

--- a/content/tutorials/finance/_index.md
+++ b/content/tutorials/finance/_index.md
@@ -2,7 +2,6 @@
 title: Finance
 weight: 1
 variants: -flyte +union
-sidebar_expanded: true
 ---
 
 # Finance

--- a/content/tutorials/flytelab/_index.md
+++ b/content/tutorials/flytelab/_index.md
@@ -2,7 +2,6 @@
 title: Flytelab
 weight: 1
 variants: +flyte -union
-sidebar_expanded: true
 ---
 
 # Flytelab

--- a/content/tutorials/flytelab/weather-forecasting.md
+++ b/content/tutorials/flytelab/weather-forecasting.md
@@ -2,7 +2,6 @@
 title: Weather forecasting
 weight: 1
 variants: +flyte -union
-sidebar_expanded: true
 ---
 
 # Weather Forecasting

--- a/content/tutorials/language-models/_index.md
+++ b/content/tutorials/language-models/_index.md
@@ -2,7 +2,6 @@
 title: Language Models
 weight: 1
 variants: -flyte +union
-sidebar_expanded: true
 ---
 
 # Language Models

--- a/content/tutorials/model-training/_index.md
+++ b/content/tutorials/model-training/_index.md
@@ -2,7 +2,6 @@
 title: Model training
 weight: 1
 variants: +flyte -union
-sidebar_expanded: true
 ---
 
 # Model training

--- a/content/tutorials/model-training/forecasting-sales/_index.md
+++ b/content/tutorials/model-training/forecasting-sales/_index.md
@@ -2,7 +2,6 @@
 title: Forecasting Rossman store sales with Horovod and Spark
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # Forecasting Rossman Store Sales with Horovod and Spark

--- a/content/tutorials/model-training/house-price-prediction/_index.md
+++ b/content/tutorials/model-training/house-price-prediction/_index.md
@@ -2,7 +2,6 @@
 title: House price regression
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # House Price Regression

--- a/content/tutorials/model-training/mnist-classifier/_index.md
+++ b/content/tutorials/model-training/mnist-classifier/_index.md
@@ -2,7 +2,6 @@
 title: MNIST classification with PyTorch and W & B
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # MNIST Classification With PyTorch and W&B

--- a/content/tutorials/model-training/nlp-processing/_index.md
+++ b/content/tutorials/model-training/nlp-processing/_index.md
@@ -2,7 +2,6 @@
 title: NLP processing
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # NLP Processing

--- a/content/tutorials/model-training/pima-diabetes/_index.md
+++ b/content/tutorials/model-training/pima-diabetes/_index.md
@@ -2,7 +2,6 @@
 title: Diabetes classification
 weight: 1
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # Diabetes Classification

--- a/content/tutorials/parallel-processing-and-job-scheduling/_index.md
+++ b/content/tutorials/parallel-processing-and-job-scheduling/_index.md
@@ -2,7 +2,6 @@
 title: Parallel Processing and Job Scheduling
 weight: 1
 variants: -flyte +union
-sidebar_expanded: true
 ---
 
 # Parallel Processing and Job Scheduling

--- a/content/tutorials/retrieval-augmented-generation/_index.md
+++ b/content/tutorials/retrieval-augmented-generation/_index.md
@@ -2,7 +2,6 @@
 title: Retrieval Augmented Generation
 weight: 1
 variants: -flyte +union
-sidebar_expanded: true
 ---
 
 # Retrieval Augmented Generation

--- a/content/tutorials/serving/_index.md
+++ b/content/tutorials/serving/_index.md
@@ -2,7 +2,6 @@
 title: Serving
 variants: -flyte +union
 weight: 1
-sidebar_expanded: true
 ---
 
 # Serving

--- a/content/tutorials/time-series/_index.md
+++ b/content/tutorials/time-series/_index.md
@@ -2,7 +2,6 @@
 title: Time Series
 weight: 1
 variants: -flyte +union
-sidebar_expanded: true
 ---
 
 # Time Series

--- a/content/user-guide/_index.md
+++ b/content/user-guide/_index.md
@@ -4,7 +4,6 @@ weight: 1
 variants: +flyte +union
 top_menu: true
 site_root: true
-sidebar_expanded: true
 ---
 
 {{< variant flyte >}}

--- a/content/user-guide/administration/_index.md
+++ b/content/user-guide/administration/_index.md
@@ -2,7 +2,6 @@
 title: Administration
 weight: 7
 variants: -flyte +union
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/user-guide/core-concepts/_index.md
+++ b/content/user-guide/core-concepts/_index.md
@@ -2,7 +2,6 @@
 title: Core concepts
 weight: 4
 variants: +flyte +union
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/user-guide/core-concepts/actors/_index.md
+++ b/content/user-guide/core-concepts/actors/_index.md
@@ -2,7 +2,6 @@
 title: Actors
 weight: 4
 variants: -flyte +union
-sidebar_expanded: false
 llm_readable_bundle: true
 ---
 

--- a/content/user-guide/core-concepts/artifacts/_index.md
+++ b/content/user-guide/core-concepts/artifacts/_index.md
@@ -2,7 +2,6 @@
 title: Artifacts
 weight: 5
 variants: -flyte +union
-sidebar_expanded: false
 llm_readable_bundle: true
 ---
 

--- a/content/user-guide/core-concepts/launch-plans/_index.md
+++ b/content/user-guide/core-concepts/launch-plans/_index.md
@@ -2,7 +2,6 @@
 title: Launch plans
 weight: 3
 variants: +flyte +union
-sidebar_expanded: false
 llm_readable_bundle: true
 ---
 

--- a/content/user-guide/core-concepts/serving/_index.md
+++ b/content/user-guide/core-concepts/serving/_index.md
@@ -2,7 +2,6 @@
 title: App Serving
 weight: 6
 variants: -flyte +union
-sidebar_expanded: false
 llm_readable_bundle: true
 ---
 

--- a/content/user-guide/core-concepts/tasks/_index.md
+++ b/content/user-guide/core-concepts/tasks/_index.md
@@ -2,7 +2,6 @@
 title: Tasks
 weight: 2
 variants: +flyte +union
-sidebar_expanded: false
 llm_readable_bundle: true
 ---
 

--- a/content/user-guide/core-concepts/tasks/task-hardware-environment/_index.md
+++ b/content/user-guide/core-concepts/tasks/task-hardware-environment/_index.md
@@ -2,7 +2,6 @@
 title: Task hardware environment
 weight: 7
 variants: +flyte +union
-sidebar_expanded: false
 ---
 
 # Task hardware environment

--- a/content/user-guide/core-concepts/tasks/task-software-environment/_index.md
+++ b/content/user-guide/core-concepts/tasks/task-software-environment/_index.md
@@ -2,7 +2,6 @@
 title: Task software environment
 weight: 6
 variants: +flyte +union
-sidebar_expanded: false
 ---
 
 # Task software environment

--- a/content/user-guide/core-concepts/workflows/_index.md
+++ b/content/user-guide/core-concepts/workflows/_index.md
@@ -2,7 +2,6 @@
 title: Workflows
 weight: 1
 variants: +flyte +union
-sidebar_expanded: false
 llm_readable_bundle: true
 ---
 

--- a/content/user-guide/data-input-output/_index.md
+++ b/content/user-guide/data-input-output/_index.md
@@ -2,7 +2,6 @@
 title: Data input/output
 weight: 6
 variants: +flyte +union
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/user-guide/development-cycle/_index.md
+++ b/content/user-guide/development-cycle/_index.md
@@ -2,7 +2,6 @@
 title: Development cycle
 weight: 5
 variants: +flyte +union
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 

--- a/content/user-guide/development-cycle/remote-management/_index.md
+++ b/content/user-guide/development-cycle/remote-management/_index.md
@@ -2,7 +2,6 @@
 title: Remote management
 weight: 19
 variants: +flyte +union
-sidebar_expanded: false
 ---
 
 # {{< key kit_remote >}}

--- a/content/user-guide/development-cycle/testing/_index.md
+++ b/content/user-guide/development-cycle/testing/_index.md
@@ -2,7 +2,6 @@
 title: Testing
 weight: 19
 variants: +flyte -union
-sidebar_expanded: false
 ---
 
 # Testing

--- a/content/user-guide/getting-started/_index.md
+++ b/content/user-guide/getting-started/_index.md
@@ -1,7 +1,6 @@
 ---
 title: Getting started
 weight: 3
-sidebar_expanded: true
 variants: +flyte +union
 llm_readable_bundle: true
 ---

--- a/content/user-guide/programming/_index.md
+++ b/content/user-guide/programming/_index.md
@@ -2,7 +2,6 @@
 title: Programming
 weight: 7
 variants: +flyte +union
-sidebar_expanded: true
 llm_readable_bundle: true
 ---
 


### PR DESCRIPTION
## Summary

Mirrors the v2 cleanup (#951) on the v1 branch.

Same change, same outcome: collapsed sidebar by default, active path auto-expands, manual chevron clicks expand siblings without collapsing others. This is the modern docs convention (Docusaurus, VitePress, MkDocs Material, MDN, etc.).

## Changes

- **Sweep 116 v1 content files**: remove `sidebar_expanded: true` (forced expansion) and `sidebar_expanded: false` (no-op).
- **`contributing-docs/authoring.md`**: reframe the field as an opt-in escape hatch.
- **`unionai-docs-infra` submodule pointer**: bump to `main` (06ac424) to pick up unionai/unionai-docs-infra#89, which fixes the chevron click handler. Without that, manual sibling expansion still wouldn't work even with sensible defaults.

## v1-specific note

Unlike v2, v1's `api-packages.toml` never set `expanded = true` for the SDK generators, so no toml change is needed here — every `sidebar_expanded` entry on v1 was hand-authored. v1's `flytekit-sdk` and `union-sdk` generated `_index.md` files were already clean.

## Capability preserved

`sidebar_expanded` still works in `section-tree-nav` as an explicit override. We just don't apply it by default anywhere.

## Verified

`make dev` on this branch:

| Page | Section titles | Collapsed | Expanded |
| - | - | - | - |
| `/user-guide/` (landing) | 16 | 16 | 0 |
| `/api-reference/flytekit-sdk/` | 99 | 98 | 1 |
| `/deployment/byoc/` | 4 | 4 | 0 |
| `/tutorials/` (landing) | 20 | 20 | 0 |

## Test plan

- [ ] Visit `/api-reference/flytekit-sdk/` — sidebar shows the active package expanded, all 98 siblings collapsed
- [ ] Click chevron on a sibling — it expands in place
- [ ] Visit `/user-guide/`, `/deployment/`, `/tutorials/` — fully collapsed
- [ ] Search bar (Algolia DocSearch) still finds content across all sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)