### PR TITLE
Clean up stale variant code names in contributing-docs

### DIFF
--- a/content/community/contributing-docs/publishing.md
+++ b/content/community/contributing-docs/publishing.md
@@ -70,7 +70,7 @@ Variants are flavors of the site (that you can change at the top).
 During development, you can render any variant by setting it in `hugo.local.toml`:
 
 ```
-variant = "byoc"
+variant = "union"
 ```
 
 We call this the "active" variant.

--- a/content/community/contributing-docs/shortcodes.md
+++ b/content/community/contributing-docs/shortcodes.md
@@ -61,7 +61,7 @@ The Union SDK provides the Python API for building Union workflows and apps.
 
 The big difference of this site, compared to other documentation sites, is that we generate multiple "flavors" of the documentation that are slightly different from each other. We are calling these "variants."
 
-When you are writing your content, and you want a specific part of the content to be conditional to a flavor, say "Union", you surround that with `variant`.
+When you are writing your content, and you want a specific part of the content to be conditional on a flavor, say "Union", you surround that with `variant`.
 
 >[!NOTE]
 > `variant` is a container, so inside you will specify what you are wrapping.
@@ -138,7 +138,7 @@ In the Flyte variant of the site this will render as:
 
 > The Flyte platform is awesome.
 
-While, in the Union variant of the site it will render as:
+Whereas in the Union variant of the site it will render as:
 
 > The Union.ai platform is awesome.
 

--- a/content/community/contributing-docs/shortcodes.md
+++ b/content/community/contributing-docs/shortcodes.md
@@ -61,7 +61,7 @@ The Union SDK provides the Python API for building Union workflows and apps.
 
 The big difference of this site, compared to other documentation sites, is that we generate multiple "flavors" of the documentation that are slightly different from each other. We are calling these "variants."
 
-When you are writing your content, and you want a specific part of the content to be conditional to a flavor, say "BYOC", you surround that with `variant`.
+When you are writing your content, and you want a specific part of the content to be conditional to a flavor, say "Union", you surround that with `variant`.
 
 >[!NOTE]
 > `variant` is a container, so inside you will specify what you are wrapping.
@@ -70,7 +70,7 @@ When you are writing your content, and you want a specific part of the content t
 Example:
 
 ```markdown
-{{</* variant byoc selfmanaged */>}}
+{{</* variant union */>}}
 {{</* markdown */>}}
 **The quick brown fox signed up for Union!**
 {{</* /markdown */>}}
@@ -138,7 +138,7 @@ In the Flyte variant of the site this will render as:
 
 > The Flyte platform is awesome.
 
-While, in the BYOC, Self-managed and Serverless variants of the site it will render as:
+While, in the Union variant of the site it will render as:
 
 > The Union.ai platform is awesome.
 
@@ -147,8 +147,7 @@ You can add keywords and specify their value, per variant, in `hugo.site.toml`:
 ```toml
 [params.key.product_full_name]
 flyte = "Flyte"
-byoc = "Union BYOC"
-selfmanaged = "Union Self-managed"
+union = "Union.ai"
 ```
 
 #### List of available keys
@@ -156,7 +155,7 @@ selfmanaged = "Union Self-managed"
 | Key               | Description                           | Example Usage (Flyte → Union)                                          |
 | ----------------- | ------------------------------------- | ---------------------------------------------------------------------- |
 | default_project   | Default project name used in examples | `{{</* key default_project */>}}` → "flytesnacks" or "default"             |
-| product_full_name | Full product name                     | `{{</* key product_full_name */>}}` → "Flyte OSS" or "Union.ai BYOC"       |
+| product_full_name | Full product name                     | `{{</* key product_full_name */>}}` → "Flyte OSS" or "Union.ai"            |
 | product_name      | Short product name                    | `{{</* key product_name */>}}` → "Flyte" or "Union.ai"                     |
 | product           | Lowercase product identifier          | `{{</* key product */>}}` → "flyte" or "union"                             |
 | kit_name          | SDK name                              | `{{</* key kit_name */>}}` → "Flytekit" or "Union"                         |
@@ -170,7 +169,7 @@ selfmanaged = "Union Self-managed"
 | ctl               | Lowercase control tool identifier     | `{{</* key ctl */>}}` → "flytectl" or "uctl"                               |
 | config_env        | Configuration environment variable    | `{{</* key config_env */>}}` → "FLYTECTL_CONFIG" or "UNION_CONFIG"         |
 | env_prefix        | Environment variable prefix           | `{{</* key env_prefix */>}}` → "FLYTE" or "UNION"                          |
-| docs_home         | Documentation home URL                | `{{</* key docs_home */>}}` → "/docs/flyte" or "/docs/byoc"               |
+| docs_home         | Documentation home URL                | `{{</* key docs_home */>}}` → "/docs/v2/flyte" or "/docs/v2/union"        |
 | map_func          | Map function name                     | `{{</* key map_func */>}}` → "map_task" or "map"                           |
 | logo              | Logo image filename                   | `{{</* key logo */>}}` → "flyte-logo.svg" or "union-logo.svg"              |
 | favicon           | Favicon image filename                | `{{</* key favicon */>}}` → "flyte-favicon.ico" or "union-favicon.ico"     |

--- a/content/community/contributing-docs/variants.md
+++ b/content/community/contributing-docs/variants.md
@@ -21,7 +21,7 @@ Currently, the docs site supports two variants:
 Each variant is referenced in the page logic using its respective code name: `flyte` or `union`.
 
 > [!NOTE]
-> The previous code names `byoc`, `selfmanaged`, and `serverless` are no longer valid. If you encounter them in older content, frontmatter, or shortcodes, update them to the current `flyte` or `union` codes. BYOC and Self-managed are now treated as deployment types within the `union` variant rather than separate variants.
+> The previous code names `byoc`, `selfmanaged`, and `serverless` are no longer valid. They all map to the current `union` variant — Union.ai now ships as a single docs variant covering BYOC and Self-managed deployments. The `flyte` variant covers open-source Flyte. If you encounter any of the retired names in older content, frontmatter, or shortcodes, replace `byoc`, `selfmanaged`, or `serverless` with `union`.
 
 The available set of variants are defined in the `config.<code_name>.toml` files in the `unionai-docs-infra/` directory.
 

--- a/content/community/contributing-docs/variants.md
+++ b/content/community/contributing-docs/variants.md
@@ -20,6 +20,9 @@ Currently, the docs site supports two variants:
 
 Each variant is referenced in the page logic using its respective code name: `flyte` or `union`.
 
+> [!NOTE]
+> The previous code names `byoc`, `selfmanaged`, and `serverless` are no longer valid. If you encounter them in older content, frontmatter, or shortcodes, update them to the current `flyte` or `union` codes. BYOC and Self-managed are now treated as deployment types within the `union` variant rather than separate variants.
+
 The available set of variants are defined in the `config.<code_name>.toml` files in the `unionai-docs-infra/` directory.
 
 ## Variants at the whole-page level


### PR DESCRIPTION
## Summary

Mirrors PR #947 (v1) on the main branch. The variant consolidation landed earlier but missed a few contributor-facing pages that still referenced the retired `byoc`, `selfmanaged`, and `serverless` code names.

Found while reviewing #947 — the same issues are present on main, with one extra: the `docs_home` table entry on main still says `"/docs/flyte" or "/docs/byoc"`, where `byoc` is no longer a valid variant.

## Changes

- **`shortcodes.md`** — 6 stale spots fixed:
  - "say 'BYOC'" → "say 'Union'" prose
  - `{{< variant byoc selfmanaged >}}` example → `{{< variant union >}}`
  - "in the BYOC, Self-managed and Serverless variants" → "in the Union variant"
  - `[params.key.product_full_name]` TOML example: `byoc`/`selfmanaged` keys → single `union` key
  - `product_full_name` example value "Union.ai BYOC" → "Union.ai"
  - `docs_home` example: `"/docs/flyte" or "/docs/byoc"` → `"/docs/v2/flyte" or "/docs/v2/union"` (now matches production URL pattern)
- **`publishing.md`** — dev-config example `variant = "byoc"` → `variant = "union"`
- **`variants.md`** — add a `> [!NOTE]` block listing the retired code names with guidance to update them, and clarifying that BYOC and Self-managed are now deployment types within the `union` variant rather than separate variants.

## Deliberately left alone

- `CLAUDE.md:7` — "Selfmanaged & Selfhosted Context" / "selfhosted or selfmanaged context" refers to the deployment type, not the variant code name.
- `content/deployment/**` — BYOC and Self-managed are real product deployment types within the `union` variant.

## Test plan

- [ ] CI passes.
- [ ] Reviewer: confirm the contributing-docs pages read accurately for the current two-variant state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)