### PR TITLE
Ignore .codex/ alongside .claude/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,6 @@ scripts/.e2e-keys/
 
 # AI assistant
 .claude/
+.codex/
 
 **/.flyte


### PR DESCRIPTION
## Summary
- Adds \`.codex/\` to \`.gitignore\` so local Codex AI assistant config doesn't get tracked, mirroring the existing \`.claude/\` entry.
- Salvaged from the abandoned \`plugin-separate-venvs\` branch (originally by @samhita-alla). The substantive submodule bump from that branch already landed via subsequent infra updates; this one-liner was the only remaining piece.

## Test plan
- [x] No-op for users who don't use Codex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)