### PR TITLE
Sync .gitignore with main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,15 @@ __pycache__/
 .python-version
 uv.lock
 
+# E2E test artifacts
+scripts/.debug/
+scripts/.e2e-workspace/
+scripts/e2e-workspace/
+scripts/e2e_workspace/
+scripts/.e2e-keys/
+
 # AI assistant
 .claude/
+.codex/
+
+**/.flyte


### PR DESCRIPTION
## Summary
- Brings v1's \`.gitignore\` in line with \`main\`. Adds three sections that were missing on v1:
  - E2E test artifacts (\`scripts/.debug/\`, \`scripts/.e2e-workspace/\`, etc.)
  - \`.codex/\` (alongside the existing \`.claude/\` AI assistant entry — same one being added to main in #964)
  - \`**/.flyte\`
- After this lands, \`v1/.gitignore\` is byte-for-byte identical to \`main/.gitignore\` (post-#964).

## Test plan
- [x] Diffed against post-#964 main; identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)