### PR TITLE
Phase 0a follow-through: variant cleanup in content (docs-main)

### DIFF
--- a/content/release-notes/_index.md
+++ b/content/release-notes/_index.md
@@ -15,7 +15,7 @@ Panel apps now support longer idle times for websocket connections, with session
 
 ### :wrench: Plugin Variants Documentation
 
-The new `--plugin-variants` flag in `flyte gen docs` generates variant-scoped CLI documentation. Plugin-contributed CLI commands are wrapped in Hugo `{{</* variant */>}}` shortcodes, so core commands appear unconditionally while plugin commands are shown only in specified variants (e.g., `byoc`, `selfmanaged`).
+The new `--plugin-variants` flag in `flyte gen docs` generates variant-scoped CLI documentation. Plugin-contributed CLI commands are wrapped in Hugo `{{</* variant */>}}` shortcodes, so core commands appear unconditionally while plugin commands are shown only in specified variants (e.g., `flyte`, `union`).
 
 ### :rocket: Google Gemini Plugin Integration
 

--- a/content/tutorials/micro-batching/_index.md
+++ b/content/tutorials/micro-batching/_index.md
@@ -586,7 +586,7 @@ async def process_batch(batch_start: int, batch_end: int) -> List[int]:
 - Ensure traced functions are idempotent when possible
 - Keep traced function signatures simple (serializable inputs/outputs)
 
-See the [Traces]({{< docs_home byoc v2 >}}/user-guide/task-programming/traces/) docs for more details on how it works
+See the [Traces]({{< docs_home union v2 >}}/user-guide/task-programming/traces/) docs for more details on how it works
 
 ### Step 6: Implement the Orchestrator Workflow
 
@@ -823,7 +823,7 @@ On execution, this is what this example looks like at the Kubernetes level:
 
 ![](./images/reusable-containers-k8s.png)
 
-This is, 10 replicas (as defined in the `TaskEnvironment`) and the driver Pod that runs the parent task (`a0`). [Learn more about the parent task]({{< docs_home byoc v2 >}}/user-guide/considerations/#driver-pod-requirements).
+This is, 10 replicas (as defined in the `TaskEnvironment`) and the driver Pod that runs the parent task (`a0`). [Learn more about the parent task]({{< docs_home union v2 >}}/user-guide/considerations/#driver-pod-requirements).
 
 ## Batch Size Selection
 
@@ -838,7 +838,7 @@ This is, 10 replicas (as defined in the `TaskEnvironment`) and the driver Pod th
 - Failure tolerance (critical = smaller batches for faster recovery)
 - Total workload size (larger total = can use larger batches)
 
-Read the [Optimization strategies]({{< docs_home byoc v2 >}}/user-guide/run-scaling/scale-your-workflows/#2-batch-workloads-to-reduce-overhead) page to understand the overheads associated with an execution and how to choose the appropiate batch size.
+Read the [Optimization strategies]({{< docs_home union v2 >}}/user-guide/run-scaling/scale-your-workflows/#2-batch-workloads-to-reduce-overhead) page to understand the overheads associated with an execution and how to choose the appropiate batch size.
 
 
 


### PR DESCRIPTION
## Summary

Companion to **unionai-docs-infra#100**. Bumps the infra submodule to that PR's branch HEAD and fixes the docs-main content that referenced the removed `byoc` / `selfmanaged` variants.

> [!IMPORTANT]
> The submodule currently points at `f8444a3` on `peeter/gha-docs-build` (unmerged infra branch). **Before merging this PR**, re-bump the submodule to the merged-main SHA from infra#100. The current pointer is intentional so CF Pages can preview-build the infra changes alongside the content changes.

## Changes

- **`unionai-docs-infra` submodule**: bump `37cc27d` → `f8444a3` (HEAD of infra#100)
- **`content/tutorials/micro-batching/_index.md`**: 3× `{{< docs_home byoc v2 >}}` → `{{< docs_home union v2 >}}`. Required because the `byoc` key was removed from `hugo.site.toml` in infra#100.
- **`content/release-notes/_index.md`**: variant-list example `(e.g., byoc, selfmanaged)` → `(e.g., flyte, union)` to match active variants.

## Test plan
- [ ] CF Pages preview build succeeds (this is the real test — exercises infra#100 changes against current pinned Hugo)
- [ ] Render-check `tutorials/micro-batching/_index.md` — links resolve to `union.ai/docs/union/v2/...`
- [ ] Render-check `release-notes/_index.md` — example reads naturally

## Pre-merge checklist
- [ ] infra#100 reviewed/merged
- [ ] Re-bump submodule pointer to merged-main SHA
- [ ] Force-push or new commit to update this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)