### PR TITLE
Regenerate v1 API reference docs

### DIFF
--- a/content/api-reference/flytekit-sdk/_index.md
+++ b/content/api-reference/flytekit-sdk/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Flytekit SDK
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/classes.md
+++ b/content/api-reference/flytekit-sdk/classes.md
@@ -1,6 +1,6 @@
 ---
 title: Classes & Protocols
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/_index.md
+++ b/content/api-reference/flytekit-sdk/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.bin.entrypoint.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.bin.entrypoint.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.bin.entrypoint
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.clients.auth.auth_client.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.clients.auth.auth_client.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.clients.auth.auth_client
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.clients.auth.authenticator.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.clients.auth.authenticator.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.clients.auth.authenticator
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.clients.auth.default_html.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.clients.auth.default_html.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.clients.auth.default_html
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.clients.auth.exceptions.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.clients.auth.exceptions.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.clients.auth.exceptions
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.clients.auth.keyring.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.clients.auth.keyring.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.clients.auth.keyring
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.clients.auth.token_client.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.clients.auth.token_client.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.clients.auth.token_client
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.clients.auth_helper.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.clients.auth_helper.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.clients.auth_helper
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.clients.friendly.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.clients.friendly.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.clients.friendly
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.clients.grpc_utils.auth_interceptor.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.clients.grpc_utils.auth_interceptor.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.clients.grpc_utils.auth_interceptor
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.clients.grpc_utils.default_metadata_interceptor.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.clients.grpc_utils.default_metadata_interceptor.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.clients.grpc_utils.default_metadata_interceptor
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.clients.grpc_utils.wrap_exception_interceptor.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.clients.grpc_utils.wrap_exception_interceptor.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.clients.grpc_utils.wrap_exception_interceptor
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.clients.helpers.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.clients.helpers.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.clients.helpers
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.clients.raw.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.clients.raw.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.clients.raw
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.clis.helpers.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.clis.helpers.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.clis.helpers
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.clis.sdk_in_container.backfill.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.clis.sdk_in_container.backfill.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.clis.sdk_in_container.backfill
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.clis.sdk_in_container.build.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.clis.sdk_in_container.build.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.clis.sdk_in_container.build
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.clis.sdk_in_container.constants.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.clis.sdk_in_container.constants.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.clis.sdk_in_container.constants
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.clis.sdk_in_container.executions.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.clis.sdk_in_container.executions.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.clis.sdk_in_container.executions
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.clis.sdk_in_container.helpers.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.clis.sdk_in_container.helpers.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.clis.sdk_in_container.helpers
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.clis.sdk_in_container.metrics.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.clis.sdk_in_container.metrics.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.clis.sdk_in_container.metrics
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.clis.sdk_in_container.package.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.clis.sdk_in_container.package.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.clis.sdk_in_container.package
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.clis.sdk_in_container.pyflyte.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.clis.sdk_in_container.pyflyte.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.clis.sdk_in_container.pyflyte
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.clis.sdk_in_container.run.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.clis.sdk_in_container.run.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.clis.sdk_in_container.run
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.clis.sdk_in_container.serialize.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.clis.sdk_in_container.serialize.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.clis.sdk_in_container.serialize
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.clis.sdk_in_container.serve.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.clis.sdk_in_container.serve.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.clis.sdk_in_container.serve
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.clis.sdk_in_container.utils.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.clis.sdk_in_container.utils.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.clis.sdk_in_container.utils
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.clis.version.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.clis.version.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.clis.version
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.configuration.default_images.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.configuration.default_images.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.configuration.default_images
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.configuration.feature_flags.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.configuration.feature_flags.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.configuration.feature_flags
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.configuration.file.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.configuration.file.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.configuration.file
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.configuration.internal.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.configuration.internal.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.configuration.internal
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.configuration.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.configuration.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.configuration
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.configuration.plugin.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.configuration.plugin.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.configuration.plugin
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.constants.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.constants.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.constants
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.annotation.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.annotation.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.annotation
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.array_node.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.array_node.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.array_node
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.array_node_map_task.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.array_node_map_task.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.array_node_map_task
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.artifact.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.artifact.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.artifact
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.artifact_utils.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.artifact_utils.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.artifact_utils
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.base_sql_task.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.base_sql_task.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.base_sql_task
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.base_task.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.base_task.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.base_task
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.cache.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.cache.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.cache
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.checkpointer.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.checkpointer.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.checkpointer
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.class_based_resolver.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.class_based_resolver.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.class_based_resolver
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.condition.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.condition.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.condition
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.constants.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.constants.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.constants
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.container_task.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.container_task.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.container_task
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.context_manager.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.context_manager.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.context_manager
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.data_persistence.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.data_persistence.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.data_persistence
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.docstring.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.docstring.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.docstring
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.environment.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.environment.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.environment
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.gate.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.gate.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.gate
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.hash.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.hash.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.hash
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.interface.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.interface.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.interface
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.launch_plan.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.launch_plan.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.launch_plan
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.legacy_map_task.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.legacy_map_task.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.legacy_map_task
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.local_cache.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.local_cache.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.local_cache
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.local_fsspec.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.local_fsspec.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.local_fsspec
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.mock_stats.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.mock_stats.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.mock_stats
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.node.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.node.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.node
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.node_creation.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.node_creation.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.node_creation
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.notification.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.notification.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.notification
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.options.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.options.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.options
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.pod_template.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.pod_template.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.pod_template
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.promise.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.promise.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.promise
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.python_auto_container.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.python_auto_container.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.python_auto_container
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.python_customized_container_task.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.python_customized_container_task.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.python_customized_container_task
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.python_function_task.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.python_function_task.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.python_function_task
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.reference.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.reference.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.reference
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.reference_entity.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.reference_entity.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.reference_entity
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.resources.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.resources.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.resources
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---
@@ -131,15 +131,15 @@ def from_dict(
 
 ```python
 def from_json(
-    data: typing.Union[str, bytes, bytearray],
-    decoder: collections.abc.Callable[[typing.Union[str, bytes, bytearray]], dict[typing.Any, typing.Any]],
+    data: str | bytes | bytearray,
+    decoder: collections.abc.Callable[[str | bytes | bytearray], dict[typing.Any, typing.Any]],
     from_dict_kwargs: typing.Any,
 ) -> ~T
 ```
 | Parameter | Type | Description |
 |-|-|-|
-| `data` | `typing.Union[str, bytes, bytearray]` | |
-| `decoder` | `collections.abc.Callable[[typing.Union[str, bytes, bytearray]], dict[typing.Any, typing.Any]]` | |
+| `data` | `str \| bytes \| bytearray` | |
+| `decoder` | `collections.abc.Callable[[str \| bytes \| bytearray], dict[typing.Any, typing.Any]]` | |
 | `from_dict_kwargs` | `typing.Any` | |
 
 #### from_multiple_resource()
@@ -165,13 +165,13 @@ def to_dict()
 
 ```python
 def to_json(
-    encoder: collections.abc.Callable[[typing.Any], typing.Union[str, bytes, bytearray]],
+    encoder: collections.abc.Callable[[typing.Any], str | bytes | bytearray],
     to_dict_kwargs: typing.Any,
-) -> typing.Union[str, bytes, bytearray]
+) -> str | bytes | bytearray
 ```
 | Parameter | Type | Description |
 |-|-|-|
-| `encoder` | `collections.abc.Callable[[typing.Any], typing.Union[str, bytes, bytearray]]` | |
+| `encoder` | `collections.abc.Callable[[typing.Any], str \| bytes \| bytearray]` | |
 | `to_dict_kwargs` | `typing.Any` | |
 
 ## flytekit.core.resources.Resources
@@ -244,15 +244,15 @@ def from_dict(
 
 ```python
 def from_json(
-    data: typing.Union[str, bytes, bytearray],
-    decoder: collections.abc.Callable[[typing.Union[str, bytes, bytearray]], dict[typing.Any, typing.Any]],
+    data: str | bytes | bytearray,
+    decoder: collections.abc.Callable[[str | bytes | bytearray], dict[typing.Any, typing.Any]],
     from_dict_kwargs: typing.Any,
 ) -> ~T
 ```
 | Parameter | Type | Description |
 |-|-|-|
-| `data` | `typing.Union[str, bytes, bytearray]` | |
-| `decoder` | `collections.abc.Callable[[typing.Union[str, bytes, bytearray]], dict[typing.Any, typing.Any]]` | |
+| `data` | `str \| bytes \| bytearray` | |
+| `decoder` | `collections.abc.Callable[[str \| bytes \| bytearray], dict[typing.Any, typing.Any]]` | |
 | `from_dict_kwargs` | `typing.Any` | |
 
 #### to_dict()
@@ -264,12 +264,12 @@ def to_dict()
 
 ```python
 def to_json(
-    encoder: collections.abc.Callable[[typing.Any], typing.Union[str, bytes, bytearray]],
+    encoder: collections.abc.Callable[[typing.Any], str | bytes | bytearray],
     to_dict_kwargs: typing.Any,
-) -> typing.Union[str, bytes, bytearray]
+) -> str | bytes | bytearray
 ```
 | Parameter | Type | Description |
 |-|-|-|
-| `encoder` | `collections.abc.Callable[[typing.Any], typing.Union[str, bytes, bytearray]]` | |
+| `encoder` | `collections.abc.Callable[[typing.Any], str \| bytes \| bytearray]` | |
 | `to_dict_kwargs` | `typing.Any` | |
 

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.schedule.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.schedule.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.schedule
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.shim_task.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.shim_task.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.shim_task
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.task.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.task.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.task
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.testing.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.testing.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.testing
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.tracked_abc.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.tracked_abc.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.tracked_abc
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.tracker.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.tracker.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.tracker
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.type_engine.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.type_engine.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.type_engine
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.type_helpers.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.type_helpers.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.type_helpers
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.type_match_checking.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.type_match_checking.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.type_match_checking
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.utils.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.utils.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.utils
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.worker_queue.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.worker_queue.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.worker_queue
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.core.workflow.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.core.workflow.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.core.workflow
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.deck.deck.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.deck.deck.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.deck.deck
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.deck.renderer.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.deck.renderer.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.deck.renderer
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.exceptions.base.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.exceptions.base.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.exceptions.base
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.exceptions.eager.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.exceptions.eager.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.exceptions.eager
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.exceptions.scopes.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.exceptions.scopes.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.exceptions.scopes
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.exceptions.system.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.exceptions.system.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.exceptions.system
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.exceptions.user.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.exceptions.user.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.exceptions.user
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.exceptions.utils.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.exceptions.utils.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.exceptions.utils
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.experimental.eager_function.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.experimental.eager_function.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.experimental.eager_function
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.extend.backend.base_connector.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.extend.backend.base_connector.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.extend.backend.base_connector
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.extend.backend.connector_service.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.extend.backend.connector_service.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.extend.backend.connector_service
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.extend.backend.utils.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.extend.backend.utils.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.extend.backend.utils
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.extras.accelerators.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.extras.accelerators.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.extras.accelerators
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.extras.cloud_pickle_resolver.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.extras.cloud_pickle_resolver.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.extras.cloud_pickle_resolver
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.extras.pydantic_transformer.transformer.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.extras.pydantic_transformer.transformer.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.extras.pydantic_transformer.transformer
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.extras.sklearn.native.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.extras.sklearn.native.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.extras.sklearn.native
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.extras.sqlite3.task.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.extras.sqlite3.task.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.extras.sqlite3.task
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.extras.tasks.shell.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.extras.tasks.shell.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.extras.tasks.shell
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.extras.webhook.connector.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.extras.webhook.connector.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.extras.webhook.connector
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.extras.webhook.constants.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.extras.webhook.constants.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.extras.webhook.constants
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.extras.webhook.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.extras.webhook.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.extras.webhook
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.extras.webhook.task.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.extras.webhook.task.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.extras.webhook.task
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.image_spec.default_builder.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.image_spec.default_builder.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.image_spec.default_builder
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.image_spec.image_spec.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.image_spec.image_spec.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.image_spec.image_spec
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.image_spec.noop_builder.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.image_spec.noop_builder.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.image_spec.noop_builder
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.interaction.click_types.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.interaction.click_types.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.interaction.click_types
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.interaction.parse_stdin.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.interaction.parse_stdin.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.interaction.parse_stdin
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.interaction.rich_utils.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.interaction.rich_utils.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.interaction.rich_utils
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.interaction.string_literals.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.interaction.string_literals.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.interaction.string_literals
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.interactive.constants.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.interactive.constants.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.interactive.constants
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.interactive.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.interactive.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.interactive
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.interactive.utils.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.interactive.utils.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.interactive.utils
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.interactive.vscode_lib.config.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.interactive.vscode_lib.config.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.interactive.vscode_lib.config
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.interactive.vscode_lib.decorator.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.interactive.vscode_lib.decorator.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.interactive.vscode_lib.decorator
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.interactive.vscode_lib.vscode_constants.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.interactive.vscode_lib.vscode_constants.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.interactive.vscode_lib.vscode_constants
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.interfaces.cli_identifiers.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.interfaces.cli_identifiers.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.interfaces.cli_identifiers
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.interfaces.random.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.interfaces.random.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.interfaces.random
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.interfaces.stats.client.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.interfaces.stats.client.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.interfaces.stats.client
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.interfaces.stats.taggable.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.interfaces.stats.taggable.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.interfaces.stats.taggable
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.lazy_import.lazy_module.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.lazy_import.lazy_module.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.lazy_import.lazy_module
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.loggers.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.loggers.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.loggers
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.models.admin.common.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.models.admin.common.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.models.admin.common
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.models.admin.task_execution.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.models.admin.task_execution.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.models.admin.task_execution
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.models.admin.workflow.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.models.admin.workflow.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.models.admin.workflow
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.models.annotation.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.models.annotation.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.models.annotation
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.models.array_job.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.models.array_job.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.models.array_job
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.models.common.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.models.common.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.models.common
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.models.concurrency.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.models.concurrency.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.models.concurrency
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.models.core.catalog.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.models.core.catalog.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.models.core.catalog
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.models.core.compiler.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.models.core.compiler.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.models.core.compiler
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.models.core.condition.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.models.core.condition.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.models.core.condition
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.models.core.errors.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.models.core.errors.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.models.core.errors
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.models.core.execution.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.models.core.execution.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.models.core.execution
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.models.core.identifier.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.models.core.identifier.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.models.core.identifier
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.models.core.types.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.models.core.types.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.models.core.types
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.models.core.workflow.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.models.core.workflow.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.models.core.workflow
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.models.documentation.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.models.documentation.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.models.documentation
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.models.domain.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.models.domain.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.models.domain
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.models.dynamic_job.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.models.dynamic_job.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.models.dynamic_job
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.models.event.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.models.event.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.models.event
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.models.execution.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.models.execution.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.models.execution
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.models.filters.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.models.filters.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.models.filters
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.models.interface.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.models.interface.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.models.interface
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.models.launch_plan.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.models.launch_plan.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.models.launch_plan
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.models.literals.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.models.literals.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.models.literals
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.models.matchable_resource.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.models.matchable_resource.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.models.matchable_resource
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.models.named_entity.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.models.named_entity.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.models.named_entity
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.models.node_execution.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.models.node_execution.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.models.node_execution
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.models.presto.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.models.presto.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.models.presto
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.models.project.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.models.project.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.models.project
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.models.qubole.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.models.qubole.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.models.qubole
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.models.schedule.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.models.schedule.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.models.schedule
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.models.security.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.models.security.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.models.security
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.models.task.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.models.task.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.models.task
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.models.types.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.models.types.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.models.types
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.models.workflow_closure.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.models.workflow_closure.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.models.workflow_closure
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.remote.backfill.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.remote.backfill.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.remote.backfill
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.remote.data.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.remote.data.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.remote.data
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.remote.entities.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.remote.entities.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.remote.entities
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.remote.executions.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.remote.executions.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.remote.executions
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.remote.interface.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.remote.interface.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.remote.interface
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.remote.lazy_entity.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.remote.lazy_entity.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.remote.lazy_entity
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.remote.metrics.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.remote.metrics.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.remote.metrics
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.remote.remote.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.remote.remote.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.remote.remote
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.remote.remote_callable.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.remote.remote_callable.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.remote.remote_callable
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.remote.remote_fs.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.remote.remote_fs.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.remote.remote_fs
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.sensor.base_sensor.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.sensor.base_sensor.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.sensor.base_sensor
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.sensor.file_sensor.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.sensor.file_sensor.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.sensor.file_sensor
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.sensor.sensor_engine.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.sensor.sensor_engine.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.sensor.sensor_engine
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.tools.fast_registration.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.tools.fast_registration.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.tools.fast_registration
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.tools.ignore.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.tools.ignore.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.tools.ignore
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.tools.interactive.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.tools.interactive.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.tools.interactive
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.tools.module_loader.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.tools.module_loader.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.tools.module_loader
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.tools.repo.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.tools.repo.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.tools.repo
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.tools.script_mode.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.tools.script_mode.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.tools.script_mode
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.tools.serialize_helpers.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.tools.serialize_helpers.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.tools.serialize_helpers
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.tools.subprocess.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.tools.subprocess.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.tools.subprocess
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.tools.translator.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.tools.translator.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.tools.translator
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.types.directory.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.types.directory.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.types.directory
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.types.directory.types.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.types.directory.types.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.types.directory.types
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.types.error.error.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.types.error.error.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.types.error.error
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---
@@ -279,15 +279,15 @@ def from_dict(
 
 ```python
 def from_json(
-    data: typing.Union[str, bytes, bytearray],
-    decoder: collections.abc.Callable[[typing.Union[str, bytes, bytearray]], dict[typing.Any, typing.Any]],
+    data: str | bytes | bytearray,
+    decoder: collections.abc.Callable[[str | bytes | bytearray], dict[typing.Any, typing.Any]],
     from_dict_kwargs: typing.Any,
 ) -> ~T
 ```
 | Parameter | Type | Description |
 |-|-|-|
-| `data` | `typing.Union[str, bytes, bytearray]` | |
-| `decoder` | `collections.abc.Callable[[typing.Union[str, bytes, bytearray]], dict[typing.Any, typing.Any]]` | |
+| `data` | `str \| bytes \| bytearray` | |
+| `decoder` | `collections.abc.Callable[[str \| bytes \| bytearray], dict[typing.Any, typing.Any]]` | |
 | `from_dict_kwargs` | `typing.Any` | |
 
 #### to_dict()
@@ -299,12 +299,12 @@ def to_dict()
 
 ```python
 def to_json(
-    encoder: collections.abc.Callable[[typing.Any], typing.Union[str, bytes, bytearray]],
+    encoder: collections.abc.Callable[[typing.Any], str | bytes | bytearray],
     to_dict_kwargs: typing.Any,
-) -> typing.Union[str, bytes, bytearray]
+) -> str | bytes | bytearray
 ```
 | Parameter | Type | Description |
 |-|-|-|
-| `encoder` | `collections.abc.Callable[[typing.Any], typing.Union[str, bytes, bytearray]]` | |
+| `encoder` | `collections.abc.Callable[[typing.Any], str \| bytes \| bytearray]` | |
 | `to_dict_kwargs` | `typing.Any` | |
 

--- a/content/api-reference/flytekit-sdk/packages/flytekit.types.file.file.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.types.file.file.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.types.file.file
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---
@@ -124,15 +124,15 @@ def from_dict(
 
 ```python
 def from_json(
-    data: typing.Union[str, bytes, bytearray],
-    decoder: collections.abc.Callable[[typing.Union[str, bytes, bytearray]], dict[typing.Any, typing.Any]],
+    data: str | bytes | bytearray,
+    decoder: collections.abc.Callable[[str | bytes | bytearray], dict[typing.Any, typing.Any]],
     from_dict_kwargs: typing.Any,
 ) -> ~T
 ```
 | Parameter | Type | Description |
 |-|-|-|
-| `data` | `typing.Union[str, bytes, bytearray]` | |
-| `decoder` | `collections.abc.Callable[[typing.Union[str, bytes, bytearray]], dict[typing.Any, typing.Any]]` | |
+| `data` | `str \| bytes \| bytearray` | |
+| `decoder` | `collections.abc.Callable[[str \| bytes \| bytearray], dict[typing.Any, typing.Any]]` | |
 | `from_dict_kwargs` | `typing.Any` | |
 
 #### from_source()
@@ -226,13 +226,13 @@ def to_dict()
 
 ```python
 def to_json(
-    encoder: collections.abc.Callable[[typing.Any], typing.Union[str, bytes, bytearray]],
+    encoder: collections.abc.Callable[[typing.Any], str | bytes | bytearray],
     to_dict_kwargs: typing.Any,
-) -> typing.Union[str, bytes, bytearray]
+) -> str | bytes | bytearray
 ```
 | Parameter | Type | Description |
 |-|-|-|
-| `encoder` | `collections.abc.Callable[[typing.Any], typing.Union[str, bytes, bytearray]]` | |
+| `encoder` | `collections.abc.Callable[[typing.Any], str \| bytes \| bytearray]` | |
 | `to_dict_kwargs` | `typing.Any` | |
 
 ## flytekit.types.file.file.FlyteFilePathTransformer

--- a/content/api-reference/flytekit-sdk/packages/flytekit.types.file.image.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.types.file.image.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.types.file.image
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.types.file.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.types.file.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.types.file
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.types.iterator.iterator.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.types.iterator.iterator.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.types.iterator.iterator
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.types.iterator.json_iterator.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.types.iterator.json_iterator.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.types.iterator.json_iterator
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.types.numpy.ndarray.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.types.numpy.ndarray.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.types.numpy.ndarray
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.types.pickle.pickle.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.types.pickle.pickle.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.types.pickle.pickle
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.types.schema.types.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.types.schema.types.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.types.schema.types
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---
@@ -144,15 +144,15 @@ def from_dict(
 
 ```python
 def from_json(
-    data: typing.Union[str, bytes, bytearray],
-    decoder: collections.abc.Callable[[typing.Union[str, bytes, bytearray]], dict[typing.Any, typing.Any]],
+    data: str | bytes | bytearray,
+    decoder: collections.abc.Callable[[str | bytes | bytearray], dict[typing.Any, typing.Any]],
     from_dict_kwargs: typing.Any,
 ) -> ~T
 ```
 | Parameter | Type | Description |
 |-|-|-|
-| `data` | `typing.Union[str, bytes, bytearray]` | |
-| `decoder` | `collections.abc.Callable[[typing.Union[str, bytes, bytearray]], dict[typing.Any, typing.Any]]` | |
+| `data` | `str \| bytes \| bytearray` | |
+| `decoder` | `collections.abc.Callable[[str \| bytes \| bytearray], dict[typing.Any, typing.Any]]` | |
 | `from_dict_kwargs` | `typing.Any` | |
 
 #### open()
@@ -189,13 +189,13 @@ def to_dict()
 
 ```python
 def to_json(
-    encoder: collections.abc.Callable[[typing.Any], typing.Union[str, bytes, bytearray]],
+    encoder: collections.abc.Callable[[typing.Any], str | bytes | bytearray],
     to_dict_kwargs: typing.Any,
-) -> typing.Union[str, bytes, bytearray]
+) -> str | bytes | bytearray
 ```
 | Parameter | Type | Description |
 |-|-|-|
-| `encoder` | `collections.abc.Callable[[typing.Any], typing.Union[str, bytes, bytearray]]` | |
+| `encoder` | `collections.abc.Callable[[typing.Any], str \| bytes \| bytearray]` | |
 | `to_dict_kwargs` | `typing.Any` | |
 
 ## flytekit.types.schema.types.FlyteSchemaTransformer

--- a/content/api-reference/flytekit-sdk/packages/flytekit.types.schema.types_pandas.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.types.schema.types_pandas.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.types.schema.types_pandas
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.types.structured.basic_dfs.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.types.structured.basic_dfs.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.types.structured.basic_dfs
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.types.structured.bigquery.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.types.structured.bigquery.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.types.structured.bigquery
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.types.structured.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.types.structured.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.types.structured
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.types.structured.snowflake.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.types.structured.snowflake.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.types.structured.snowflake
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.types.structured.structured_dataset.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.types.structured.structured_dataset.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.types.structured.structured_dataset
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---
@@ -202,15 +202,15 @@ def from_dict(
 
 ```python
 def from_json(
-    data: typing.Union[str, bytes, bytearray],
-    decoder: collections.abc.Callable[[typing.Union[str, bytes, bytearray]], dict[typing.Any, typing.Any]],
+    data: str | bytes | bytearray,
+    decoder: collections.abc.Callable[[str | bytes | bytearray], dict[typing.Any, typing.Any]],
     from_dict_kwargs: typing.Any,
 ) -> ~T
 ```
 | Parameter | Type | Description |
 |-|-|-|
-| `data` | `typing.Union[str, bytes, bytearray]` | |
-| `decoder` | `collections.abc.Callable[[typing.Union[str, bytes, bytearray]], dict[typing.Any, typing.Any]]` | |
+| `data` | `str \| bytes \| bytearray` | |
+| `decoder` | `collections.abc.Callable[[str \| bytes \| bytearray], dict[typing.Any, typing.Any]]` | |
 | `from_dict_kwargs` | `typing.Any` | |
 
 #### iter()
@@ -261,13 +261,13 @@ def to_dict()
 
 ```python
 def to_json(
-    encoder: collections.abc.Callable[[typing.Any], typing.Union[str, bytes, bytearray]],
+    encoder: collections.abc.Callable[[typing.Any], str | bytes | bytearray],
     to_dict_kwargs: typing.Any,
-) -> typing.Union[str, bytes, bytearray]
+) -> str | bytes | bytearray
 ```
 | Parameter | Type | Description |
 |-|-|-|
-| `encoder` | `collections.abc.Callable[[typing.Any], typing.Union[str, bytes, bytearray]]` | |
+| `encoder` | `collections.abc.Callable[[typing.Any], str \| bytes \| bytearray]` | |
 | `to_dict_kwargs` | `typing.Any` | |
 
 ## flytekit.types.structured.structured_dataset.StructuredDatasetDecoder

--- a/content/api-reference/flytekit-sdk/packages/flytekit.utils.asyn.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.utils.asyn.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.utils.asyn
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.utils.dict_formatter.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.utils.dict_formatter.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.utils.dict_formatter
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.utils.pbhash.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.utils.pbhash.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.utils.pbhash
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flytekit-sdk/packages/flytekit.utils.rate_limiter.md
+++ b/content/api-reference/flytekit-sdk/packages/flytekit.utils.rate_limiter.md
@@ -1,6 +1,6 @@
 ---
 title: flytekit.utils.rate_limiter
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/airflow/_index.md
+++ b/content/api-reference/plugins/airflow/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Apache Airflow
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/airflow/classes.md
+++ b/content/api-reference/plugins/airflow/classes.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/airflow/packages/_index.md
+++ b/content/api-reference/plugins/airflow/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/airflow/packages/flytekitplugins.airflow.connector.md
+++ b/content/api-reference/plugins/airflow/packages/flytekitplugins.airflow.connector.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.airflow.connector
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/airflow/packages/flytekitplugins.airflow.task.md
+++ b/content/api-reference/plugins/airflow/packages/flytekitplugins.airflow.task.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.airflow.task
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/async-fsspec/_index.md
+++ b/content/api-reference/plugins/async-fsspec/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Async FSSpec
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/async-fsspec/classes.md
+++ b/content/api-reference/plugins/async-fsspec/classes.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/async-fsspec/packages/_index.md
+++ b/content/api-reference/plugins/async-fsspec/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/async-fsspec/packages/flytekitplugins.async_fsspec.s3fs.constants.md
+++ b/content/api-reference/plugins/async-fsspec/packages/flytekitplugins.async_fsspec.s3fs.constants.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.async_fsspec.s3fs.constants
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/async-fsspec/packages/flytekitplugins.async_fsspec.s3fs.s3fs.md
+++ b/content/api-reference/plugins/async-fsspec/packages/flytekitplugins.async_fsspec.s3fs.s3fs.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.async_fsspec.s3fs.s3fs
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/hive/_index.md
+++ b/content/api-reference/plugins/hive/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Hive
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/hive/classes.md
+++ b/content/api-reference/plugins/hive/classes.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/hive/packages/_index.md
+++ b/content/api-reference/plugins/hive/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/hive/packages/flytekitplugins.hive.task.md
+++ b/content/api-reference/plugins/hive/packages/flytekitplugins.hive.task.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.hive.task
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/huggingface/_index.md
+++ b/content/api-reference/plugins/huggingface/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Hugging Face
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/huggingface/classes.md
+++ b/content/api-reference/plugins/huggingface/classes.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/huggingface/packages/_index.md
+++ b/content/api-reference/plugins/huggingface/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/huggingface/packages/flytekitplugins.huggingface.sd_transformers.md
+++ b/content/api-reference/plugins/huggingface/packages/flytekitplugins.huggingface.sd_transformers.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.huggingface.sd_transformers
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/identity-aware-proxy/_index.md
+++ b/content/api-reference/plugins/identity-aware-proxy/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Google IAP
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/identity-aware-proxy/classes.md
+++ b/content/api-reference/plugins/identity-aware-proxy/classes.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/identity-aware-proxy/packages/_index.md
+++ b/content/api-reference/plugins/identity-aware-proxy/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/identity-aware-proxy/packages/flytekitplugins.identity_aware_proxy.cli.md
+++ b/content/api-reference/plugins/identity-aware-proxy/packages/flytekitplugins.identity_aware_proxy.cli.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.identity_aware_proxy.cli
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/inference/_index.md
+++ b/content/api-reference/plugins/inference/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Inference
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/inference/classes.md
+++ b/content/api-reference/plugins/inference/classes.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/inference/packages/_index.md
+++ b/content/api-reference/plugins/inference/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/inference/packages/flytekitplugins.inference.nim.serve.md
+++ b/content/api-reference/plugins/inference/packages/flytekitplugins.inference.nim.serve.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.inference.nim.serve
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/inference/packages/flytekitplugins.inference.ollama.serve.md
+++ b/content/api-reference/plugins/inference/packages/flytekitplugins.inference.ollama.serve.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.inference.ollama.serve
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/inference/packages/flytekitplugins.inference.sidecar_template.md
+++ b/content/api-reference/plugins/inference/packages/flytekitplugins.inference.sidecar_template.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.inference.sidecar_template
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/inference/packages/flytekitplugins.inference.vllm.serve.md
+++ b/content/api-reference/plugins/inference/packages/flytekitplugins.inference.vllm.serve.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.inference.vllm.serve
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/k8s-pod/_index.md
+++ b/content/api-reference/plugins/k8s-pod/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Kubernetes Pod
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/k8s-pod/classes.md
+++ b/content/api-reference/plugins/k8s-pod/classes.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/k8s-pod/packages/_index.md
+++ b/content/api-reference/plugins/k8s-pod/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/k8s-pod/packages/flytekitplugins.pod.task.md
+++ b/content/api-reference/plugins/k8s-pod/packages/flytekitplugins.pod.task.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.pod.task
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/kf-mpi/_index.md
+++ b/content/api-reference/plugins/kf-mpi/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Kubeflow MPI
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/kf-mpi/classes.md
+++ b/content/api-reference/plugins/kf-mpi/classes.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/kf-mpi/packages/_index.md
+++ b/content/api-reference/plugins/kf-mpi/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/kf-mpi/packages/flytekitplugins.kfmpi.task.md
+++ b/content/api-reference/plugins/kf-mpi/packages/flytekitplugins.kfmpi.task.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.kfmpi.task
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/kf-pytorch/_index.md
+++ b/content/api-reference/plugins/kf-pytorch/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Kubeflow PyTorch
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/kf-pytorch/classes.md
+++ b/content/api-reference/plugins/kf-pytorch/classes.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/kf-pytorch/packages/_index.md
+++ b/content/api-reference/plugins/kf-pytorch/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/kf-pytorch/packages/flytekitplugins.kfpytorch.error_handling.md
+++ b/content/api-reference/plugins/kf-pytorch/packages/flytekitplugins.kfpytorch.error_handling.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.kfpytorch.error_handling
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/kf-pytorch/packages/flytekitplugins.kfpytorch.pod_template.md
+++ b/content/api-reference/plugins/kf-pytorch/packages/flytekitplugins.kfpytorch.pod_template.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.kfpytorch.pod_template
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/kf-pytorch/packages/flytekitplugins.kfpytorch.task.md
+++ b/content/api-reference/plugins/kf-pytorch/packages/flytekitplugins.kfpytorch.task.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.kfpytorch.task
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/kf-tensorflow/_index.md
+++ b/content/api-reference/plugins/kf-tensorflow/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Kubeflow TensorFlow
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/kf-tensorflow/classes.md
+++ b/content/api-reference/plugins/kf-tensorflow/classes.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/kf-tensorflow/packages/_index.md
+++ b/content/api-reference/plugins/kf-tensorflow/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/kf-tensorflow/packages/flytekitplugins.kftensorflow.task.md
+++ b/content/api-reference/plugins/kf-tensorflow/packages/flytekitplugins.kftensorflow.task.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.kftensorflow.task
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/memray/_index.md
+++ b/content/api-reference/plugins/memray/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Memray Profiling
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/memray/classes.md
+++ b/content/api-reference/plugins/memray/classes.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/memray/packages/_index.md
+++ b/content/api-reference/plugins/memray/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/memray/packages/flytekitplugins.memray.md
+++ b/content/api-reference/plugins/memray/packages/flytekitplugins.memray.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.memray
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/mmcloud/_index.md
+++ b/content/api-reference/plugins/mmcloud/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Memory Machine Cloud
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/mmcloud/classes.md
+++ b/content/api-reference/plugins/mmcloud/classes.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/mmcloud/packages/_index.md
+++ b/content/api-reference/plugins/mmcloud/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/mmcloud/packages/flytekitplugins.mmcloud.connector.md
+++ b/content/api-reference/plugins/mmcloud/packages/flytekitplugins.mmcloud.connector.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.mmcloud.connector
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/mmcloud/packages/flytekitplugins.mmcloud.task.md
+++ b/content/api-reference/plugins/mmcloud/packages/flytekitplugins.mmcloud.task.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.mmcloud.task
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/mmcloud/packages/flytekitplugins.mmcloud.utils.md
+++ b/content/api-reference/plugins/mmcloud/packages/flytekitplugins.mmcloud.utils.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.mmcloud.utils
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/neptune/_index.md
+++ b/content/api-reference/plugins/neptune/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Neptune
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/neptune/packages/flytekitplugins.neptune.md
+++ b/content/api-reference/plugins/neptune/packages/flytekitplugins.neptune.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.neptune
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/omegaconf/_index.md
+++ b/content/api-reference/plugins/omegaconf/_index.md
@@ -1,6 +1,6 @@
 ---
 title: OmegaConf
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/omegaconf/classes.md
+++ b/content/api-reference/plugins/omegaconf/classes.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/omegaconf/packages/_index.md
+++ b/content/api-reference/plugins/omegaconf/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/omegaconf/packages/flytekitplugins.omegaconf.md
+++ b/content/api-reference/plugins/omegaconf/packages/flytekitplugins.omegaconf.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.omegaconf
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/onnx-scikitlearn/_index.md
+++ b/content/api-reference/plugins/onnx-scikitlearn/_index.md
@@ -1,6 +1,6 @@
 ---
 title: ONNX ScikitLearn
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/onnx-scikitlearn/classes.md
+++ b/content/api-reference/plugins/onnx-scikitlearn/classes.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/onnx-scikitlearn/packages/_index.md
+++ b/content/api-reference/plugins/onnx-scikitlearn/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/onnx-scikitlearn/packages/flytekitplugins.onnxscikitlearn.schema.md
+++ b/content/api-reference/plugins/onnx-scikitlearn/packages/flytekitplugins.onnxscikitlearn.schema.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.onnxscikitlearn.schema
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/openai/_index.md
+++ b/content/api-reference/plugins/openai/_index.md
@@ -1,6 +1,6 @@
 ---
 title: OpenAI
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/openai/classes.md
+++ b/content/api-reference/plugins/openai/classes.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/openai/packages/_index.md
+++ b/content/api-reference/plugins/openai/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/openai/packages/flytekitplugins.openai.batch.connector.md
+++ b/content/api-reference/plugins/openai/packages/flytekitplugins.openai.batch.connector.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.openai.batch.connector
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/openai/packages/flytekitplugins.openai.batch.task.md
+++ b/content/api-reference/plugins/openai/packages/flytekitplugins.openai.batch.task.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.openai.batch.task
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---
@@ -410,15 +410,15 @@ def from_dict(
 
 ```python
 def from_json(
-    data: typing.Union[str, bytes, bytearray],
-    decoder: collections.abc.Callable[[typing.Union[str, bytes, bytearray]], dict[typing.Any, typing.Any]],
+    data: str | bytes | bytearray,
+    decoder: collections.abc.Callable[[str | bytes | bytearray], dict[typing.Any, typing.Any]],
     from_dict_kwargs: typing.Any,
 ) -> ~T
 ```
 | Parameter | Type | Description |
 |-|-|-|
-| `data` | `typing.Union[str, bytes, bytearray]` | |
-| `decoder` | `collections.abc.Callable[[typing.Union[str, bytes, bytearray]], dict[typing.Any, typing.Any]]` | |
+| `data` | `str \| bytes \| bytearray` | |
+| `decoder` | `collections.abc.Callable[[str \| bytes \| bytearray], dict[typing.Any, typing.Any]]` | |
 | `from_dict_kwargs` | `typing.Any` | |
 
 #### to_dict()
@@ -430,13 +430,13 @@ def to_dict()
 
 ```python
 def to_json(
-    encoder: collections.abc.Callable[[typing.Any], typing.Union[str, bytes, bytearray]],
+    encoder: collections.abc.Callable[[typing.Any], str | bytes | bytearray],
     to_dict_kwargs: typing.Any,
-) -> typing.Union[str, bytes, bytearray]
+) -> str | bytes | bytearray
 ```
 | Parameter | Type | Description |
 |-|-|-|
-| `encoder` | `collections.abc.Callable[[typing.Any], typing.Union[str, bytes, bytearray]]` | |
+| `encoder` | `collections.abc.Callable[[typing.Any], str \| bytes \| bytearray]` | |
 | `to_dict_kwargs` | `typing.Any` | |
 
 ## flytekitplugins.openai.batch.task.DownloadJSONFilesExecutor

--- a/content/api-reference/plugins/openai/packages/flytekitplugins.openai.batch.workflow.md
+++ b/content/api-reference/plugins/openai/packages/flytekitplugins.openai.batch.workflow.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.openai.batch.workflow
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/openai/packages/flytekitplugins.openai.chatgpt.connector.md
+++ b/content/api-reference/plugins/openai/packages/flytekitplugins.openai.chatgpt.connector.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.openai.chatgpt.connector
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/openai/packages/flytekitplugins.openai.chatgpt.task.md
+++ b/content/api-reference/plugins/openai/packages/flytekitplugins.openai.chatgpt.task.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.openai.chatgpt.task
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/optuna/_index.md
+++ b/content/api-reference/plugins/optuna/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Optuna
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/optuna/classes.md
+++ b/content/api-reference/plugins/optuna/classes.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/optuna/packages/_index.md
+++ b/content/api-reference/plugins/optuna/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/optuna/packages/flytekitplugins.optuna.md
+++ b/content/api-reference/plugins/optuna/packages/flytekitplugins.optuna.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.optuna
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/pandera/_index.md
+++ b/content/api-reference/plugins/pandera/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Pandera
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/pandera/classes.md
+++ b/content/api-reference/plugins/pandera/classes.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/pandera/packages/_index.md
+++ b/content/api-reference/plugins/pandera/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/pandera/packages/flytekitplugins.pandera.config.md
+++ b/content/api-reference/plugins/pandera/packages/flytekitplugins.pandera.config.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.pandera.config
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/pandera/packages/flytekitplugins.pandera.pandas_renderer.md
+++ b/content/api-reference/plugins/pandera/packages/flytekitplugins.pandera.pandas_renderer.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.pandera.pandas_renderer
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/pandera/packages/flytekitplugins.pandera.pandas_transformer.md
+++ b/content/api-reference/plugins/pandera/packages/flytekitplugins.pandera.pandas_transformer.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.pandera.pandas_transformer
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/papermill/_index.md
+++ b/content/api-reference/plugins/papermill/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Papermill
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/papermill/classes.md
+++ b/content/api-reference/plugins/papermill/classes.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/papermill/packages/_index.md
+++ b/content/api-reference/plugins/papermill/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/papermill/packages/flytekitplugins.papermill.task.md
+++ b/content/api-reference/plugins/papermill/packages/flytekitplugins.papermill.task.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.papermill.task
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/polars/_index.md
+++ b/content/api-reference/plugins/polars/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Polars
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/polars/classes.md
+++ b/content/api-reference/plugins/polars/classes.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/polars/packages/_index.md
+++ b/content/api-reference/plugins/polars/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/polars/packages/flytekitplugins.polars.sd_transformers.md
+++ b/content/api-reference/plugins/polars/packages/flytekitplugins.polars.sd_transformers.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.polars.sd_transformers
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/ray/_index.md
+++ b/content/api-reference/plugins/ray/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Ray
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/ray/classes.md
+++ b/content/api-reference/plugins/ray/classes.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/ray/packages/_index.md
+++ b/content/api-reference/plugins/ray/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/ray/packages/flytekitplugins.ray.models.md
+++ b/content/api-reference/plugins/ray/packages/flytekitplugins.ray.models.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.ray.models
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/ray/packages/flytekitplugins.ray.task.md
+++ b/content/api-reference/plugins/ray/packages/flytekitplugins.ray.task.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.ray.task
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/slurm/_index.md
+++ b/content/api-reference/plugins/slurm/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Slurm
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/slurm/classes.md
+++ b/content/api-reference/plugins/slurm/classes.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/slurm/packages/_index.md
+++ b/content/api-reference/plugins/slurm/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/slurm/packages/flytekitplugins.slurm.ssh_utils.md
+++ b/content/api-reference/plugins/slurm/packages/flytekitplugins.slurm.ssh_utils.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.slurm.ssh_utils
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/snowflake/_index.md
+++ b/content/api-reference/plugins/snowflake/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Snowflake
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/snowflake/classes.md
+++ b/content/api-reference/plugins/snowflake/classes.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/snowflake/packages/_index.md
+++ b/content/api-reference/plugins/snowflake/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/snowflake/packages/flytekitplugins.snowflake.connector.md
+++ b/content/api-reference/plugins/snowflake/packages/flytekitplugins.snowflake.connector.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.snowflake.connector
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/snowflake/packages/flytekitplugins.snowflake.task.md
+++ b/content/api-reference/plugins/snowflake/packages/flytekitplugins.snowflake.task.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.snowflake.task
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/spark/_index.md
+++ b/content/api-reference/plugins/spark/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Spark
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/spark/classes.md
+++ b/content/api-reference/plugins/spark/classes.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/spark/packages/_index.md
+++ b/content/api-reference/plugins/spark/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/spark/packages/flytekitplugins.spark.connector.md
+++ b/content/api-reference/plugins/spark/packages/flytekitplugins.spark.connector.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.spark.connector
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/spark/packages/flytekitplugins.spark.generic_task.md
+++ b/content/api-reference/plugins/spark/packages/flytekitplugins.spark.generic_task.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.spark.generic_task
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/spark/packages/flytekitplugins.spark.models.md
+++ b/content/api-reference/plugins/spark/packages/flytekitplugins.spark.models.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.spark.models
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/spark/packages/flytekitplugins.spark.pyspark_transformers.md
+++ b/content/api-reference/plugins/spark/packages/flytekitplugins.spark.pyspark_transformers.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.spark.pyspark_transformers
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/spark/packages/flytekitplugins.spark.schema.md
+++ b/content/api-reference/plugins/spark/packages/flytekitplugins.spark.schema.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.spark.schema
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/spark/packages/flytekitplugins.spark.sd_transformers.md
+++ b/content/api-reference/plugins/spark/packages/flytekitplugins.spark.sd_transformers.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.spark.sd_transformers
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/spark/packages/flytekitplugins.spark.task.md
+++ b/content/api-reference/plugins/spark/packages/flytekitplugins.spark.task.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.spark.task
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/spark/packages/flytekitplugins.spark.utils.md
+++ b/content/api-reference/plugins/spark/packages/flytekitplugins.spark.utils.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.spark.utils
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/sqlalchemy/_index.md
+++ b/content/api-reference/plugins/sqlalchemy/_index.md
@@ -1,6 +1,6 @@
 ---
 title: SQLAlchemy
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/sqlalchemy/classes.md
+++ b/content/api-reference/plugins/sqlalchemy/classes.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/sqlalchemy/packages/_index.md
+++ b/content/api-reference/plugins/sqlalchemy/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/sqlalchemy/packages/flytekitplugins.sqlalchemy.task.md
+++ b/content/api-reference/plugins/sqlalchemy/packages/flytekitplugins.sqlalchemy.task.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.sqlalchemy.task
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/wandb/_index.md
+++ b/content/api-reference/plugins/wandb/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Weights & Biases
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/wandb/classes.md
+++ b/content/api-reference/plugins/wandb/classes.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/wandb/packages/_index.md
+++ b/content/api-reference/plugins/wandb/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/plugins/wandb/packages/flytekitplugins.wandb.md
+++ b/content/api-reference/plugins/wandb/packages/flytekitplugins.wandb.md
@@ -1,6 +1,6 @@
 ---
 title: flytekitplugins.wandb
-version: 1.16.19
+version: 1.16.20
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/union-sdk/packages/union.md
+++ b/content/api-reference/union-sdk/packages/union.md
@@ -2066,15 +2066,15 @@ def from_dict(
 
 ```python
 def from_json(
-    data: typing.Union[str, bytes, bytearray],
-    decoder: collections.abc.Callable[[typing.Union[str, bytes, bytearray]], dict[typing.Any, typing.Any]],
+    data: str | bytes | bytearray,
+    decoder: collections.abc.Callable[[str | bytes | bytearray], dict[typing.Any, typing.Any]],
     from_dict_kwargs: typing.Any,
 ) -> ~T
 ```
 | Parameter | Type | Description |
 |-|-|-|
-| `data` | `typing.Union[str, bytes, bytearray]` | |
-| `decoder` | `collections.abc.Callable[[typing.Union[str, bytes, bytearray]], dict[typing.Any, typing.Any]]` | |
+| `data` | `str \| bytes \| bytearray` | |
+| `decoder` | `collections.abc.Callable[[str \| bytes \| bytearray], dict[typing.Any, typing.Any]]` | |
 | `from_dict_kwargs` | `typing.Any` | |
 
 #### from_source()
@@ -2168,13 +2168,13 @@ def to_dict()
 
 ```python
 def to_json(
-    encoder: collections.abc.Callable[[typing.Any], typing.Union[str, bytes, bytearray]],
+    encoder: collections.abc.Callable[[typing.Any], str | bytes | bytearray],
     to_dict_kwargs: typing.Any,
-) -> typing.Union[str, bytes, bytearray]
+) -> str | bytes | bytearray
 ```
 | Parameter | Type | Description |
 |-|-|-|
-| `encoder` | `collections.abc.Callable[[typing.Any], typing.Union[str, bytes, bytearray]]` | |
+| `encoder` | `collections.abc.Callable[[typing.Any], str \| bytes \| bytearray]` | |
 | `to_dict_kwargs` | `typing.Any` | |
 
 ## union.ImageSpec
@@ -2772,15 +2772,15 @@ def from_dict(
 
 ```python
 def from_json(
-    data: typing.Union[str, bytes, bytearray],
-    decoder: collections.abc.Callable[[typing.Union[str, bytes, bytearray]], dict[typing.Any, typing.Any]],
+    data: str | bytes | bytearray,
+    decoder: collections.abc.Callable[[str | bytes | bytearray], dict[typing.Any, typing.Any]],
     from_dict_kwargs: typing.Any,
 ) -> ~T
 ```
 | Parameter | Type | Description |
 |-|-|-|
-| `data` | `typing.Union[str, bytes, bytearray]` | |
-| `decoder` | `collections.abc.Callable[[typing.Union[str, bytes, bytearray]], dict[typing.Any, typing.Any]]` | |
+| `data` | `str \| bytes \| bytearray` | |
+| `decoder` | `collections.abc.Callable[[str \| bytes \| bytearray], dict[typing.Any, typing.Any]]` | |
 | `from_dict_kwargs` | `typing.Any` | |
 
 #### to_dict()
@@ -2792,13 +2792,13 @@ def to_dict()
 
 ```python
 def to_json(
-    encoder: collections.abc.Callable[[typing.Any], typing.Union[str, bytes, bytearray]],
+    encoder: collections.abc.Callable[[typing.Any], str | bytes | bytearray],
     to_dict_kwargs: typing.Any,
-) -> typing.Union[str, bytes, bytearray]
+) -> str | bytes | bytearray
 ```
 | Parameter | Type | Description |
 |-|-|-|
-| `encoder` | `collections.abc.Callable[[typing.Any], typing.Union[str, bytes, bytearray]]` | |
+| `encoder` | `collections.abc.Callable[[typing.Any], str \| bytes \| bytearray]` | |
 | `to_dict_kwargs` | `typing.Any` | |
 
 ## union.Secret
@@ -2962,15 +2962,15 @@ def from_dict(
 
 ```python
 def from_json(
-    data: typing.Union[str, bytes, bytearray],
-    decoder: collections.abc.Callable[[typing.Union[str, bytes, bytearray]], dict[typing.Any, typing.Any]],
+    data: str | bytes | bytearray,
+    decoder: collections.abc.Callable[[str | bytes | bytearray], dict[typing.Any, typing.Any]],
     from_dict_kwargs: typing.Any,
 ) -> ~T
 ```
 | Parameter | Type | Description |
 |-|-|-|
-| `data` | `typing.Union[str, bytes, bytearray]` | |
-| `decoder` | `collections.abc.Callable[[typing.Union[str, bytes, bytearray]], dict[typing.Any, typing.Any]]` | |
+| `data` | `str \| bytes \| bytearray` | |
+| `decoder` | `collections.abc.Callable[[str \| bytes \| bytearray], dict[typing.Any, typing.Any]]` | |
 | `from_dict_kwargs` | `typing.Any` | |
 
 #### iter()
@@ -3021,13 +3021,13 @@ def to_dict()
 
 ```python
 def to_json(
-    encoder: collections.abc.Callable[[typing.Any], typing.Union[str, bytes, bytearray]],
+    encoder: collections.abc.Callable[[typing.Any], str | bytes | bytearray],
     to_dict_kwargs: typing.Any,
-) -> typing.Union[str, bytes, bytearray]
+) -> str | bytes | bytearray
 ```
 | Parameter | Type | Description |
 |-|-|-|
-| `encoder` | `collections.abc.Callable[[typing.Any], typing.Union[str, bytes, bytearray]]` | |
+| `encoder` | `collections.abc.Callable[[typing.Any], str \| bytes \| bytearray]` | |
 | `to_dict_kwargs` | `typing.Any` | |
 
 ## union.UnionRemote


### PR DESCRIPTION
## Summary
- Re-runs `make update-api-docs` for the v1 docs against the current `flytekit` SDK and plugin sources
- 334 files modified in `content/api-reference/`
- Picks up plugin version bumps (e.g. `wandb` 1.16.19 → 1.16.20) and modernized type-hint rendering (`typing.Union[A, B]` → `A | B`) from the upstream generator

No infrastructure dependency — this PR is independent of the v2 regen + generator fix.

## Test plan
- [ ] Run `make dist` locally and spot-check rendered API pages for type signatures
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)