### PR TITLE
Document automatic source-code link discovery during deploy

### DIFF
--- a/content/user-guide/task-configuration/additional-task-settings.md
+++ b/content/user-guide/task-configuration/additional-task-settings.md
@@ -65,6 +65,12 @@ def train(data: list) -> dict:
 The `report` parameter on `@env.task` controls whether an HTML report is generated for the task.
 See [Reports](../task-programming/reports) for details.
 
+### Source-code link (automatic)
+
+In addition to the description and docs above, Flyte automatically attaches a link from each deployed task back to its source code on GitHub or GitLab, when you deploy from inside a checked-out git repository.
+The link is rendered next to the task description in the UI.
+There is no parameter to set — see [Source-code link discovery](../task-deployment/how-task-deployment-works#6-source-code-link-discovery) for the conditions and caveats.
+
 ### `links`
 
 The `links` parameter on `@env.task` (and `override()`) attaches clickable URLs to tasks in the UI.

--- a/content/user-guide/task-deployment/how-task-deployment-works.md
+++ b/content/user-guide/task-deployment/how-task-deployment-works.md
@@ -151,6 +151,44 @@ When `image.builder` is set to `remote` in [your `config.yaml`](../run-modes/run
 > [!NOTE]
 > Remote building is currently exclusive to Union backends. OSS Flyte installations must use `local`
 
+## 6. Source-code link discovery
+
+While each task is being serialized in step 2, Flyte attempts to attach a link from the task back to the source line of its Python function.
+The link is rendered next to the task description in the UI, so anyone viewing a deployed task can jump directly to the code that defines it.
+
+This is fully automatic. There is no decorator argument, no config flag, and no opt-in step — if the conditions below are met, the link appears.
+
+### How the link is built
+
+Flyte inspects the local repository at deploy time using the standard `git` CLI:
+
+- The repository root, current commit SHA, working-tree-clean status, and remote push URL are read via `git rev-parse` and `git remote get-url --push origin`.
+- The file path is taken from the task function's `__code__.co_filename`, made relative to the repo root.
+- The line number is the line of the function definition (the line just after the `@env.task` decorator).
+- For a GitHub remote, the URL takes the form `https://github.com/<owner>/<repo>/blob/<sha>/<file>#L<line>`. GitLab uses the equivalent `/-/blob/` form.
+
+The `#L<line>` anchor is only included when the working tree is clean. A dirty tree still produces a valid blob URL, but without the line jump — because the local file may no longer match the committed file.
+
+### Conditions
+
+For the link to appear, all of the following must hold:
+
+- The `git` CLI is installed and the directory you deploy from is inside a git repository.
+- The repository has a remote. The push URL of `origin` is preferred; otherwise the first remote, alphabetically, is used.
+- The remote host is `github.com` or `gitlab.com`. Other hosts (Bitbucket, self-hosted Gitea, GitHub Enterprise on a custom domain, etc.) currently produce no link.
+- The task's source file lives under the repository root.
+
+If any condition fails, the deploy still succeeds — only the source-code link is omitted.
+
+> [!NOTE]
+> Flyte does not check whether the current commit has been pushed.
+> If you deploy from a clean local commit that is not yet on the remote, the URL will resolve to a missing SHA on GitHub or GitLab.
+> Push your commit before deploying if you want the link to be followable.
+
+For private repositories, the link is still generated; viewers need to be authenticated to the host to follow it.
+
+See [`flyte.git.GitStatus`](../../api-reference/flyte-sdk/packages/flyte.git/gitstatus) for the underlying API.
+
 ## Understanding option relationships
 
 It's important to understand how the various deployment options work together.


### PR DESCRIPTION
## Summary

- Adds a new section "Source-code link discovery" to `user-guide/task-deployment/how-task-deployment-works.md` documenting the automatic GitHub/GitLab link Flyte attaches to deployed tasks. Covers what the user sees in the UI, how the URL is built, the conditions required, the working-tree-clean line-anchor behavior, and the unpushed-commit gotcha.
- Adds a short cross-reference in the task-metadata cluster of `user-guide/task-configuration/additional-task-settings.md` so readers looking at `description` / `docs` / `links` also see this automatic behavior.
- Links out to the existing auto-generated `flyte.git.GitStatus` API reference.

The feature is implemented in `flyte-sdk` at `src/flyte/git/_config.py` and invoked during deploy in `src/flyte/_deploy.py:274-311` (`_get_documentation_entity()`), which attaches the URL as `task_definition_pb2.SourceCode(link=...)` on the task's `DocumentationEntity`. The console renders it from `descriptionEntity.sourceCode.link`. No user-facing config or code change is required; until now, this was entirely undocumented outside the API reference.

## Test plan

- [ ] `make dev` and visit `/v2/union/user-guide/task-deployment/how-task-deployment-works/` — verify the new "6. Source-code link discovery" section renders, list items format correctly, and the `> [!NOTE]` callout for the unpushed-commit caveat shows.
- [ ] Visit `/v2/union/user-guide/task-configuration/additional-task-settings/` — verify the new "Source-code link (automatic)" subsection appears under "Naming and metadata" after `report`, and the relative link to `../task-deployment/how-task-deployment-works#6-source-code-link-discovery` resolves to the correct heading anchor.
- [ ] Verify the relative link to `../../api-reference/flyte-sdk/packages/flyte.git/gitstatus` from the deployment-works page resolves.
- [ ] Repeat the above checks against the `flyte` variant (set `variant = "flyte"` in `hugo.local.toml`) since the section uses `+flyte +union` scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)