### PR TITLE
Add build-and-deploy.yml workflow (Phase 1+2 of gha-docs-build)

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,118 @@
+name: Build and deploy docs
+
+# Part of the gha-docs-build migration: builds the docs via `make dist`
+# and pushes the result to a Cloudflare Pages project via Direct Upload.
+# Replaces CF Pages' native build runner — CF Pages stays only as the
+# static host.
+#
+# Currently scoped to the dev branch (`peeter/gha-build-spike**`) and
+# manual dispatch. Will graduate to trigger on PRs (Phase 3) and on
+# main pushes (Phase 4 cutover).
+
+on:
+  push:
+    branches:
+      - 'peeter/gha-build-spike**'
+  workflow_dispatch:
+    inputs:
+      project_name:
+        description: 'CF Pages project to deploy to'
+        required: false
+        default: 'docs-staging'
+        type: choice
+        options:
+          - docs-staging
+          - docs-builder
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 1
+
+      - name: Set up Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: '0.161.1'
+          extended: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Print environment
+        run: |
+          echo "::group::versions"
+          hugo version
+          python --version
+          uv --version
+          echo "::endgroup::"
+
+      - name: Build dist
+        run: |
+          start=$(date +%s)
+          make dist
+          echo "BUILD_SECONDS=$(( $(date +%s) - start ))" >> "$GITHUB_ENV"
+
+      - name: Build summary
+        if: always()
+        run: |
+          echo "::group::dist tree (top 2 levels)"
+          find dist -maxdepth 2 -mindepth 1 -print 2>/dev/null | sort || true
+          echo "::endgroup::"
+          echo "::group::dist size"
+          du -sh dist 2>/dev/null || true
+          du -sh dist/docs/v2 dist/docs/v1 2>/dev/null || true
+          echo "::endgroup::"
+          if [ -n "${BUILD_SECONDS:-}" ]; then
+            echo "Build wall time: ${BUILD_SECONDS}s"
+          fi
+
+      - name: Upload dist artifact
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          retention-days: 7
+          if-no-files-found: error
+
+      - name: Sanitize branch name for CF Pages
+        if: success()
+        id: branch
+        run: |
+          # CF Pages branch names: lowercase alphanumeric + hyphens, max 28 chars.
+          sanitized=$(echo "${{ github.ref_name }}" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^a-z0-9]+#-#g' | sed -E 's#^-+|-+$##g' | cut -c1-28)
+          echo "name=$sanitized" >> "$GITHUB_OUTPUT"
+          echo "Branch for CF Pages: $sanitized"
+
+      - name: Deploy to Cloudflare Pages
+        if: success()
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_PAGES_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy ./dist --project-name=${{ inputs.project_name || 'docs-staging' }} --branch=${{ steps.branch.outputs.name }} --commit-hash=${{ github.sha }}
+
+      - name: Deploy summary
+        if: success()
+        run: |
+          echo "## Deployment" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Project: \`${{ inputs.project_name || 'docs-staging' }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Branch (CF Pages): \`${{ steps.branch.outputs.name }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Commit: \`${{ github.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
+          if [ -n "${{ steps.deploy.outputs.deployment-url }}" ]; then
+            echo "- Deployment URL: ${{ steps.deploy.outputs.deployment-url }}" >> "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
## Summary

Adds the GHA workflow that builds the docs and pushes the result to a Cloudflare Pages project via Direct Upload (`wrangler-action`). This is the first part of the `gha-docs-build` project — moving the docs build off CF Pages' native build runner onto GitHub Actions. CF Pages stays only as a static host.

A parallel PR adds the same workflow to the `v1` branch.

## What this PR does

Drops a new workflow file at `.github/workflows/build-and-deploy.yml`. **Behavior change is minimal:** the workflow is currently scoped to a dev branch (`peeter/gha-build-spike**`) and manual `workflow_dispatch`. It does **not** run on `main` pushes or on PRs in this PR — those triggers come in Phase 3 (PR previews) and Phase 4 (cutover).

So merging this PR adds the file to `main` but does not change any current build behavior. CF Pages' native build runner continues to handle production deploys until the cutover.

## Validated end-to-end on the spike branch

- **Phase 1** — GHA build alone: clean run in 1m 19s, `dist/` matches CF output structure (471M, 2810 files for v2).
- **Phase 2a** — wrangler deploy to a fresh `docs-staging` CF Pages project (Direct Upload mode): ✓ green, deployed at https://peeter-gha-build-spike.docs-staging-ed8.pages.dev
- **Phase 2b** — wrangler deploy to `docs-builder` (Git-connected, `deployments_enabled: false`): ✓ green, deployed at https://peeter-gha-build-spike.docs-builder.pages.dev — proves **Approach A** is viable for the eventual prod cutover (preserve `docs-dog.pages.dev` + `docs.union.ai` + `web-docs.union.ai` rather than delete-and-recreate).

## Configuration

- Hugo pinned to `0.161.1` to match what CF Pages uses today.
- Python 3.12 + uv (matches existing check workflows).
- Uses a new repo secret `CLOUDFLARE_PAGES_API_TOKEN` (scope: `Pages:Edit` on Union Systems Inc.) — added separately from the existing `CLOUDFLARE_API_TOKEN` (which is scoped only for redirect deploys).
- Deploy target chosen via `workflow_dispatch` input: `docs-staging` (default) or `docs-builder`.

## Test plan
- [x] First spike run on `peeter/gha-build-spike` — green
- [x] Phase 2a — deploy to `docs-staging` — green
- [x] Phase 2b — deploy to `docs-builder` — green
- [ ] Workflow file lands on `main` (this PR)
- [ ] Companion PR adds the same file to `v1`

## Follow-ups
- Phase 3: add PR trigger + post per-PR preview URL as a comment.
- Phase 4: change deploy target to the prod `docs` project; add `main`/`v1` push triggers; disable auto-deploys on prod `docs` project.
- Cleanup: bump deprecated Node.js 20 actions before June 2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)