### PR TITLE
Add build-and-deploy.yml workflow (v1 branch — Phase 1+2 of gha-docs-build)

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,121 @@
+name: Build and deploy docs
+
+# Part of the gha-docs-build migration: builds the docs via `make dist`
+# and pushes the result to a Cloudflare Pages project via Direct Upload.
+# Replaces CF Pages' native build runner — CF Pages stays only as the
+# static host.
+#
+# Currently scoped to the dev branch (`peeter/gha-build-spike-v1**`)
+# and manual dispatch. Will graduate to trigger on PRs (Phase 3) and on
+# v1 pushes (Phase 4 cutover) — and deploy with `--branch=v1` so the
+# result lands at `v1.docs-dog.pages.dev`, the stable alias that
+# CloudFront (today) and the new-infra Worker (later) target for
+# `/docs/v1/*` requests.
+
+on:
+  push:
+    branches:
+      - 'peeter/gha-build-spike-v1**'
+  workflow_dispatch:
+    inputs:
+      project_name:
+        description: 'CF Pages project to deploy to'
+        required: false
+        default: 'docs-staging'
+        type: choice
+        options:
+          - docs-staging
+          - docs-builder
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 1
+
+      - name: Set up Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: '0.161.1'
+          extended: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Print environment
+        run: |
+          echo "::group::versions"
+          hugo version
+          python --version
+          uv --version
+          echo "::endgroup::"
+
+      - name: Build dist
+        run: |
+          start=$(date +%s)
+          make dist
+          echo "BUILD_SECONDS=$(( $(date +%s) - start ))" >> "$GITHUB_ENV"
+
+      - name: Build summary
+        if: always()
+        run: |
+          echo "::group::dist tree (top 2 levels)"
+          find dist -maxdepth 2 -mindepth 1 -print 2>/dev/null | sort || true
+          echo "::endgroup::"
+          echo "::group::dist size"
+          du -sh dist 2>/dev/null || true
+          du -sh dist/docs/v2 dist/docs/v1 2>/dev/null || true
+          echo "::endgroup::"
+          if [ -n "${BUILD_SECONDS:-}" ]; then
+            echo "Build wall time: ${BUILD_SECONDS}s"
+          fi
+
+      - name: Upload dist artifact
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          retention-days: 7
+          if-no-files-found: error
+
+      - name: Sanitize branch name for CF Pages
+        if: success()
+        id: branch
+        run: |
+          # CF Pages branch names: lowercase alphanumeric + hyphens, max 28 chars.
+          sanitized=$(echo "${{ github.ref_name }}" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^a-z0-9]+#-#g' | sed -E 's#^-+|-+$##g' | cut -c1-28)
+          echo "name=$sanitized" >> "$GITHUB_OUTPUT"
+          echo "Branch for CF Pages: $sanitized"
+
+      - name: Deploy to Cloudflare Pages
+        if: success()
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_PAGES_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy ./dist --project-name=${{ inputs.project_name || 'docs-staging' }} --branch=${{ steps.branch.outputs.name }} --commit-hash=${{ github.sha }}
+
+      - name: Deploy summary
+        if: success()
+        run: |
+          echo "## Deployment" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Project: \`${{ inputs.project_name || 'docs-staging' }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Branch (CF Pages): \`${{ steps.branch.outputs.name }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Commit: \`${{ github.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
+          if [ -n "${{ steps.deploy.outputs.deployment-url }}" ]; then
+            echo "- Deployment URL: ${{ steps.deploy.outputs.deployment-url }}" >> "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
## Summary

v1 companion to [the main-branch PR](https://github.com/unionai/unionai-docs/pulls?q=peeter%2Fadd-build-and-deploy-workflow). Adds the same GHA workflow that builds the docs and pushes via wrangler Direct Upload — but on the v1 branch, so v1 pushes can build via GHA too.

## Why a separate PR

GHA workflows are **branch-scoped**: a `push` event only triggers workflows defined on the pushed branch. Without this file on `v1`, v1 pushes wouldn't trigger any GHA build, and we'd silently lose v1 deploys at the Phase 4 cutover.

## What's different from the main PR

Only the `push.branches` trigger pattern: `peeter/gha-build-spike-v1**` instead of `peeter/gha-build-spike**`. Same Hugo (0.161.1), same Python 3.12 + uv, same `make dist`, same `wrangler pages deploy`. The branch's `makefile.inc` (which sets `VERSION := v1`) automatically directs the build to `dist/docs/v1/`.

## How v1 plays into the prod architecture

Today CF Pages builds v1 as a **preview deployment** within the `docs` project, with a stable alias at `v1.docs-dog.pages.dev`. AWS CloudFront routes `/docs/v1/*` to that alias. After the Phase 4 cutover, this workflow will deploy v1 to the same `docs` project with `--branch=v1`, recreating the same alias — and CloudFront keeps pointing at it unchanged.

## Validated

Spike branch run on `peeter/gha-build-spike-v1`: ✓ green, deployed v1 to `docs-staging` at https://peeter-gha-build-spike-v1.docs-staging-ed8.pages.dev/docs/v1/union/

## Test plan
- [x] Spike run green on `peeter/gha-build-spike-v1`
- [ ] Companion main-branch PR also merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)