### PR TITLE
Emit dist/docs/build-info.json with build provenance (Phase 4 prep)

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -71,6 +71,30 @@ jobs:
           make dist
           echo "BUILD_SECONDS=$(( $(date +%s) - start ))" >> "$GITHUB_ENV"
 
+      - name: Emit build provenance
+        if: success()
+        run: |
+          # Write build-info.json at dist/docs/ so it's served at
+          # docs.union.ai/docs/build-info.json (CloudFront routes /docs/*
+          # to the CF Pages origin). Lets us verify GHA is what's
+          # actually serving prod after Phase 4 cutover, and gives
+          # incident response a quick "what version is live?" probe.
+          mkdir -p dist/docs
+          cat > dist/docs/build-info.json <<EOF
+          {
+            "builder": "github-actions",
+            "repository": "${{ github.repository }}",
+            "workflow_file": ".github/workflows/build-and-deploy.yml",
+            "run_id": "${{ github.run_id }}",
+            "run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            "commit": "${{ github.event.pull_request.head.sha || github.sha }}",
+            "ref": "${{ github.head_ref || github.ref_name }}",
+            "event": "${{ github.event_name }}",
+            "built_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          }
+          EOF
+          cat dist/docs/build-info.json
+
       - name: Build summary
         if: always()
         run: |


### PR DESCRIPTION
## Summary

Phase 4 prep — adds a step to `build-and-deploy.yml` that writes `dist/docs/build-info.json` with the GHA run identity. After the cutover, this gives us a one-liner to verify the deployed content was built by GHA (not by CF Pages' native runner).

```sh
curl https://docs.union.ai/docs/build-info.json | jq
```

## Path choice

`dist/docs/build-info.json` — sits outside any variant subtree, single file per deploy. CloudFront routes `docs.union.ai/docs/*` to the CF Pages origin (per `infra/ROUTING-ARCHITECTURE.md`), so the file becomes reachable at `docs.union.ai/docs/build-info.json` after Phase 4.

## Self-test

This PR's own preview deploy will produce the file. After the workflow runs, verify:

```sh
curl https://<branch>.docs-staging-ed8.pages.dev/docs/build-info.json | jq
```

…should return JSON with `"builder": "github-actions"` and a `run_url` pointing back at this PR's workflow run.

## Companion PR for v1

Will land the same step on `v1` separately (workflows are branch-scoped).

## Why now, not bundled into the cutover PR

So we get a live shakedown of the file's path, contents, and CloudFront routing on a regular preview *before* relying on it at cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)