### PR TITLE
Phase 4 cutover: route production through GHA (main)

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -6,14 +6,18 @@ name: Build and deploy docs
 # static host.
 #
 # Triggers:
-#   - pull_request — builds + deploys to docs-staging, posts a sticky
-#     comment on the PR with the preview URL
-#   - workflow_dispatch — manual run, choose project_name
-#
-# Phase 4 (cutover) will add push triggers on main and v1, targeting
-# the prod `docs` project instead of `docs-staging`.
+#   - push to main — production deploy (project=docs, --branch=main).
+#     This is the prod path; CF auto-deploys on the `docs` project are
+#     disabled, so GHA owns prod end-to-end.
+#   - pull_request — branch deploy to the `docs` project. Each PR gets
+#     a preview at <sanitized-branch>.docs-dog.pages.dev, identical to
+#     what CF Pages' bot used to produce. Sticky comment posts the URL.
+#   - workflow_dispatch — manual run, choose project_name (default docs).
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
@@ -21,9 +25,10 @@ on:
       project_name:
         description: 'CF Pages project to deploy to'
         required: false
-        default: 'docs-staging'
+        default: 'docs'
         type: choice
         options:
+          - docs
           - docs-staging
           - docs-builder
 
@@ -137,14 +142,14 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_PAGES_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy ./dist --project-name=${{ inputs.project_name || 'docs-staging' }} --branch=${{ steps.branch.outputs.name }} --commit-hash=${{ github.event.pull_request.head.sha || github.sha }}
+          command: pages deploy ./dist --project-name=${{ inputs.project_name || 'docs' }} --branch=${{ steps.branch.outputs.name }} --commit-hash=${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Deploy summary
         if: success()
         run: |
           echo "## Deployment" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Project: \`${{ inputs.project_name || 'docs-staging' }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Project: \`${{ inputs.project_name || 'docs' }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Branch (CF Pages): \`${{ steps.branch.outputs.name }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Commit: \`${{ github.event.pull_request.head.sha || github.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
           if [ -n "${{ steps.deploy.outputs.deployment-url }}" ]; then
@@ -159,12 +164,12 @@ jobs:
           message: |
             ### GHA build & deploy preview
 
-            Built by `.github/workflows/build-and-deploy.yml` and deployed to the **`${{ inputs.project_name || 'docs-staging' }}`** CF Pages project.
+            Built by `.github/workflows/build-and-deploy.yml` and deployed to the **`${{ inputs.project_name || 'docs' }}`** CF Pages project.
 
             | | |
             |---|---|
-            | Branch alias | <https://${{ steps.branch.outputs.name }}.docs-staging-ed8.pages.dev> |
+            | Branch alias | <https://${{ steps.branch.outputs.name }}.docs-dog.pages.dev> |
             | This commit | ${{ steps.deploy.outputs.deployment-url }} |
             | Commit SHA | `${{ github.event.pull_request.head.sha }}` |
 
-            Updated automatically on every push. After Phase 4 cutover this will replace the CF Pages-native preview comment.
+            Updated automatically on every push.


### PR DESCRIPTION
## Summary

**The cutover PR.** Switches the docs build/deploy from CF Pages' native runner to our GHA workflow, end-to-end. After merging this PR (and its v1 sibling), GHA owns the production build path. CF Pages keeps serving the static output.

## Sequence to execute the cutover

This PR alone doesn't cut over — it has to be coordinated with disabling CF auto-deploys on the `docs` project. Order:

1. ✅ Open this PR (main) and its v1 sibling
2. ⏳ Verify both PR previews build cleanly into `docs` (deploys land at `<branch>.docs-dog.pages.dev`)
3. ⏳ Pin the current production deployment ID into PLAN.md as the rollback target
4. ⏳ `PATCH docs project: source.config.deployments_enabled=false` — moment of no-return, but reversible by re-PATCHing to true
5. ⏳ Merge this PR — first GHA-built production deploy lands at docs.union.ai
6. ⏳ Verify: `curl https://docs.union.ai/docs/build-info.json` shows `"builder": "github-actions"` + `"event": "push"`
7. ⏳ Merge v1 sibling PR (same sequence on v1)

## Workflow changes

- **Add `push: [main]` trigger** — production deploy on every main push, with `--branch=main` so it lands at the production endpoint of `docs`.
- **Default `project_name: docs`** (was `docs-staging`). All event types (PR, push, dispatch) now default to deploying to prod. `docs-staging` and `docs-builder` stay as workflow_dispatch choices for manual testing.
- **Sticky comment URL pattern:** `<branch>.docs-dog.pages.dev` — matches what CF Pages' bot used to produce, so PR reviewers see the same URL pattern they're used to. Comment now comes from `github-actions[bot]` instead of `cloudflare-workers-and-pages[bot]`.

## PR preview behavior post-cutover

This PR's own preview deploy will land at `peeter-phase4-cutover.docs-dog.pages.dev` — **already in the `docs` project**, alongside production. Test it before merging:

```sh
curl https://peeter-phase4-cutover.docs-dog.pages.dev/docs/build-info.json | jq
```

Should return `"event": "pull_request"`, `"builder": "github-actions"`.

## Rollback

Documented in `PLAN.md` § "Rollback hatch". Three escalating options: promote a past deployment (seconds), re-deploy a known-good commit via workflow_dispatch (minutes), or re-enable CF auto-deploys (one API call — full reverse of Phase 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)