### PR TITLE
Address Copilot feedback on cutover (main)

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -45,7 +45,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -36,6 +36,14 @@ permissions:
   contents: read
   pull-requests: write
 
+# For PRs: cancel any in-flight run when a new commit is pushed to the same PR
+# (only latest commit's preview matters).
+# For push events on main: queue runs in order (don't cancel) so we never
+# leave production in an inconsistent state mid-deploy.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -127,13 +135,28 @@ jobs:
         if: success()
         id: branch
         run: |
-          # On pull_request events, github.head_ref is the source branch.
-          # On workflow_dispatch and push, github.ref_name is the branch.
           # CF Pages branch names: lowercase alphanumeric + hyphens, max 28 chars.
-          raw="${{ github.head_ref || github.ref_name }}"
-          sanitized=$(echo "$raw" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^a-z0-9]+#-#g' | sed -E 's#^-+|-+$##g' | cut -c1-28)
+          #
+          # On pull_request events we prefix the deploy branch with `pr-<num>`.
+          # This both (a) makes each PR's preview alias unique even when two
+          # PRs share a long common branch-name prefix, and (b) guarantees a
+          # PR-event deploy can never sanitize to a production branch name
+          # like `main` or `v1` (e.g. a branch named `main_` would otherwise
+          # sanitize to `main` and overwrite production now that PRs deploy
+          # into the same `docs` Pages project).
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            pr_num="${{ github.event.pull_request.number }}"
+            raw_branch="${{ github.head_ref }}"
+            # `pr-NNNN-` is 8 chars (for 4-digit PR #s); leave the rest for branch.
+            branch_suffix=$(echo "$raw_branch" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^a-z0-9]+#-#g' | sed -E 's#^-+|-+$##g' | cut -c1-20)
+            sanitized=$(printf 'pr-%s-%s' "$pr_num" "$branch_suffix" | cut -c1-28 | sed -E 's#-+$##g')
+            echo "Source PR #$pr_num branch '$raw_branch' → CF Pages branch: $sanitized"
+          else
+            raw="${{ github.ref_name }}"
+            sanitized=$(echo "$raw" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^a-z0-9]+#-#g' | sed -E 's#^-+|-+$##g' | cut -c1-28)
+            echo "Source branch: $raw → CF Pages branch: $sanitized"
+          fi
           echo "name=$sanitized" >> "$GITHUB_OUTPUT"
-          echo "Source branch: $raw → CF Pages branch: $sanitized"
 
       - name: Deploy to Cloudflare Pages
         if: success()


### PR DESCRIPTION
## Summary

Two safety improvements raised by Copilot review on the Phase 4 cutover PR ([#1013](https://github.com/unionai/unionai-docs/pull/1013)).

## 1. Concurrency group

Now that pushes to `main` trigger production deploys, two close pushes can run in parallel and finish out-of-order, potentially deploying an older commit after a newer one.

Adds a workflow-level concurrency group:
- Grouped by PR number (for `pull_request` events) or ref name (for `push` events).
- `cancel-in-progress: true` for `pull_request` events — only the latest commit's preview matters; cancel stale builds to save CI minutes.
- `cancel-in-progress: false` for `push` events — queue runs in order so we never leave production in an inconsistent state mid-deploy.

## 2. `pr-<num>-` prefix on PR-event deploys

Previously the wrangler `--branch` arg was just the sanitized git branch name. Now that PRs deploy into the production `docs` Pages project, a branch name like `main_`, `MAIN`, `main--`, etc. would sanitize to `main` and **overwrite production**.

Prefix all `pull_request`-event deploys with the immutable `pr-<NUM>-` so they can never collide with a production branch name. Example output:

| Source branch | New CF Pages branch alias |
|---|---|
| `peeter/cutover-followups` | `pr-1015-peeter-cutover-foll` |
| `main_` (malicious) | `pr-1016-main` (safely scoped to PR) |

As a side benefit, this also resolves the "two PRs sharing a long common prefix sanitize to the same alias" issue (the previous low-priority follow-up noted in `PLAN.md`).

Push and workflow_dispatch sanitization is unchanged — those events already use a branch name we control.

## Self-test

This PR's own preview will deploy at `pr-<this-PR-number>-peeter-cutover-foll.docs-dog.pages.dev`.

## Companion PR for v1

Will land the same fixes on `v1` separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)