### PR TITLE
Phase 5 workflow hygiene + Copilot follow-ups (main)

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -36,12 +36,15 @@ permissions:
   contents: read
   pull-requests: write
 
-# For PRs: cancel any in-flight run when a new commit is pushed to the same PR
-# (only latest commit's preview matters).
-# For push events on main: queue runs in order (don't cancel) so we never
-# leave production in an inconsistent state mid-deploy.
+# Concurrency policy:
+#   - PRs: cancel any in-flight run when a new commit is pushed to the
+#     same PR (only the latest commit's preview matters).
+#   - push to main: queue in order, don't cancel, so we never leave
+#     production in an inconsistent state mid-deploy.
+#   - workflow_dispatch: own group, distinct from push, so a manual
+#     docs-staging / docs-builder test can't block a production deploy.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
@@ -147,9 +150,10 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             pr_num="${{ github.event.pull_request.number }}"
             raw_branch="${{ github.head_ref }}"
-            # `pr-NNNN-` is 8 chars (for 4-digit PR #s); leave the rest for branch.
-            branch_suffix=$(echo "$raw_branch" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^a-z0-9]+#-#g' | sed -E 's#^-+|-+$##g' | cut -c1-20)
-            sanitized=$(printf 'pr-%s-%s' "$pr_num" "$branch_suffix" | cut -c1-28 | sed -E 's#-+$##g')
+            # Compose `pr-<num>-<branch>` then truncate to 28 chars (CF Pages
+            # limit). Branch portion auto-shrinks as PR numbers grow digits.
+            full=$(printf 'pr-%s-%s' "$pr_num" "$raw_branch" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^a-z0-9]+#-#g' | sed -E 's#^-+|-+$##g')
+            sanitized=$(printf '%s' "$full" | cut -c1-28 | sed -E 's#-+$##g')
             echo "Source PR #$pr_num branch '$raw_branch' → CF Pages branch: $sanitized"
           else
             raw="${{ github.ref_name }}"
@@ -165,7 +169,15 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_PAGES_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy ./dist --project-name=${{ inputs.project_name || 'docs' }} --branch=${{ steps.branch.outputs.name }} --commit-hash=${{ github.event.pull_request.head.sha || github.sha }}
+          # --commit-dirty: make dist regenerates tracked files (notebooks,
+          # API docs), so the working tree is always dirty by the time we hit
+          # wrangler. The warning is noise, not a real condition.
+          # We don't pass --commit-hash because we use fetch-depth: 1 above
+          # (shallow checkout), which means the local repo can't resolve the
+          # SHA wrangler tries to look up and would emit "fatal: bad object".
+          # wrangler-action records the commit metadata on its own via the
+          # GITHUB_SHA env var.
+          command: pages deploy ./dist --project-name=${{ inputs.project_name || 'docs' }} --branch=${{ steps.branch.outputs.name }} --commit-dirty=true
 
       - name: Deploy summary
         if: success()

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -81,6 +81,28 @@ jobs:
           uv --version
           echo "::endgroup::"
 
+      - name: Write Hugo data file for build provenance
+        run: |
+          # Hugo reads data/*.yaml at build time and exposes it to templates
+          # as .Site.Data.<filename>. The infra repo's baseof.html uses
+          # .Site.Data.build_info to render an HTML comment in <head> so
+          # `view source` on any rendered page shows what built it.
+          # Local `make dist` runs (no GHA) won't write this file, and Hugo's
+          # `{{ with .Site.Data.build_info }}` block silently no-ops in that
+          # case.
+          mkdir -p data
+          cat > data/build_info.yaml <<EOF
+          builder: github-actions
+          repository: ${{ github.repository }}
+          run_id: "${{ github.run_id }}"
+          run_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          commit: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.head_ref || github.ref_name }}
+          event: ${{ github.event_name }}
+          built_at: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+          EOF
+          cat data/build_info.yaml
+
       - name: Build dist
         run: |
           start=$(date +%s)

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -81,25 +81,6 @@ jobs:
           uv --version
           echo "::endgroup::"
 
-      - name: Write build_info.yaml for Hugo template provenance
-        run: |
-          # Written at the repo root (not data/) because the infra repo's
-          # baseof.html reads it via readFile (Hugo's data namespace evolution
-          # made .Site.Data/site.Data/hugo.Data all problematic on 0.161).
-          # On local builds without this step, baseof.html's os.FileExists
-          # check silently no-ops.
-          cat > build_info.yaml <<EOF
-          builder: github-actions
-          repository: ${{ github.repository }}
-          run_id: "${{ github.run_id }}"
-          run_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          commit: ${{ github.event.pull_request.head.sha || github.sha }}
-          ref: ${{ github.head_ref || github.ref_name }}
-          event: ${{ github.event_name }}
-          built_at: $(date -u +%Y-%m-%dT%H:%M:%SZ)
-          EOF
-          cat build_info.yaml
-
       - name: Build dist
         run: |
           start=$(date +%s)

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -81,17 +81,14 @@ jobs:
           uv --version
           echo "::endgroup::"
 
-      - name: Write Hugo data file for build provenance
+      - name: Write build_info.yaml for Hugo template provenance
         run: |
-          # Hugo reads data/*.yaml at build time and exposes it to templates
-          # as .Site.Data.<filename>. The infra repo's baseof.html uses
-          # .Site.Data.build_info to render an HTML comment in <head> so
-          # `view source` on any rendered page shows what built it.
-          # Local `make dist` runs (no GHA) won't write this file, and Hugo's
-          # `{{ with .Site.Data.build_info }}` block silently no-ops in that
-          # case.
-          mkdir -p data
-          cat > data/build_info.yaml <<EOF
+          # Written at the repo root (not data/) because the infra repo's
+          # baseof.html reads it via readFile (Hugo's data namespace evolution
+          # made .Site.Data/site.Data/hugo.Data all problematic on 0.161).
+          # On local builds without this step, baseof.html's os.FileExists
+          # check silently no-ops.
+          cat > build_info.yaml <<EOF
           builder: github-actions
           repository: ${{ github.repository }}
           run_id: "${{ github.run_id }}"
@@ -101,7 +98,7 @@ jobs:
           event: ${{ github.event_name }}
           built_at: $(date -u +%Y-%m-%dT%H:%M:%SZ)
           EOF
-          cat data/build_info.yaml
+          cat build_info.yaml
 
       - name: Build dist
         run: |


### PR DESCRIPTION
## Summary

Phase 5 cleanup pass on the build-and-deploy workflow. Addresses two further Copilot comments on [#1015](https://github.com/unionai/unionai-docs/pull/1015) and silences two wrangler warnings observed on the first GHA-built production deploys.

## Changes

| # | Change | Why |
|---|---|---|
| 1 | Concurrency group key includes `github.event_name` | workflow_dispatch runs on `main` no longer share a group with `push: main` runs — a manual `docs-staging` test can't block / serialize behind a production deploy. (Copilot review on #1015) |
| 2 | Sanitize step composes the full `pr-<num>-<branch>` string before truncating | Was pre-truncating to 20 chars based on assumed 4-digit PR #s; would have shrunk further at PR 10000+. Now branch portion auto-shrinks. (Copilot review on #1015) |
| 3 | `--commit-dirty=true` on wrangler | Silences the noisy "uncommitted changes" warning — `make dist` regenerates tracked files (notebooks, API docs), so the tree is always dirty by deploy time. |
| 4 | Drop `--commit-hash` from wrangler | Silences `fatal: bad object` from our shallow checkout (`fetch-depth: 1`). wrangler-action records commit metadata via `GITHUB_SHA` on its own. |

## v1 sibling PR

Will land the same changes plus a v1-only fix that writes `dist/docs/v1/build-info.json` (instead of `dist/docs/build-info.json`) so the build-info probe is reachable through CloudFront at `www.union.ai/docs/v1/build-info.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)