### PR TITLE
Fix broken Monty link in workflow-sandboxing-flyte page

### DIFF
--- a/content/user-guide/sandboxing/workflow-sandboxing-flyte.md
+++ b/content/user-guide/sandboxing/workflow-sandboxing-flyte.md
@@ -17,7 +17,7 @@ Three properties of Flyte make it a natural fit for sandboxed code execution:
 
 1. **Infrastructure on demand**: Flyte spins up containers with specific permissions, secrets, and resources for each task.
 2. **LLMs are great at Python**: Models trained on billions of lines of code can reliably generate Python orchestration logic.
-3. **Microsecond startup**: The sandbox is powered by [Monty](https://github.com/pydantic/pydantic-monty) (Pydantic's Rust-based Python interpreter), which starts in microseconds without the overhead of VMs or containers.
+3. **Microsecond startup**: The sandbox is powered by [Monty](https://github.com/pydantic/monty) (Pydantic's Rust-based Python interpreter), which starts in microseconds without the overhead of VMs or containers.
 
 The result: LLMs generate the orchestration code (control flow, conditionals, loops), and Flyte tasks handle the heavy lifting (data access, computation, external APIs) in full containers.
 


### PR DESCRIPTION
## Summary
- The Monty link on the [workflow-sandboxing-flyte](https://www.union.ai/docs/v2/union/user-guide/sandboxing/workflow-sandboxing-flyte/) page pointed to `github.com/pydantic/pydantic-monty`, which 404s.
- The actual Pydantic Monty repo is at `github.com/pydantic/monty`. Updated the link accordingly.

## Test plan
- [ ] Click the Monty link on the rendered page and confirm it resolves to https://github.com/pydantic/monty