### PR TITLE
Bump infra for variant-aware link checker; drop now-redundant excludes

### DIFF
--- a/.link-checker-exclude
+++ b/.link-checker-exclude
@@ -41,8 +41,3 @@ user-guide/core-concepts/projects-and-domains\.md:\.\./run-modes/running-remote
 user-guide/task-configuration/container-images\.md:\.\./run-modes/running-remote
 user-guide/task-deployment/how-task-deployment-works\.md:\.\./run-modes/running-remote
 
-# Link inside {{< variant union >}} block on dual-variant page (cicd.md is +union only)
-user-guide/project-patterns/bring-your-own-image\.md:\./cicd
-
-# Link inside {{< variant union >}} block on dual-variant page (connector-app.md is +union only)
-user-guide/build-apps/_index\.md:\./connector-app


### PR DESCRIPTION
## Summary

- Bumps the `unionai-docs-infra` submodule to pull in [unionai-docs-infra#116](https://github.com/unionai/unionai-docs-infra/pull/116), which teaches the internal link checker to honor `{{< variant ... >}}` blocks. Without that fix, a link inside `{{< variant union >}}...{{< /variant >}}` was still parsed when checking the flyte variant and triggered `page exists but not in this variant` whenever the link target was a `+union` only page.
- Removes two `.link-checker-exclude` entries that were workarounds for that exact bug:
  - `user-guide/project-patterns/bring-your-own-image.md:./cicd` (`cicd.md` is `+union` only)
  - `user-guide/build-apps/_index.md:./connector-app` (`connector-app.md` is `+union` only, added in #989)

  Both targets are linked from inside a `{{< variant union >}}` wrapper, so they're never rendered in the flyte variant. With the new checker behavior they no longer trigger false positives.

## Test plan

- [x] `uv run python unionai-docs-infra/tools/link_checker/check_internal_links.py` reports `flyte: all links OK / union: all links OK / All internal links are valid.`
- [ ] CI `check-links` green.