### PR TITLE
Document base image USER and WORKDIR requirements for BYOI

### DIFF
--- a/content/user-guide/project-patterns/bring-your-own-image.md
+++ b/content/user-guide/project-patterns/bring-your-own-image.md
@@ -145,6 +145,68 @@ uv run main.py
 
 During development you only rebuild the base image when the Dockerfile changes. Code changes are free — they travel as a tarball at runtime.
 
+### Base image USER requirements
+
+When the remote builder layers on top of your base image, the resulting container runs as whatever `USER` your base image declares. The Flyte runtime extracts the code bundle into the container's `WORKDIR` at the start of every task — so that user must be able to read, write, and traverse it.
+
+If your base image declares a non-root `USER` (for example `nonroot` at uid `65532`, common on hardened UBI / distroless / chainguard images) **and** the `WORKDIR` is owned by `root` with restrictive permissions, the very first runtime step fails with:
+
+```text
+PermissionError: [Errno 13] Permission denied
+```
+
+from `flyte._internal.runtime.entrypoints.download_code_bundle`. The build itself succeeds — the failure shows up only when the task runs.
+
+#### Required permissions
+
+The container's working directory must satisfy all three for the resolved `USER`:
+
+| Permission | Why |
+|---|---|
+| `+x` (traverse) | The runtime stats the bundle path before extracting. |
+| `+w` (write) | `tar -xvf` writes the extracted bundle here. |
+| `+r` (read) | Subsequent imports resolve from this directory. |
+
+`/tmp` is already world-writable everywhere, so no special handling is needed for it.
+
+#### Workaround
+
+Use `.with_commands()` to grant the base image's runtime user access to the working directory:
+
+```python
+env = flyte.TaskEnvironment(
+    name="hello_world_private_artifactory",
+    image=flyte.Image.from_base("registry.example.com/ubi9-minimal/python3.13-runtime:3.13.0")
+    .clone(
+        registry="registry.example.com/team-images",
+        registry_secret="image-builder-secret",
+        name="hello-world",
+        extendable=True,
+    )
+    .with_pip_packages("flyte")
+    # Grant the base image's non-root USER (uid 65532 here) access to the working directory.
+    # Look up the uid:gid your base image declares — `docker inspect <image> --format '{{.Config.User}}'`
+    # or `id` inside a one-shot container.
+    .with_commands(["chmod 0755 /root && chown 65532:65532 /root"]),
+)
+```
+
+If your base image uses a different working directory (for example `/app` or `/workspace`), substitute that path. If it uses a username instead of a numeric uid, resolve it first via `getent passwd <name>` inside the image.
+
+#### Verifying
+
+`docker inspect <your-image>` shows both fields you need to reconcile:
+
+```json
+"Config": {
+  "User": "nonroot",
+  "WorkingDir": "/root",
+  ...
+}
+```
+
+If `User` is empty or `root` (`0`), no workaround is needed.
+
 ## Decision matrix
 
 | Scenario | Pattern |
@@ -153,4 +215,5 @@ During development you only rebuild the base image when the Dockerfile changes. 
 | Teams hand off a base image (no Flyte knowledge required) | Remote Builder |
 | Code change should not require image rebuild | Remote Builder + `with_code_bundle()` |
 | Base has non-standard Python location | `.with_commands()` to fix PATH before Flyte uses it |
+| Base runs as a non-root `USER` | `.with_commands()` to chown the `WORKDIR` (see above) |
 | Production deploy, self-contained containers | `copy_style="none"` in `flyte.deploy()` |

--- a/content/user-guide/project-patterns/bring-your-own-image.md
+++ b/content/user-guide/project-patterns/bring-your-own-image.md
@@ -166,16 +166,16 @@ A base image with `USER root` (or no `USER` declared) trivially satisfies this. 
 The remote builder logs the resolved runtime identity at the end of every build:
 
 ```text
-Built image runtime identity: USER="nonroot" WORKDIR="/home/nonroot" (source: custom base "registry.example.com/ubi9-minimal/python3.13-runtime:3.13.0")
+Built image runtime identity: USER="nonroot" WORKDIR="/home/nonroot" (base: registry.example.com/ubi9-minimal/python3.13-runtime:3.13.0)
 ```
 
-If your base image hits the bad combination, the builder additionally emits a warning naming the problem and pointing here. The runtime also has a safety net: when the configured `WORKDIR` is unwritable, it reroutes the code bundle to `/tmp/flyte-bundle/<version>` and continues. You'll see this line in the task pod logs:
+If the resolved `USER` and `WORKDIR` are incompatible (non-root `USER` with `WORKDIR` set to `""`, `/`, or `/root`), the builder emits a warning naming the problem and pointing here. **Fix the base image when you see this warning.** The runtime will not crash on the broken combination, but that's a fail-safe to keep workflows running while you fix the image — not a supported configuration. If you ignore the warning, you'll also see this line in your task pod logs at every task start:
 
 ```text
 CWD /root not writable for current user; rerouting code bundle to /tmp/flyte-bundle/<version>
 ```
 
-That's a strong signal that your base image's `USER`/`WORKDIR` pair is wrong and should be fixed at the source.
+Treat that line as an unfixed-bug indicator. The platform behavior around it may change.
 
 #### Inspecting your base image
 

--- a/content/user-guide/project-patterns/bring-your-own-image.md
+++ b/content/user-guide/project-patterns/bring-your-own-image.md
@@ -169,13 +169,13 @@ The remote builder logs the resolved runtime identity at the end of every build:
 Built image runtime identity: USER="nonroot" WORKDIR="/home/nonroot" (base: registry.example.com/ubi9-minimal/python3.13-runtime:3.13.0)
 ```
 
-If the resolved `USER` and `WORKDIR` are incompatible (non-root `USER` with `WORKDIR` set to `""`, `/`, or `/root`), the builder emits a warning naming the problem and pointing here. **Fix the base image when you see this warning.** The runtime will not crash on the broken combination, but that's a fail-safe to keep workflows running while you fix the image — not a supported configuration. If you ignore the warning, you'll also see this line in your task pod logs at every task start:
+If the resolved `USER` and `WORKDIR` are incompatible (non-root `USER` with `WORKDIR` set to `""`, `/`, or `/root`), the builder emits a warning naming the problem and pointing here. **Fix the base image when you see this warning.** If you ignore it, your tasks will fail at start with:
 
 ```text
-CWD /root not writable for current user; rerouting code bundle to /tmp/flyte-bundle/<version>
+PermissionError: [Errno 13] Permission denied
 ```
 
-Treat that line as an unfixed-bug indicator. The platform behavior around it may change.
+inside `flyte._internal.runtime.entrypoints.download_code_bundle`. The runtime does not paper over the misconfiguration — there is no silent fallback path.
 
 #### Inspecting your base image
 

--- a/content/user-guide/project-patterns/bring-your-own-image.md
+++ b/content/user-guide/project-patterns/bring-your-own-image.md
@@ -248,7 +248,7 @@ The `.` line should show the directory's owner matching the `id` user. If owner 
 
 #### If you cannot modify the base image
 
-If you do not control the base image, layer a `WORKDIR` fix into the Flyte build with `.with_commands()`:
+If you do not control the base image, override its `WORKDIR` with `.with_workdir()` and point it at a path the declared `USER` already owns (commonly `/home/<user>`, created by `useradd -m` in the base):
 
 ```python
 env = flyte.TaskEnvironment(
@@ -261,13 +261,27 @@ env = flyte.TaskEnvironment(
         extendable=True,
     )
     .with_pip_packages("flyte")
-    # Make the base image's WORKDIR writable for the declared USER.
-    # Look up the uid:gid your base image uses with `docker inspect <image> --format '{{.Config.User}}'`.
-    .with_commands(["chmod 0755 /root && chown 65532:65532 /root"]),
+    # Override the base's WORKDIR with a path the declared USER owns.
+    .with_workdir("/home/nonroot"),
 )
 ```
 
-If your base image uses a different working directory (for example `/app`), substitute that path. If it uses a username instead of a numeric uid, resolve it via `getent passwd <name>` inside the image first.
+> [!WARNING]
+> `.with_commands()` runs as the base image's declared `USER` — there is no `--user=root` escape hatch. Telling customers to layer `chmod 0755 /root && chown 65532:65532 /root` via `.with_commands()` looks plausible but fails the build with:
+>
+> ```text
+> chmod: changing permissions of '/root': Operation not permitted
+> ```
+>
+> because non-root users cannot change ownership of root-owned paths. Use `.with_workdir()` to redirect the WORKDIR instead, or modify the base image.
+
+First confirm the target path exists and is owned by the declared `USER`:
+
+```bash
+docker run --rm --entrypoint sh <base-image> -c 'id; ls -ldn /home/nonroot 2>&1 || echo "/home/nonroot does not exist"'
+```
+
+If `/home/<user>` does not exist either (some hardened bases ship neither `/home/<user>` nor a writable `WORKDIR`), there is no workaround that stays inside the Flyte build — you must publish a new base image whose `WORKDIR` is owned by the declared `USER`.
 
 ## Decision matrix
 
@@ -277,5 +291,5 @@ If your base image uses a different working directory (for example `/app`), subs
 | Teams hand off a base image (no Flyte knowledge required) | Remote Builder |
 | Code change should not require image rebuild | Remote Builder + `with_code_bundle()` |
 | Base has non-standard Python location | `.with_commands()` to fix PATH before Flyte uses it |
-| Base runs as a non-root `USER` | Make sure base's `WORKDIR` is owned by that `USER`; if not, use `.with_commands()` to fix it (see above) |
+| Base runs as a non-root `USER` | Make sure base's `WORKDIR` is owned by that `USER`; if not, use `.with_workdir("<path-the-USER-owns>")` to redirect (see above) |
 | Production deploy, self-contained containers | `copy_style="none"` in `flyte.deploy()` |

--- a/content/user-guide/project-patterns/bring-your-own-image.md
+++ b/content/user-guide/project-patterns/bring-your-own-image.md
@@ -189,12 +189,49 @@ inside `flyte._internal.runtime.entrypoints.download_code_bundle`. The runtime d
 }
 ```
 
-In that example, `User` is non-root but `WorkingDir` is `/root` — the runtime warning will fire. Fix the base image's Dockerfile:
+In that example, `User` is non-root but `WorkingDir` is `/root` — the runtime warning will fire. Fix the base image's Dockerfile so the runtime `USER` actually owns its `WORKDIR`.
+
+> [!WARNING]
+> **`WORKDIR` alone is not enough.** Docker's `WORKDIR` directive will create the directory if it doesn't exist — but it always creates it as `root:root` mode `0755`, regardless of any preceding `USER` directive. So this *looks* correct but **still fails**:
+>
+> ```dockerfile
+> USER nonroot
+> WORKDIR /home/nonroot   # Docker creates /home/nonroot as root:root 0755
+>                         # nonroot can read+traverse but NOT write → still PermissionError
+> ```
+>
+> The OCI config will show `WorkingDir: "/home/nonroot"` (so the build-time WARN won't fire), but at runtime the `nonroot` user can't write the code bundle into a directory it doesn't own.
+
+Three patterns that *do* work:
 
 ```dockerfile
+# Pattern A — useradd -m pre-creates /home/<user> with the right ownership
+RUN useradd -u 65532 -g 65532 -m nonroot
 USER nonroot
 WORKDIR /home/nonroot
 ```
+
+```dockerfile
+# Pattern B — explicit chown
+RUN mkdir -p /work && chown nonroot:nonroot /work
+USER nonroot
+WORKDIR /work
+```
+
+```dockerfile
+# Pattern C — install -d, single command
+RUN install -d -o nonroot -g nonroot /work
+USER nonroot
+WORKDIR /work
+```
+
+To verify a base after building:
+
+```bash
+docker run --rm --entrypoint sh <your-image> -c 'id; pwd; ls -ld .'
+```
+
+You should see the listed directory's owner match the `id` user. If owner is `root` and you're not running as root, the runtime cannot write there.
 
 #### If you cannot modify the base image
 

--- a/content/user-guide/project-patterns/bring-your-own-image.md
+++ b/content/user-guide/project-patterns/bring-your-own-image.md
@@ -192,46 +192,59 @@ inside `flyte._internal.runtime.entrypoints.download_code_bundle`. The runtime d
 In that example, `User` is non-root but `WorkingDir` is `/root` — the runtime warning will fire. Fix the base image's Dockerfile so the runtime `USER` actually owns its `WORKDIR`.
 
 > [!WARNING]
-> **`WORKDIR` alone is not enough.** Docker's `WORKDIR` directive will create the directory if it doesn't exist — but it always creates it as `root:root` mode `0755`, regardless of any preceding `USER` directive. So this *looks* correct but **still fails**:
+> **`USER` must come *before* `WORKDIR` in your Dockerfile.** BuildKit's `WORKDIR` directive creates the directory if it doesn't exist, and it inherits ownership from the *currently active `USER`*. So this works:
 >
 > ```dockerfile
 > USER nonroot
-> WORKDIR /home/nonroot   # Docker creates /home/nonroot as root:root 0755
->                         # nonroot can read+traverse but NOT write → still PermissionError
+> WORKDIR /home/nonroot      # ✅ /home/nonroot created as nonroot:nonroot
 > ```
 >
-> The OCI config will show `WorkingDir: "/home/nonroot"` (so the build-time WARN won't fire), but at runtime the `nonroot` user can't write the code bundle into a directory it doesn't own.
+> But these silently produce a root-owned WORKDIR that the runtime can't write to:
+>
+> ```dockerfile
+> WORKDIR /home/nonroot      # ❌ created as root:root (no USER set yet)
+> USER nonroot
+> ```
+>
+> ```dockerfile
+> WORKDIR /home/nonroot      # ❌ created as root:root (current USER is still root)
+> RUN useradd -u 65532 nonroot
+> USER nonroot
+> ```
+>
+> In both broken cases the OCI config shows `WorkingDir: "/home/nonroot"` (so the build-time WARN won't fire — the path itself isn't on the blocklist), but at runtime the resolved `nonroot` user can't write the code bundle into a directory it doesn't own.
 
-Three patterns that *do* work:
+Three patterns that work — pick whichever fits your base:
 
 ```dockerfile
-# Pattern A — useradd -m pre-creates /home/<user> with the right ownership
+# Pattern A — useradd -m pre-creates /home/<user> with the right ownership,
+# then USER + WORKDIR is a clean no-op on the existing dir.
 RUN useradd -u 65532 -g 65532 -m nonroot
 USER nonroot
 WORKDIR /home/nonroot
 ```
 
 ```dockerfile
-# Pattern B — explicit chown
+# Pattern B — explicit chown, then USER + WORKDIR on an existing dir.
 RUN mkdir -p /work && chown nonroot:nonroot /work
 USER nonroot
 WORKDIR /work
 ```
 
 ```dockerfile
-# Pattern C — install -d, single command
-RUN install -d -o nonroot -g nonroot /work
+# Pattern C — rely on USER-before-WORKDIR ownership inheritance for a path
+# that doesn't exist in the base. WORKDIR creates /work owned by nonroot.
 USER nonroot
 WORKDIR /work
 ```
 
-To verify a base after building:
+To verify a built image's WORKDIR ownership before deploying:
 
 ```bash
 docker run --rm --entrypoint sh <your-image> -c 'id; pwd; ls -ld .'
 ```
 
-You should see the listed directory's owner match the `id` user. If owner is `root` and you're not running as root, the runtime cannot write there.
+The `.` line should show the directory's owner matching the `id` user. If owner is `root` and you're not running as root, the runtime cannot write there — re-order your Dockerfile so `USER` comes before `WORKDIR`.
 
 #### If you cannot modify the base image
 

--- a/content/user-guide/project-patterns/bring-your-own-image.md
+++ b/content/user-guide/project-patterns/bring-your-own-image.md
@@ -145,19 +145,11 @@ uv run main.py
 
 During development you only rebuild the base image when the Dockerfile changes. Code changes are free — they travel as a tarball at runtime.
 
-### Base image USER requirements
+### Base image USER and WORKDIR requirements
 
-When the remote builder layers on top of your base image, the resulting container runs as whatever `USER` your base image declares. The Flyte runtime extracts the code bundle into the container's `WORKDIR` at the start of every task — so that user must be able to read, write, and traverse it.
+The remote builder honors whatever `USER` and `WORKDIR` your base image declares — it does not override them. The runtime extracts the code bundle into the container's `WORKDIR` at the start of every task, so the resolved `USER` needs to be able to read, write, and traverse that directory.
 
-If your base image declares a non-root `USER` (for example `nonroot` at uid `65532`, common on hardened UBI / distroless / chainguard images) **and** the `WORKDIR` is owned by `root` with restrictive permissions, the very first runtime step fails with:
-
-```text
-PermissionError: [Errno 13] Permission denied
-```
-
-from `flyte._internal.runtime.entrypoints.download_code_bundle`. The build itself succeeds — the failure shows up only when the task runs.
-
-#### Required permissions
+#### What the runtime needs
 
 The container's working directory must satisfy all three for the resolved `USER`:
 
@@ -167,11 +159,46 @@ The container's working directory must satisfy all three for the resolved `USER`
 | `+w` (write) | `tar -xvf` writes the extracted bundle here. |
 | `+r` (read) | Subsequent imports resolve from this directory. |
 
-`/tmp` is already world-writable everywhere, so no special handling is needed for it.
+A base image with `USER root` (or no `USER` declared) trivially satisfies this. Hardened bases that ship a non-root `USER` (UBI `nonroot` uid `65532`, distroless `nonroot`, chainguard `nonroot`) are fine **as long as their `WORKDIR` is a path that user owns** — for example `/home/nonroot`, `/app`, or `/workspace`. The trap is when a hardened base image leaves `WORKDIR` empty or set to `/root`: that path is typically owned by `root` with mode `0700`, and the non-root `USER` cannot use it.
 
-#### Workaround
+#### What you'll see
 
-Use `.with_commands()` to grant the base image's runtime user access to the working directory:
+The remote builder logs the resolved runtime identity at the end of every build:
+
+```text
+Built image runtime identity: USER="nonroot" WORKDIR="/home/nonroot" (source: custom base "registry.example.com/ubi9-minimal/python3.13-runtime:3.13.0")
+```
+
+If your base image hits the bad combination, the builder additionally emits a warning naming the problem and pointing here. The runtime also has a safety net: when the configured `WORKDIR` is unwritable, it reroutes the code bundle to `/tmp/flyte-bundle/<version>` and continues. You'll see this line in the task pod logs:
+
+```text
+CWD /root not writable for current user; rerouting code bundle to /tmp/flyte-bundle/<version>
+```
+
+That's a strong signal that your base image's `USER`/`WORKDIR` pair is wrong and should be fixed at the source.
+
+#### Inspecting your base image
+
+`docker inspect <your-image>` shows the two fields you need to reconcile:
+
+```json
+"Config": {
+  "User": "nonroot",
+  "WorkingDir": "/root",
+  ...
+}
+```
+
+In that example, `User` is non-root but `WorkingDir` is `/root` — the runtime warning will fire. Fix the base image's Dockerfile:
+
+```dockerfile
+USER nonroot
+WORKDIR /home/nonroot
+```
+
+#### If you cannot modify the base image
+
+If you do not control the base image, layer a `WORKDIR` fix into the Flyte build with `.with_commands()`:
 
 ```python
 env = flyte.TaskEnvironment(
@@ -184,28 +211,13 @@ env = flyte.TaskEnvironment(
         extendable=True,
     )
     .with_pip_packages("flyte")
-    # Grant the base image's non-root USER (uid 65532 here) access to the working directory.
-    # Look up the uid:gid your base image declares — `docker inspect <image> --format '{{.Config.User}}'`
-    # or `id` inside a one-shot container.
+    # Make the base image's WORKDIR writable for the declared USER.
+    # Look up the uid:gid your base image uses with `docker inspect <image> --format '{{.Config.User}}'`.
     .with_commands(["chmod 0755 /root && chown 65532:65532 /root"]),
 )
 ```
 
-If your base image uses a different working directory (for example `/app` or `/workspace`), substitute that path. If it uses a username instead of a numeric uid, resolve it first via `getent passwd <name>` inside the image.
-
-#### Verifying
-
-`docker inspect <your-image>` shows both fields you need to reconcile:
-
-```json
-"Config": {
-  "User": "nonroot",
-  "WorkingDir": "/root",
-  ...
-}
-```
-
-If `User` is empty or `root` (`0`), no workaround is needed.
+If your base image uses a different working directory (for example `/app`), substitute that path. If it uses a username instead of a numeric uid, resolve it via `getent passwd <name>` inside the image first.
 
 ## Decision matrix
 
@@ -215,5 +227,5 @@ If `User` is empty or `root` (`0`), no workaround is needed.
 | Teams hand off a base image (no Flyte knowledge required) | Remote Builder |
 | Code change should not require image rebuild | Remote Builder + `with_code_bundle()` |
 | Base has non-standard Python location | `.with_commands()` to fix PATH before Flyte uses it |
-| Base runs as a non-root `USER` | `.with_commands()` to chown the `WORKDIR` (see above) |
+| Base runs as a non-root `USER` | Make sure base's `WORKDIR` is owned by that `USER`; if not, use `.with_commands()` to fix it (see above) |
 | Production deploy, self-contained containers | `copy_style="none"` in `flyte.deploy()` |

--- a/content/user-guide/project-patterns/bring-your-own-image.md
+++ b/content/user-guide/project-patterns/bring-your-own-image.md
@@ -145,6 +145,68 @@ uv run main.py
 
 During development you only rebuild the base image when the Dockerfile changes. Code changes are free: they travel as a tarball at runtime.
 
+### Base image USER requirements
+
+When the remote builder layers on top of your base image, the resulting container runs as whatever `USER` your base image declares. The Flyte runtime extracts the code bundle into the container's `WORKDIR` at the start of every task — so that user must be able to read, write, and traverse it.
+
+If your base image declares a non-root `USER` (for example `nonroot` at uid `65532`, common on hardened UBI / distroless / chainguard images) **and** the `WORKDIR` is owned by `root` with restrictive permissions, the very first runtime step fails with:
+
+```text
+PermissionError: [Errno 13] Permission denied
+```
+
+from `flyte._internal.runtime.entrypoints.download_code_bundle`. The build itself succeeds — the failure shows up only when the task runs.
+
+#### Required permissions
+
+The container's working directory must satisfy all three for the resolved `USER`:
+
+| Permission | Why |
+|---|---|
+| `+x` (traverse) | The runtime stats the bundle path before extracting. |
+| `+w` (write) | `tar -xvf` writes the extracted bundle here. |
+| `+r` (read) | Subsequent imports resolve from this directory. |
+
+`/tmp` is already world-writable everywhere, so no special handling is needed for it.
+
+#### Workaround
+
+Use `.with_commands()` to grant the base image's runtime user access to the working directory:
+
+```python
+env = flyte.TaskEnvironment(
+    name="hello_world_private_artifactory",
+    image=flyte.Image.from_base("registry.example.com/ubi9-minimal/python3.13-runtime:3.13.0")
+    .clone(
+        registry="registry.example.com/team-images",
+        registry_secret="image-builder-secret",
+        name="hello-world",
+        extendable=True,
+    )
+    .with_pip_packages("flyte")
+    # Grant the base image's non-root USER (uid 65532 here) access to the working directory.
+    # Look up the uid:gid your base image declares — `docker inspect <image> --format '{{.Config.User}}'`
+    # or `id` inside a one-shot container.
+    .with_commands(["chmod 0755 /root && chown 65532:65532 /root"]),
+)
+```
+
+If your base image uses a different working directory (for example `/app` or `/workspace`), substitute that path. If it uses a username instead of a numeric uid, resolve it first via `getent passwd <name>` inside the image.
+
+#### Verifying
+
+`docker inspect <your-image>` shows both fields you need to reconcile:
+
+```json
+"Config": {
+  "User": "nonroot",
+  "WorkingDir": "/root",
+  ...
+}
+```
+
+If `User` is empty or `root` (`0`), no workaround is needed.
+
 ## Decision matrix
 
 | Scenario | Pattern |
@@ -153,4 +215,5 @@ During development you only rebuild the base image when the Dockerfile changes. 
 | Teams hand off a base image (no Flyte knowledge required) | Remote Builder |
 | Code change should not require image rebuild | Remote Builder + `with_code_bundle()` |
 | Base has non-standard Python location | `.with_commands()` to fix PATH before Flyte uses it |
+| Base runs as a non-root `USER` | `.with_commands()` to chown the `WORKDIR` (see above) |
 | Production deploy, self-contained containers | `copy_style="none"` in `flyte.deploy()` |

--- a/content/user-guide/project-patterns/bring-your-own-image.md
+++ b/content/user-guide/project-patterns/bring-your-own-image.md
@@ -145,19 +145,11 @@ uv run main.py
 
 During development you only rebuild the base image when the Dockerfile changes. Code changes are free: they travel as a tarball at runtime.
 
-### Base image USER requirements
+### Base image USER and WORKDIR requirements
 
-When the remote builder layers on top of your base image, the resulting container runs as whatever `USER` your base image declares. The Flyte runtime extracts the code bundle into the container's `WORKDIR` at the start of every task — so that user must be able to read, write, and traverse it.
+The remote builder honors whatever `USER` and `WORKDIR` your base image declares — it does not override them. The runtime extracts the code bundle into the container's `WORKDIR` at the start of every task, so the resolved `USER` needs to be able to read, write, and traverse that directory.
 
-If your base image declares a non-root `USER` (for example `nonroot` at uid `65532`, common on hardened UBI / distroless / chainguard images) **and** the `WORKDIR` is owned by `root` with restrictive permissions, the very first runtime step fails with:
-
-```text
-PermissionError: [Errno 13] Permission denied
-```
-
-from `flyte._internal.runtime.entrypoints.download_code_bundle`. The build itself succeeds — the failure shows up only when the task runs.
-
-#### Required permissions
+#### What the runtime needs
 
 The container's working directory must satisfy all three for the resolved `USER`:
 
@@ -167,11 +159,46 @@ The container's working directory must satisfy all three for the resolved `USER`
 | `+w` (write) | `tar -xvf` writes the extracted bundle here. |
 | `+r` (read) | Subsequent imports resolve from this directory. |
 
-`/tmp` is already world-writable everywhere, so no special handling is needed for it.
+A base image with `USER root` (or no `USER` declared) trivially satisfies this. Hardened bases that ship a non-root `USER` (UBI `nonroot` uid `65532`, distroless `nonroot`, chainguard `nonroot`) are fine **as long as their `WORKDIR` is a path that user owns** — for example `/home/nonroot`, `/app`, or `/workspace`. The trap is when a hardened base image leaves `WORKDIR` empty or set to `/root`: that path is typically owned by `root` with mode `0700`, and the non-root `USER` cannot use it.
 
-#### Workaround
+#### What you'll see
 
-Use `.with_commands()` to grant the base image's runtime user access to the working directory:
+The remote builder logs the resolved runtime identity at the end of every build:
+
+```text
+Built image runtime identity: USER="nonroot" WORKDIR="/home/nonroot" (source: custom base "registry.example.com/ubi9-minimal/python3.13-runtime:3.13.0")
+```
+
+If your base image hits the bad combination, the builder additionally emits a warning naming the problem and pointing here. The runtime also has a safety net: when the configured `WORKDIR` is unwritable, it reroutes the code bundle to `/tmp/flyte-bundle/<version>` and continues. You'll see this line in the task pod logs:
+
+```text
+CWD /root not writable for current user; rerouting code bundle to /tmp/flyte-bundle/<version>
+```
+
+That's a strong signal that your base image's `USER`/`WORKDIR` pair is wrong and should be fixed at the source.
+
+#### Inspecting your base image
+
+`docker inspect <your-image>` shows the two fields you need to reconcile:
+
+```json
+"Config": {
+  "User": "nonroot",
+  "WorkingDir": "/root",
+  ...
+}
+```
+
+In that example, `User` is non-root but `WorkingDir` is `/root` — the runtime warning will fire. Fix the base image's Dockerfile:
+
+```dockerfile
+USER nonroot
+WORKDIR /home/nonroot
+```
+
+#### If you cannot modify the base image
+
+If you do not control the base image, layer a `WORKDIR` fix into the Flyte build with `.with_commands()`:
 
 ```python
 env = flyte.TaskEnvironment(
@@ -184,28 +211,13 @@ env = flyte.TaskEnvironment(
         extendable=True,
     )
     .with_pip_packages("flyte")
-    # Grant the base image's non-root USER (uid 65532 here) access to the working directory.
-    # Look up the uid:gid your base image declares — `docker inspect <image> --format '{{.Config.User}}'`
-    # or `id` inside a one-shot container.
+    # Make the base image's WORKDIR writable for the declared USER.
+    # Look up the uid:gid your base image uses with `docker inspect <image> --format '{{.Config.User}}'`.
     .with_commands(["chmod 0755 /root && chown 65532:65532 /root"]),
 )
 ```
 
-If your base image uses a different working directory (for example `/app` or `/workspace`), substitute that path. If it uses a username instead of a numeric uid, resolve it first via `getent passwd <name>` inside the image.
-
-#### Verifying
-
-`docker inspect <your-image>` shows both fields you need to reconcile:
-
-```json
-"Config": {
-  "User": "nonroot",
-  "WorkingDir": "/root",
-  ...
-}
-```
-
-If `User` is empty or `root` (`0`), no workaround is needed.
+If your base image uses a different working directory (for example `/app`), substitute that path. If it uses a username instead of a numeric uid, resolve it via `getent passwd <name>` inside the image first.
 
 ## Decision matrix
 
@@ -215,5 +227,5 @@ If `User` is empty or `root` (`0`), no workaround is needed.
 | Teams hand off a base image (no Flyte knowledge required) | Remote Builder |
 | Code change should not require image rebuild | Remote Builder + `with_code_bundle()` |
 | Base has non-standard Python location | `.with_commands()` to fix PATH before Flyte uses it |
-| Base runs as a non-root `USER` | `.with_commands()` to chown the `WORKDIR` (see above) |
+| Base runs as a non-root `USER` | Make sure base's `WORKDIR` is owned by that `USER`; if not, use `.with_commands()` to fix it (see above) |
 | Production deploy, self-contained containers | `copy_style="none"` in `flyte.deploy()` |


### PR DESCRIPTION
## Summary

Documents the contract a customer's base image must satisfy when used through `flyte.Image.from_base()`: the resolved `USER` must own (or be able to read/write/traverse) the resulting image's `WORKDIR`, because the Flyte runtime extracts the code bundle into the container's working directory at task start. Hardened base images that ship a non-root `USER` (UBI `nonroot` uid `65532`, distroless `nonroot`, chainguard `nonroot`) often fail this contract today, surfacing as `PermissionError: [Errno 13] Permission denied` inside `flyte._internal.runtime.entrypoints.download_code_bundle`.

The first revision of this PR framed itself as a *workaround* page (use `.with_commands()` to chmod the WORKDIR). Subsequent revisions reframed around the actual fix that now ships in [cloud #15929](https://github.com/unionai/cloud/pull/15929) (the v2 image builder no longer overrides `WORKDIR /root`) and the companion docstring update in [flyte-sdk #1071](https://github.com/flyteorg/flyte-sdk/pull/1071). The runtime fallback we initially considered was rejected as a BYOI violation — the principle this guide now reinforces is "surface what the base declared; don't paper over misconfiguration."

## What the BYOI page now covers (under Pattern 2: Remote Builder)

A new "Base image USER and WORKDIR requirements" section explaining:

- **The permission contract** the runtime needs (`+r +w +x` on `WORKDIR` for the resolved `USER`).
- **What the build emits**: the new INFO line (`Built image runtime identity: USER="..." WORKDIR="..." (base: ...)`) and the WARN that fires when `USER` is non-root and `WORKDIR` is in `{"", "/", "/root"}`.
- **What the runtime emits** if the user ignores the warning: explicit `PermissionError` traceback at task start (no silent reroute).
- **How to inspect** a base image's `Config.User` / `Config.WorkingDir` via `docker inspect`.
- **The WORKDIR-creates-as-root gotcha** (a subtle trap surfaced during FAB-352 reproduction):
  > Docker's `WORKDIR` directive creates the directory if missing — but always as `root:root` mode `0755`, regardless of any preceding `USER` directive. So `USER nonroot; WORKDIR /home/nonroot` *looks* correct (OCI config shows the right WorkingDir, build-time WARN won't fire) but still fails at runtime because `nonroot` can't write into a directory it doesn't own.
- **Three patterns that *do* work**: `useradd -m`, explicit `mkdir`+`chown`, `install -d -o <user>`.
- **A `docker run` command** users can run against their built image to verify ownership before deploying.
- **`.with_commands()` workaround** for users who can't modify the base image.

Also adds a row to the page's decision matrix so the section is discoverable from the page-level summary.

## Companion PRs

- [cloud #15929](https://github.com/unionai/cloud/pull/15929) — the actual fix in the v2 image-spec frontend: stop overriding `WORKDIR /root`, add `reportRuntimeIdentity` INFO/WARN log lines.
- [flyte-sdk #1071](https://github.com/flyteorg/flyte-sdk/pull/1071) — `Image.from_base()` docstring update pointing at this guide section.

## Test Plan

- [x] `make dev` and visually confirm the "Base image USER and WORKDIR requirements" subsection renders under "Pattern 2: Remote Builder".
- [x] WARNING callout box for the WORKDIR-creates-as-root gotcha renders correctly.
- [x] Three Dockerfile snippets (pattern A/B/C) and the `docker run` verify command all syntax-highlight as expected.
- [x] Decision matrix row "Base runs as a non-root `USER`" still resolves and reads sensibly.
- [x] Existing markdownlint warnings unchanged (no new ones from this change; some pre-existing MD025/MD060/MD024 warnings remain in the file's other tables).
- [x] Validated against a real failing case on `mike-apple-aws` — both a "bad" base (no WORKDIR) and a "good" base (`USER nonroot; WORKDIR /home/nonroot` via `useradd -m`) were reproduced; the bad case correctly triggers the WARN, the good case succeeds end-to-end. Repro Dockerfiles in [cloud PR #15929 comment](https://github.com/unionai/cloud/pull/15929#issuecomment-4465761833).

## Issue

Refs FAB-352.