### PR TITLE
Regenerate API reference docs against flyte 2.3.2

### DIFF
--- a/content/api-reference/flyte-cli.md
+++ b/content/api-reference/flyte-cli.md
@@ -1,6 +1,6 @@
 ---
 title: "Flyte CLI"
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 weight: 3

--- a/content/api-reference/flyte-sdk/_index.md
+++ b/content/api-reference/flyte-sdk/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Flyte SDK
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 weight: 4

--- a/content/api-reference/flyte-sdk/classes/_index.md
+++ b/content/api-reference/flyte-sdk/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes & Protocols
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/_index.md
+++ b/content/api-reference/flyte-sdk/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents.codemode/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents.codemode/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.ai.agents.codemode
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents.codemode/codemodeagent.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents.codemode/codemodeagent.md
@@ -1,6 +1,6 @@
 ---
 title: CodeModeAgent
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents.protocol/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents.protocol/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.ai.agents.protocol
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents.protocol/agent.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents.protocol/agent.md
@@ -1,6 +1,6 @@
 ---
 title: Agent
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents.protocol/agentresult.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents.protocol/agentresult.md
@@ -1,6 +1,6 @@
 ---
 title: AgentResult
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.ai.agents
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents/agent.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents/agent.md
@@ -1,6 +1,6 @@
 ---
 title: Agent
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents/agentresult.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents/agentresult.md
@@ -1,6 +1,6 @@
 ---
 title: AgentResult
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents/codemodeagent.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents/codemodeagent.md
@@ -1,6 +1,6 @@
 ---
 title: CodeModeAgent
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.chat.app/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.chat.app/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.ai.chat.app
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.chat.app/agentchatappenvironment.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.chat.app/agentchatappenvironment.md
@@ -1,6 +1,6 @@
 ---
 title: AgentChatAppEnvironment
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.chat.app/customtheme.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.chat.app/customtheme.md
@@ -1,6 +1,6 @@
 ---
 title: CustomTheme
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.chat/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.chat/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.ai.chat
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.chat/agentchatappenvironment.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.chat/agentchatappenvironment.md
@@ -1,6 +1,6 @@
 ---
 title: AgentChatAppEnvironment
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.chat/customtheme.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.chat/customtheme.md
@@ -1,6 +1,6 @@
 ---
 title: CustomTheme
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.mcp/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.mcp/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.ai.mcp
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.mcp/flytemcpappenvironment.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.mcp/flytemcpappenvironment.md
@@ -1,6 +1,6 @@
 ---
 title: FlyteMCPAppEnvironment
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.mcp/mcpappenvironment.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.mcp/mcpappenvironment.md
@@ -1,6 +1,6 @@
 ---
 title: MCPAppEnvironment
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app.extras/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app.extras/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.app.extras
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app.extras/fastapiappenvironment.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app.extras/fastapiappenvironment.md
@@ -1,6 +1,6 @@
 ---
 title: FastAPIAppEnvironment
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app.extras/fastapipassthroughauthmiddleware.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app.extras/fastapipassthroughauthmiddleware.md
@@ -1,6 +1,6 @@
 ---
 title: FastAPIPassthroughAuthMiddleware
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app.extras/flytewebhookappenvironment.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app.extras/flytewebhookappenvironment.md
@@ -1,6 +1,6 @@
 ---
 title: FlyteWebhookAppEnvironment
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.app
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app/appendpoint.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app/appendpoint.md
@@ -1,6 +1,6 @@
 ---
 title: AppEndpoint
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app/appenvironment.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app/appenvironment.md
@@ -1,6 +1,6 @@
 ---
 title: AppEnvironment
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app/connectorenvironment.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app/connectorenvironment.md
@@ -1,6 +1,6 @@
 ---
 title: ConnectorEnvironment
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app/domain.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app/domain.md
@@ -1,6 +1,6 @@
 ---
 title: Domain
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app/link.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app/link.md
@@ -1,6 +1,6 @@
 ---
 title: Link
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app/parameter.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app/parameter.md
@@ -1,6 +1,6 @@
 ---
 title: Parameter
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app/port.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app/port.md
@@ -1,6 +1,6 @@
 ---
 title: Port
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app/runoutput.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app/runoutput.md
@@ -1,6 +1,6 @@
 ---
 title: RunOutput
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app/scaling.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app/scaling.md
@@ -1,6 +1,6 @@
 ---
 title: Scaling
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app/timeouts.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app/timeouts.md
@@ -1,6 +1,6 @@
 ---
 title: Timeouts
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.config/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.config/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.config
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.config/config.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.config/config.md
@@ -1,6 +1,6 @@
 ---
 title: Config
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.connectors.utils/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.connectors.utils/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.connectors.utils
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.connectors/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.connectors/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.connectors
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.connectors/asyncconnector.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.connectors/asyncconnector.md
@@ -1,6 +1,6 @@
 ---
 title: AsyncConnector
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.connectors/asyncconnectorexecutormixin.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.connectors/asyncconnectorexecutormixin.md
@@ -1,6 +1,6 @@
 ---
 title: AsyncConnectorExecutorMixin
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.connectors/connectorregistry.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.connectors/connectorregistry.md
@@ -1,6 +1,6 @@
 ---
 title: ConnectorRegistry
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.connectors/connectorservice.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.connectors/connectorservice.md
@@ -1,6 +1,6 @@
 ---
 title: ConnectorService
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.connectors/resource.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.connectors/resource.md
@@ -1,6 +1,6 @@
 ---
 title: Resource
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.connectors/resourcemeta.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.connectors/resourcemeta.md
@@ -1,6 +1,6 @@
 ---
 title: ResourceMeta
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.durable/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.durable/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.durable
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.errors
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/actionabortederror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/actionabortederror.md
@@ -1,6 +1,6 @@
 ---
 title: ActionAbortedError
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/actionnotfounderror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/actionnotfounderror.md
@@ -1,6 +1,6 @@
 ---
 title: ActionNotFoundError
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/baseruntimeerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/baseruntimeerror.md
@@ -1,6 +1,6 @@
 ---
 title: BaseRuntimeError
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/codebundleerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/codebundleerror.md
@@ -1,6 +1,6 @@
 ---
 title: CodeBundleError
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/customerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/customerror.md
@@ -1,6 +1,6 @@
 ---
 title: CustomError
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/deploymenterror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/deploymenterror.md
@@ -1,6 +1,6 @@
 ---
 title: DeploymentError
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/imagebuilderror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/imagebuilderror.md
@@ -1,6 +1,6 @@
 ---
 title: ImageBuildError
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/imagepullbackofferror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/imagepullbackofferror.md
@@ -1,6 +1,6 @@
 ---
 title: ImagePullBackOffError
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/initializationerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/initializationerror.md
@@ -1,6 +1,6 @@
 ---
 title: InitializationError
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/inlineiomaxbytesbreached.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/inlineiomaxbytesbreached.md
@@ -1,6 +1,6 @@
 ---
 title: InlineIOMaxBytesBreached
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/invalidimagenameerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/invalidimagenameerror.md
@@ -1,6 +1,6 @@
 ---
 title: InvalidImageNameError
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/invalidpackageerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/invalidpackageerror.md
@@ -1,6 +1,6 @@
 ---
 title: InvalidPackageError
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/logsnotyetavailableerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/logsnotyetavailableerror.md
@@ -1,6 +1,6 @@
 ---
 title: LogsNotYetAvailableError
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/moduleloaderror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/moduleloaderror.md
@@ -1,6 +1,6 @@
 ---
 title: ModuleLoadError
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/nonrecoverableerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/nonrecoverableerror.md
@@ -1,6 +1,6 @@
 ---
 title: NonRecoverableError
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/notintaskcontexterror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/notintaskcontexterror.md
@@ -1,6 +1,6 @@
 ---
 title: NotInTaskContextError
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/onlyasynciosupportederror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/onlyasynciosupportederror.md
@@ -1,6 +1,6 @@
 ---
 title: OnlyAsyncIOSupportedError
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/oomerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/oomerror.md
@@ -1,6 +1,6 @@
 ---
 title: OOMError
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/parametermaterializationerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/parametermaterializationerror.md
@@ -1,6 +1,6 @@
 ---
 title: ParameterMaterializationError
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/primarycontainernotfounderror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/primarycontainernotfounderror.md
@@ -1,6 +1,6 @@
 ---
 title: PrimaryContainerNotFoundError
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/remotetasknotfounderror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/remotetasknotfounderror.md
@@ -1,6 +1,6 @@
 ---
 title: RemoteTaskNotFoundError
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/remotetaskusageerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/remotetaskusageerror.md
@@ -1,6 +1,6 @@
 ---
 title: RemoteTaskUsageError
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/restrictedtypeerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/restrictedtypeerror.md
@@ -1,6 +1,6 @@
 ---
 title: RestrictedTypeError
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/retriesexhaustederror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/retriesexhaustederror.md
@@ -1,6 +1,6 @@
 ---
 title: RetriesExhaustedError
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/runtimedatavalidationerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/runtimedatavalidationerror.md
@@ -1,6 +1,6 @@
 ---
 title: RuntimeDataValidationError
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/runtimesystemerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/runtimesystemerror.md
@@ -1,6 +1,6 @@
 ---
 title: RuntimeSystemError
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/runtimeunknownerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/runtimeunknownerror.md
@@ -1,6 +1,6 @@
 ---
 title: RuntimeUnknownError
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/runtimeusererror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/runtimeusererror.md
@@ -1,6 +1,6 @@
 ---
 title: RuntimeUserError
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/slowdownerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/slowdownerror.md
@@ -1,6 +1,6 @@
 ---
 title: SlowDownError
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/taskinterruptederror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/taskinterruptederror.md
@@ -1,6 +1,6 @@
 ---
 title: TaskInterruptedError
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/tasktimeouterror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/tasktimeouterror.md
@@ -1,6 +1,6 @@
 ---
 title: TaskTimeoutError
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/tracedoesnotallownestedtaskserror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/tracedoesnotallownestedtaskserror.md
@@ -1,6 +1,6 @@
 ---
 title: TraceDoesNotAllowNestedTasksError
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/unionrpcerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/unionrpcerror.md
@@ -1,6 +1,6 @@
 ---
 title: UnionRpcError
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extend/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extend/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.extend
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extend/asyncfunctiontasktemplate.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extend/asyncfunctiontasktemplate.md
@@ -1,6 +1,6 @@
 ---
 title: AsyncFunctionTaskTemplate
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extend/imagebuildengine.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extend/imagebuildengine.md
@@ -1,6 +1,6 @@
 ---
 title: ImageBuildEngine
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extend/imagebuilder.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extend/imagebuilder.md
@@ -1,6 +1,6 @@
 ---
 title: ImageBuilder
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extend/imagechecker.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extend/imagechecker.md
@@ -1,6 +1,6 @@
 ---
 title: ImageChecker
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extend/tasktemplate.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extend/tasktemplate.md
@@ -1,6 +1,6 @@
 ---
 title: TaskTemplate
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.extras
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras/batchstats.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras/batchstats.md
@@ -1,6 +1,6 @@
 ---
 title: BatchStats
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras/containertask.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras/containertask.md
@@ -1,6 +1,6 @@
 ---
 title: ContainerTask
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras/costestimator.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras/costestimator.md
@@ -1,6 +1,6 @@
 ---
 title: CostEstimator
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras/dynamicbatcher.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras/dynamicbatcher.md
@@ -1,6 +1,6 @@
 ---
 title: DynamicBatcher
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras/prompt.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras/prompt.md
@@ -1,6 +1,6 @@
 ---
 title: Prompt
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras/sleep.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras/sleep.md
@@ -1,6 +1,6 @@
 ---
 title: Sleep
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras/sleeptask.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras/sleeptask.md
@@ -1,6 +1,6 @@
 ---
 title: SleepTask
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras/tokenbatcher.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras/tokenbatcher.md
@@ -1,6 +1,6 @@
 ---
 title: TokenBatcher
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras/tokenestimator.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras/tokenestimator.md
@@ -1,6 +1,6 @@
 ---
 title: TokenEstimator
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.git/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.git/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.git
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.git/gitstatus.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.git/gitstatus.md
@@ -1,6 +1,6 @@
 ---
 title: GitStatus
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.io.extend/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.io.extend/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.io.extend
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.io.extend/dataframedecoder.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.io.extend/dataframedecoder.md
@@ -1,6 +1,6 @@
 ---
 title: DataFrameDecoder
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.io.extend/dataframeencoder.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.io.extend/dataframeencoder.md
@@ -1,6 +1,6 @@
 ---
 title: DataFrameEncoder
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.io.extend/dataframetransformerengine.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.io.extend/dataframetransformerengine.md
@@ -1,6 +1,6 @@
 ---
 title: DataFrameTransformerEngine
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.io/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.io/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.io
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.io/dataframe.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.io/dataframe.md
@@ -1,6 +1,6 @@
 ---
 title: DataFrame
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.io/dir.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.io/dir.md
@@ -1,6 +1,6 @@
 ---
 title: Dir
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.io/emptydir.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.io/emptydir.md
@@ -1,6 +1,6 @@
 ---
 title: EmptyDir
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.io/file.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.io/file.md
@@ -1,6 +1,6 @@
 ---
 title: File
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.io/hashfunction.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.io/hashfunction.md
@@ -1,6 +1,6 @@
 ---
 title: HashFunction
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.models/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.models/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.models
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.models/actionid.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.models/actionid.md
@@ -1,6 +1,6 @@
 ---
 title: ActionID
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.models/actionphase.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.models/actionphase.md
@@ -1,6 +1,6 @@
 ---
 title: ActionPhase
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.models/checkpointpaths.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.models/checkpointpaths.md
@@ -1,6 +1,6 @@
 ---
 title: CheckpointPaths
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.models/codebundle.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.models/codebundle.md
@@ -1,6 +1,6 @@
 ---
 title: CodeBundle
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.models/groupdata.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.models/groupdata.md
@@ -1,6 +1,6 @@
 ---
 title: GroupData
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.models/nativeinterface.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.models/nativeinterface.md
@@ -1,6 +1,6 @@
 ---
 title: NativeInterface
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.models/pathrewrite.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.models/pathrewrite.md
@@ -1,6 +1,6 @@
 ---
 title: PathRewrite
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.models/rawdatapath.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.models/rawdatapath.md
@@ -1,6 +1,6 @@
 ---
 title: RawDataPath
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.models/serializationcontext.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.models/serializationcontext.md
@@ -1,6 +1,6 @@
 ---
 title: SerializationContext
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.models/taskcontext.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.models/taskcontext.md
@@ -1,6 +1,6 @@
 ---
 title: TaskContext
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.notify/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.notify/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.notify
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.notify/email.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.notify/email.md
@@ -1,6 +1,6 @@
 ---
 title: Email
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.notify/nameddelivery.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.notify/nameddelivery.md
@@ -1,6 +1,6 @@
 ---
 title: NamedDelivery
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.notify/namedrule.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.notify/namedrule.md
@@ -1,6 +1,6 @@
 ---
 title: NamedRule
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.notify/notification.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.notify/notification.md
@@ -1,6 +1,6 @@
 ---
 title: Notification
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.notify/slack.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.notify/slack.md
@@ -1,6 +1,6 @@
 ---
 title: Slack
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.notify/teams.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.notify/teams.md
@@ -1,6 +1,6 @@
 ---
 title: Teams
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.notify/webhook.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.notify/webhook.md
@@ -1,6 +1,6 @@
 ---
 title: Webhook
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.prefetch/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.prefetch/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.prefetch
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.prefetch/huggingfacemodelinfo.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.prefetch/huggingfacemodelinfo.md
@@ -1,6 +1,6 @@
 ---
 title: HuggingFaceModelInfo
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.prefetch/shardconfig.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.prefetch/shardconfig.md
@@ -1,6 +1,6 @@
 ---
 title: ShardConfig
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.prefetch/storedmodelinfo.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.prefetch/storedmodelinfo.md
@@ -1,6 +1,6 @@
 ---
 title: StoredModelInfo
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.prefetch/vllmshardargs.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.prefetch/vllmshardargs.md
@@ -1,6 +1,6 @@
 ---
 title: VLLMShardArgs
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.remote
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/action.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/action.md
@@ -1,6 +1,6 @@
 ---
 title: Action
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/actiondetails.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/actiondetails.md
@@ -1,6 +1,6 @@
 ---
 title: ActionDetails
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/actioninputs.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/actioninputs.md
@@ -1,6 +1,6 @@
 ---
 title: ActionInputs
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/actionoutputs.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/actionoutputs.md
@@ -1,6 +1,6 @@
 ---
 title: ActionOutputs
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/app.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/app.md
@@ -1,6 +1,6 @@
 ---
 title: App
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/project.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/project.md
@@ -1,6 +1,6 @@
 ---
 title: Project
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/run.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/run.md
@@ -1,6 +1,6 @@
 ---
 title: Run
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/rundetails.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/rundetails.md
@@ -1,6 +1,6 @@
 ---
 title: RunDetails
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/secret.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/secret.md
@@ -1,6 +1,6 @@
 ---
 title: Secret
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/settings.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/settings.md
@@ -1,6 +1,6 @@
 ---
 title: Settings
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/task.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/task.md
@@ -1,6 +1,6 @@
 ---
 title: Task
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/taskdetails.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/taskdetails.md
@@ -1,6 +1,6 @@
 ---
 title: TaskDetails
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/timefilter.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/timefilter.md
@@ -1,6 +1,6 @@
 ---
 title: TimeFilter
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/trigger.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/trigger.md
@@ -1,6 +1,6 @@
 ---
 title: Trigger
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/user.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/user.md
@@ -1,6 +1,6 @@
 ---
 title: User
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.report/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.report/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.report
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.report/report.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.report/report.md
@@ -1,6 +1,6 @@
 ---
 title: Report
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.sandbox/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.sandbox/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.sandbox
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.sandbox/codetasktemplate.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.sandbox/codetasktemplate.md
@@ -1,6 +1,6 @@
 ---
 title: CodeTaskTemplate
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.sandbox/imageconfig.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.sandbox/imageconfig.md
@@ -1,6 +1,6 @@
 ---
 title: ImageConfig
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.sandbox/sandboxedconfig.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.sandbox/sandboxedconfig.md
@@ -1,6 +1,6 @@
 ---
 title: SandboxedConfig
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.sandbox/sandboxedtasktemplate.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.sandbox/sandboxedtasktemplate.md
@@ -1,6 +1,6 @@
 ---
 title: SandboxedTaskTemplate
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.storage/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.storage/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.storage
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.storage/abfs.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.storage/abfs.md
@@ -1,6 +1,6 @@
 ---
 title: ABFS
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.storage/gcs.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.storage/gcs.md
@@ -1,6 +1,6 @@
 ---
 title: GCS
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.storage/s3.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.storage/s3.md
@@ -1,6 +1,6 @@
 ---
 title: S3
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.storage/storage.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.storage/storage.md
@@ -1,6 +1,6 @@
 ---
 title: Storage
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.syncify/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.syncify/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.syncify
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.syncify/syncify.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.syncify/syncify.md
@@ -1,6 +1,6 @@
 ---
 title: Syncify
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.types/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.types/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.types
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.types/flytepickle.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.types/flytepickle.md
@@ -1,6 +1,6 @@
 ---
 title: FlytePickle
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.types/renderable.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.types/renderable.md
@@ -1,6 +1,6 @@
 ---
 title: Renderable
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.types/typeengine.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.types/typeengine.md
@@ -1,6 +1,6 @@
 ---
 title: TypeEngine
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.types/typetransformer.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.types/typetransformer.md
@@ -1,6 +1,6 @@
 ---
 title: TypeTransformer
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.types/typetransformerfailederror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.types/typetransformerfailederror.md
@@ -1,6 +1,6 @@
 ---
 title: TypeTransformerFailedError
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/apphandle.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/apphandle.md
@@ -1,6 +1,6 @@
 ---
 title: AppHandle
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/basecheckpoint.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/basecheckpoint.md
@@ -1,6 +1,6 @@
 ---
 title: BaseCheckpoint
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/cache.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/cache.md
@@ -1,6 +1,6 @@
 ---
 title: Cache
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/cachepolicy.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/cachepolicy.md
@@ -1,6 +1,6 @@
 ---
 title: CachePolicy
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/checkpoint.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/checkpoint.md
@@ -1,6 +1,6 @@
 ---
 title: Checkpoint
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/cron.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/cron.md
@@ -1,6 +1,6 @@
 ---
 title: Cron
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/device.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/device.md
@@ -1,6 +1,6 @@
 ---
 title: Device
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/environment.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/environment.md
@@ -1,6 +1,6 @@
 ---
 title: Environment
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/fixedrate.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/fixedrate.md
@@ -1,6 +1,6 @@
 ---
 title: FixedRate
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/image.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/image.md
@@ -1,6 +1,6 @@
 ---
 title: Image
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/imagebuild.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/imagebuild.md
@@ -1,6 +1,6 @@
 ---
 title: ImageBuild
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/link.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/link.md
@@ -1,6 +1,6 @@
 ---
 title: Link
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/podtemplate.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/podtemplate.md
@@ -1,6 +1,6 @@
 ---
 title: PodTemplate
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/resources.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/resources.md
@@ -1,6 +1,6 @@
 ---
 title: Resources
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/retrystrategy.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/retrystrategy.md
@@ -1,6 +1,6 @@
 ---
 title: RetryStrategy
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/reusepolicy.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/reusepolicy.md
@@ -1,6 +1,6 @@
 ---
 title: ReusePolicy
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/secret.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/secret.md
@@ -1,6 +1,6 @@
 ---
 title: Secret
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/taskenvironment.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/taskenvironment.md
@@ -1,6 +1,6 @@
 ---
 title: TaskEnvironment
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/timeout.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/timeout.md
@@ -1,6 +1,6 @@
 ---
 title: Timeout
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/trigger.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/trigger.md
@@ -1,6 +1,6 @@
 ---
 title: Trigger
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/anthropic/_index.md
+++ b/content/api-reference/integrations/anthropic/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Anthropic
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/anthropic/classes/_index.md
+++ b/content/api-reference/integrations/anthropic/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/anthropic/packages/_index.md
+++ b/content/api-reference/integrations/anthropic/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/anthropic/packages/flyteplugins.anthropic/_index.md
+++ b/content/api-reference/integrations/anthropic/packages/flyteplugins.anthropic/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.anthropic
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/anthropic/packages/flyteplugins.anthropic/agent.md
+++ b/content/api-reference/integrations/anthropic/packages/flyteplugins.anthropic/agent.md
@@ -1,6 +1,6 @@
 ---
 title: Agent
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/bigquery/_index.md
+++ b/content/api-reference/integrations/bigquery/_index.md
@@ -1,6 +1,6 @@
 ---
 title: BigQuery
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/bigquery/classes/_index.md
+++ b/content/api-reference/integrations/bigquery/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/bigquery/packages/_index.md
+++ b/content/api-reference/integrations/bigquery/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/bigquery/packages/flyteplugins.bigquery/_index.md
+++ b/content/api-reference/integrations/bigquery/packages/flyteplugins.bigquery/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.bigquery
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/bigquery/packages/flyteplugins.bigquery/bigqueryconfig.md
+++ b/content/api-reference/integrations/bigquery/packages/flyteplugins.bigquery/bigqueryconfig.md
@@ -1,6 +1,6 @@
 ---
 title: BigQueryConfig
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/bigquery/packages/flyteplugins.bigquery/bigqueryconnector.md
+++ b/content/api-reference/integrations/bigquery/packages/flyteplugins.bigquery/bigqueryconnector.md
@@ -1,6 +1,6 @@
 ---
 title: BigQueryConnector
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/bigquery/packages/flyteplugins.bigquery/bigquerytask.md
+++ b/content/api-reference/integrations/bigquery/packages/flyteplugins.bigquery/bigquerytask.md
@@ -1,6 +1,6 @@
 ---
 title: BigQueryTask
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/codegen/_index.md
+++ b/content/api-reference/integrations/codegen/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Code generation
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/codegen/classes/_index.md
+++ b/content/api-reference/integrations/codegen/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/codegen/packages/_index.md
+++ b/content/api-reference/integrations/codegen/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/_index.md
+++ b/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.codegen
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/autocoderagent.md
+++ b/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/autocoderagent.md
@@ -1,6 +1,6 @@
 ---
 title: AutoCoderAgent
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/codegenevalresult.md
+++ b/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/codegenevalresult.md
@@ -1,6 +1,6 @@
 ---
 title: CodeGenEvalResult
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/codeplan.md
+++ b/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/codeplan.md
@@ -1,6 +1,6 @@
 ---
 title: CodePlan
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/codesolution.md
+++ b/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/codesolution.md
@@ -1,6 +1,6 @@
 ---
 title: CodeSolution
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/errordiagnosis.md
+++ b/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/errordiagnosis.md
@@ -1,6 +1,6 @@
 ---
 title: ErrorDiagnosis
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/imageconfig.md
+++ b/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/imageconfig.md
@@ -1,6 +1,6 @@
 ---
 title: ImageConfig
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/dask/_index.md
+++ b/content/api-reference/integrations/dask/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Dask
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/dask/classes/_index.md
+++ b/content/api-reference/integrations/dask/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/dask/packages/_index.md
+++ b/content/api-reference/integrations/dask/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/dask/packages/flyteplugins.dask/_index.md
+++ b/content/api-reference/integrations/dask/packages/flyteplugins.dask/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.dask
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/dask/packages/flyteplugins.dask/dask.md
+++ b/content/api-reference/integrations/dask/packages/flyteplugins.dask/dask.md
@@ -1,6 +1,6 @@
 ---
 title: Dask
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/dask/packages/flyteplugins.dask/scheduler.md
+++ b/content/api-reference/integrations/dask/packages/flyteplugins.dask/scheduler.md
@@ -1,6 +1,6 @@
 ---
 title: Scheduler
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/dask/packages/flyteplugins.dask/workergroup.md
+++ b/content/api-reference/integrations/dask/packages/flyteplugins.dask/workergroup.md
@@ -1,6 +1,6 @@
 ---
 title: WorkerGroup
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/databricks/_index.md
+++ b/content/api-reference/integrations/databricks/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Databricks
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/databricks/classes/_index.md
+++ b/content/api-reference/integrations/databricks/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/databricks/packages/_index.md
+++ b/content/api-reference/integrations/databricks/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/databricks/packages/flyteplugins.databricks/_index.md
+++ b/content/api-reference/integrations/databricks/packages/flyteplugins.databricks/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.databricks
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/databricks/packages/flyteplugins.databricks/databricks.md
+++ b/content/api-reference/integrations/databricks/packages/flyteplugins.databricks/databricks.md
@@ -1,6 +1,6 @@
 ---
 title: Databricks
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/databricks/packages/flyteplugins.databricks/databricksconnector.md
+++ b/content/api-reference/integrations/databricks/packages/flyteplugins.databricks/databricksconnector.md
@@ -1,6 +1,6 @@
 ---
 title: DatabricksConnector
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/gemini/_index.md
+++ b/content/api-reference/integrations/gemini/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Gemini
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/gemini/classes/_index.md
+++ b/content/api-reference/integrations/gemini/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/gemini/packages/_index.md
+++ b/content/api-reference/integrations/gemini/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/gemini/packages/flyteplugins.gemini/_index.md
+++ b/content/api-reference/integrations/gemini/packages/flyteplugins.gemini/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.gemini
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/gemini/packages/flyteplugins.gemini/agent.md
+++ b/content/api-reference/integrations/gemini/packages/flyteplugins.gemini/agent.md
@@ -1,6 +1,6 @@
 ---
 title: Agent
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/hitl/_index.md
+++ b/content/api-reference/integrations/hitl/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Human-in-the-Loop
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/hitl/classes/_index.md
+++ b/content/api-reference/integrations/hitl/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/hitl/packages/_index.md
+++ b/content/api-reference/integrations/hitl/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/hitl/packages/flyteplugins.hitl/_index.md
+++ b/content/api-reference/integrations/hitl/packages/flyteplugins.hitl/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.hitl
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/hitl/packages/flyteplugins.hitl/event.md
+++ b/content/api-reference/integrations/hitl/packages/flyteplugins.hitl/event.md
@@ -1,6 +1,6 @@
 ---
 title: Event
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/hydra/_index.md
+++ b/content/api-reference/integrations/hydra/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Hydra
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/hydra/packages/flyteplugins.hydra/_index.md
+++ b/content/api-reference/integrations/hydra/packages/flyteplugins.hydra/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.hydra
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/jsonl/_index.md
+++ b/content/api-reference/integrations/jsonl/_index.md
@@ -1,6 +1,6 @@
 ---
 title: JSONL
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/jsonl/classes/_index.md
+++ b/content/api-reference/integrations/jsonl/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/jsonl/packages/_index.md
+++ b/content/api-reference/integrations/jsonl/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/jsonl/packages/flyteplugins.jsonl/_index.md
+++ b/content/api-reference/integrations/jsonl/packages/flyteplugins.jsonl/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.jsonl
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/jsonl/packages/flyteplugins.jsonl/jsonldir.md
+++ b/content/api-reference/integrations/jsonl/packages/flyteplugins.jsonl/jsonldir.md
@@ -1,6 +1,6 @@
 ---
 title: JsonlDir
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/jsonl/packages/flyteplugins.jsonl/jsonlfile.md
+++ b/content/api-reference/integrations/jsonl/packages/flyteplugins.jsonl/jsonlfile.md
@@ -1,6 +1,6 @@
 ---
 title: JsonlFile
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/mlflow/_index.md
+++ b/content/api-reference/integrations/mlflow/_index.md
@@ -1,6 +1,6 @@
 ---
 title: MLflow
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/mlflow/classes/_index.md
+++ b/content/api-reference/integrations/mlflow/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/mlflow/packages/_index.md
+++ b/content/api-reference/integrations/mlflow/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/mlflow/packages/flyteplugins.mlflow/_index.md
+++ b/content/api-reference/integrations/mlflow/packages/flyteplugins.mlflow/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.mlflow
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/mlflow/packages/flyteplugins.mlflow/mlflow.md
+++ b/content/api-reference/integrations/mlflow/packages/flyteplugins.mlflow/mlflow.md
@@ -1,6 +1,6 @@
 ---
 title: Mlflow
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/omegaconf/_index.md
+++ b/content/api-reference/integrations/omegaconf/_index.md
@@ -1,6 +1,6 @@
 ---
 title: OmegaConf
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/omegaconf/packages/flyteplugins.omegaconf/_index.md
+++ b/content/api-reference/integrations/omegaconf/packages/flyteplugins.omegaconf/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.omegaconf
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/openai/_index.md
+++ b/content/api-reference/integrations/openai/_index.md
@@ -1,6 +1,6 @@
 ---
 title: OpenAI
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/openai/packages/flyteplugins.openai.agents/_index.md
+++ b/content/api-reference/integrations/openai/packages/flyteplugins.openai.agents/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.openai.agents
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/papermill/_index.md
+++ b/content/api-reference/integrations/papermill/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Papermill
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/papermill/classes/_index.md
+++ b/content/api-reference/integrations/papermill/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/papermill/packages/_index.md
+++ b/content/api-reference/integrations/papermill/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/papermill/packages/flyteplugins.papermill/_index.md
+++ b/content/api-reference/integrations/papermill/packages/flyteplugins.papermill/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.papermill
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/papermill/packages/flyteplugins.papermill/notebooktask.md
+++ b/content/api-reference/integrations/papermill/packages/flyteplugins.papermill/notebooktask.md
@@ -1,6 +1,6 @@
 ---
 title: NotebookTask
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/polars/_index.md
+++ b/content/api-reference/integrations/polars/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Polars
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/polars/classes/_index.md
+++ b/content/api-reference/integrations/polars/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/polars/packages/_index.md
+++ b/content/api-reference/integrations/polars/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/polars/packages/flyteplugins.polars.df_transformer/_index.md
+++ b/content/api-reference/integrations/polars/packages/flyteplugins.polars.df_transformer/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.polars.df_transformer
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/polars/packages/flyteplugins.polars.df_transformer/parquettopolarsdecodinghandler.md
+++ b/content/api-reference/integrations/polars/packages/flyteplugins.polars.df_transformer/parquettopolarsdecodinghandler.md
@@ -1,6 +1,6 @@
 ---
 title: ParquetToPolarsDecodingHandler
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/polars/packages/flyteplugins.polars.df_transformer/parquettopolarslazyframedecodinghandler.md
+++ b/content/api-reference/integrations/polars/packages/flyteplugins.polars.df_transformer/parquettopolarslazyframedecodinghandler.md
@@ -1,6 +1,6 @@
 ---
 title: ParquetToPolarsLazyFrameDecodingHandler
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/polars/packages/flyteplugins.polars.df_transformer/polarslazyframetoparquetencodinghandler.md
+++ b/content/api-reference/integrations/polars/packages/flyteplugins.polars.df_transformer/polarslazyframetoparquetencodinghandler.md
@@ -1,6 +1,6 @@
 ---
 title: PolarsLazyFrameToParquetEncodingHandler
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/polars/packages/flyteplugins.polars.df_transformer/polarstoparquetencodinghandler.md
+++ b/content/api-reference/integrations/polars/packages/flyteplugins.polars.df_transformer/polarstoparquetencodinghandler.md
@@ -1,6 +1,6 @@
 ---
 title: PolarsToParquetEncodingHandler
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/pytorch/_index.md
+++ b/content/api-reference/integrations/pytorch/_index.md
@@ -1,6 +1,6 @@
 ---
 title: PyTorch
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/pytorch/classes/_index.md
+++ b/content/api-reference/integrations/pytorch/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/pytorch/packages/_index.md
+++ b/content/api-reference/integrations/pytorch/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/pytorch/packages/flyteplugins.pytorch/_index.md
+++ b/content/api-reference/integrations/pytorch/packages/flyteplugins.pytorch/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.pytorch
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/pytorch/packages/flyteplugins.pytorch/elastic.md
+++ b/content/api-reference/integrations/pytorch/packages/flyteplugins.pytorch/elastic.md
@@ -1,6 +1,6 @@
 ---
 title: Elastic
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/ray/_index.md
+++ b/content/api-reference/integrations/ray/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Ray
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/ray/classes/_index.md
+++ b/content/api-reference/integrations/ray/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/ray/packages/_index.md
+++ b/content/api-reference/integrations/ray/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/ray/packages/flyteplugins.ray/_index.md
+++ b/content/api-reference/integrations/ray/packages/flyteplugins.ray/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.ray
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/ray/packages/flyteplugins.ray/headnodeconfig.md
+++ b/content/api-reference/integrations/ray/packages/flyteplugins.ray/headnodeconfig.md
@@ -1,6 +1,6 @@
 ---
 title: HeadNodeConfig
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/ray/packages/flyteplugins.ray/rayjobconfig.md
+++ b/content/api-reference/integrations/ray/packages/flyteplugins.ray/rayjobconfig.md
@@ -1,6 +1,6 @@
 ---
 title: RayJobConfig
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/ray/packages/flyteplugins.ray/workernodeconfig.md
+++ b/content/api-reference/integrations/ray/packages/flyteplugins.ray/workernodeconfig.md
@@ -1,6 +1,6 @@
 ---
 title: WorkerNodeConfig
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/sglang/_index.md
+++ b/content/api-reference/integrations/sglang/_index.md
@@ -1,6 +1,6 @@
 ---
 title: SGLang
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/sglang/classes/_index.md
+++ b/content/api-reference/integrations/sglang/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/sglang/packages/_index.md
+++ b/content/api-reference/integrations/sglang/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/sglang/packages/flyteplugins.sglang/_index.md
+++ b/content/api-reference/integrations/sglang/packages/flyteplugins.sglang/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.sglang
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/sglang/packages/flyteplugins.sglang/sglangappenvironment.md
+++ b/content/api-reference/integrations/sglang/packages/flyteplugins.sglang/sglangappenvironment.md
@@ -1,6 +1,6 @@
 ---
 title: SGLangAppEnvironment
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/snowflake/_index.md
+++ b/content/api-reference/integrations/snowflake/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Snowflake
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/snowflake/classes/_index.md
+++ b/content/api-reference/integrations/snowflake/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/snowflake/packages/_index.md
+++ b/content/api-reference/integrations/snowflake/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/snowflake/packages/flyteplugins.snowflake/_index.md
+++ b/content/api-reference/integrations/snowflake/packages/flyteplugins.snowflake/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.snowflake
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/snowflake/packages/flyteplugins.snowflake/snowflake.md
+++ b/content/api-reference/integrations/snowflake/packages/flyteplugins.snowflake/snowflake.md
@@ -1,6 +1,6 @@
 ---
 title: Snowflake
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/snowflake/packages/flyteplugins.snowflake/snowflakeconfig.md
+++ b/content/api-reference/integrations/snowflake/packages/flyteplugins.snowflake/snowflakeconfig.md
@@ -1,6 +1,6 @@
 ---
 title: SnowflakeConfig
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/snowflake/packages/flyteplugins.snowflake/snowflakeconnector.md
+++ b/content/api-reference/integrations/snowflake/packages/flyteplugins.snowflake/snowflakeconnector.md
@@ -1,6 +1,6 @@
 ---
 title: SnowflakeConnector
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/spark/_index.md
+++ b/content/api-reference/integrations/spark/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Spark
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/spark/classes/_index.md
+++ b/content/api-reference/integrations/spark/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/spark/packages/_index.md
+++ b/content/api-reference/integrations/spark/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/spark/packages/flyteplugins.spark/_index.md
+++ b/content/api-reference/integrations/spark/packages/flyteplugins.spark/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.spark
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/spark/packages/flyteplugins.spark/parquettosparkdecoder.md
+++ b/content/api-reference/integrations/spark/packages/flyteplugins.spark/parquettosparkdecoder.md
@@ -1,6 +1,6 @@
 ---
 title: ParquetToSparkDecoder
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/spark/packages/flyteplugins.spark/spark.md
+++ b/content/api-reference/integrations/spark/packages/flyteplugins.spark/spark.md
@@ -1,6 +1,6 @@
 ---
 title: Spark
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/spark/packages/flyteplugins.spark/sparktoparquetencoder.md
+++ b/content/api-reference/integrations/spark/packages/flyteplugins.spark/sparktoparquetencoder.md
@@ -1,6 +1,6 @@
 ---
 title: SparkToParquetEncoder
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/vllm/_index.md
+++ b/content/api-reference/integrations/vllm/_index.md
@@ -1,6 +1,6 @@
 ---
 title: vLLM
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/vllm/classes/_index.md
+++ b/content/api-reference/integrations/vllm/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/vllm/packages/_index.md
+++ b/content/api-reference/integrations/vllm/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/vllm/packages/flyteplugins.vllm/_index.md
+++ b/content/api-reference/integrations/vllm/packages/flyteplugins.vllm/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.vllm
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/vllm/packages/flyteplugins.vllm/vllmappenvironment.md
+++ b/content/api-reference/integrations/vllm/packages/flyteplugins.vllm/vllmappenvironment.md
@@ -1,6 +1,6 @@
 ---
 title: VLLMAppEnvironment
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/wandb/_index.md
+++ b/content/api-reference/integrations/wandb/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Weights & Biases
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/wandb/classes/_index.md
+++ b/content/api-reference/integrations/wandb/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/wandb/packages/_index.md
+++ b/content/api-reference/integrations/wandb/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/wandb/packages/flyteplugins.wandb/_index.md
+++ b/content/api-reference/integrations/wandb/packages/flyteplugins.wandb/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.wandb
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/wandb/packages/flyteplugins.wandb/wandb.md
+++ b/content/api-reference/integrations/wandb/packages/flyteplugins.wandb/wandb.md
@@ -1,6 +1,6 @@
 ---
 title: Wandb
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/wandb/packages/flyteplugins.wandb/wandbsweep.md
+++ b/content/api-reference/integrations/wandb/packages/flyteplugins.wandb/wandbsweep.md
@@ -1,6 +1,6 @@
 ---
 title: WandbSweep
-version: 2.3.1
+version: 2.3.2
 variants: +flyte +union
 layout: py_api
 ---


### PR DESCRIPTION
## Summary

- Pure regen: `make clean-generated && make dist` against the current flyte/flyteplugins (2.3.1 → 2.3.2)
- All 308 changed files are version-frontmatter bumps (`version: 2.3.1` → `version: 2.3.2`); no public API surface changes
- Linkmaps regenerated identically (no diff)

## Test plan

- [ ] CI green (`check-generated-content`)
- [ ] Spot-check a couple of `/v2/union/api-reference/...` pages on the preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)