### PR TITLE
Document Flyte 2 retry model (DOC-1186)

### DIFF
--- a/content/api-reference/migration/examples-and-gotchas.md
+++ b/content/api-reference/migration/examples-and-gotchas.md
@@ -338,7 +338,17 @@ Resources(mem="2Gi")
 flyte.Resources(memory="2Gi")  # Note: "memory" not "mem"
 ```
 
-### 9. Type annotations
+### 9. Retries have no platform cap
+
+In Flyte 1, the control plane capped task attempts at 3, regardless of what `retries=N` requested. A task registered with `retries=15` would still stop after 3 attempts.
+
+In Flyte 2, the cap is gone. Total attempts equal `retries + 1`, decided entirely by the decorator. The same `retries=15` task will be attempted up to 16 times.
+
+If you're porting v1 tasks that relied on the implicit ceiling, audit the `retries` value before deploying — a number that was "fine" in v1 because the platform clipped it can produce surprising attempt counts in v2.
+
+Spot-to-on-demand fallback for `interruptible=True` tasks still happens, but it now applies to the *final* attempt rather than kicking in after a fixed number of spot failures. See [Spot to on-demand fallback](../../user-guide/task-configuration/interruptible-tasks-and-queues#spot-to-on-demand-fallback).
+
+### 10. Type annotations
 
 ```python
 # Flyte 1: Strict about type annotations

--- a/content/api-reference/migration/examples-and-gotchas.md
+++ b/content/api-reference/migration/examples-and-gotchas.md
@@ -346,7 +346,7 @@ In Flyte 2, the cap is gone. Total attempts equal `retries + 1`, decided entirel
 
 If you're porting v1 tasks that relied on the implicit ceiling, audit the `retries` value before deploying — a number that was "fine" in v1 because the platform clipped it can produce surprising attempt counts in v2.
 
-Spot-to-on-demand fallback for `interruptible=True` tasks still happens, but it now applies to the *final* attempt rather than kicking in after a fixed number of spot failures. See [Spot to on-demand fallback](../../user-guide/task-configuration/interruptible-tasks-and-queues#spot-to-on-demand-fallback).
+Spot-to-on-demand fallback for `interruptible=True` tasks still happens, but it now applies to the *final* attempt rather than kicking in after a fixed number of spot failures. See [Spot to on-demand fallback](../../../user-guide/task-configuration/interruptible-tasks-and-queues#spot-to-on-demand-fallback).
 
 ### 10. Type annotations
 

--- a/content/user-guide/task-configuration/interruptible-tasks-and-queues.md
+++ b/content/user-guide/task-configuration/interruptible-tasks-and-queues.md
@@ -79,6 +79,19 @@ def train_model(data: list) -> dict:
 > [!NOTE]
 > Retries due to spot preemption do not count against the user-configured retry budget.
 > System retries (for preemptions and other system-level failures) are tracked separately.
+> This is independent from how the medium (spot vs. on-demand) is chosen for each user-budget attempt — see [Spot to on-demand fallback](#spot-to-on-demand-fallback) below.
+
+### Spot to on-demand fallback
+
+By default, the **final attempt** of an interruptible task runs on an on-demand instance rather than on spot.
+This shields long-running or expensive workloads from getting stuck in a preemption loop — once you're on your last attempt, the platform stops gambling on spot capacity.
+
+Two consequences worth knowing:
+
+- A task with `interruptible=True` and no retries is effectively on-demand. Its single attempt is also its final attempt, so it never runs on spot.
+- A task with `interruptible=True, retries=2` makes up to 3 attempts: attempts 1 and 2 run on spot, attempt 3 (if reached) runs on on-demand.
+
+If you want spot pricing to apply to *every* attempt, you need to size `retries` so the workload realistically completes before the final attempt — there's no way to opt out of the on-demand fallback on the last attempt.
 
 ## Queues
 

--- a/content/user-guide/task-configuration/retries-and-timeouts.md
+++ b/content/user-guide/task-configuration/retries-and-timeouts.md
@@ -41,7 +41,7 @@ Finally, we configure flyte and invoke the `main` task:
 `retries=N` covers failures of *your task* — exceptions, non-zero exits, timeouts you've configured.
 Failures caused by the underlying infrastructure (a node disappearing, ephemeral storage running out, a spot instance getting preempted, and so on) are handled separately. The platform retries these on its own and they do not consume your `retries=N` budget.
 
-The platform does, however, eventually give up — a persistent infrastructure problem will still terminate the task. You don't configure this from Python; it's a platform-level concern.
+The platform does eventually give up, but only after many retries — a persistent infrastructure problem can churn for a while before the run is terminated. If you spot a task repeatedly failing on the same infrastructure error, abort it manually rather than waiting for the system to give up on its own. You don't configure the system retry budget from Python; it's a platform-level concern.
 
 For workloads on spot/preemptible compute, see also [Spot to on-demand fallback](./interruptible-tasks-and-queues#spot-to-on-demand-fallback), which describes how interruptible tasks transition to on-demand on their final attempt.
 

--- a/content/user-guide/task-configuration/retries-and-timeouts.md
+++ b/content/user-guide/task-configuration/retries-and-timeouts.md
@@ -36,6 +36,15 @@ Finally, we configure flyte and invoke the `main` task:
 
 {{< code file="/unionai-examples/v2/user-guide/task-configuration/retries-and-timeouts/retries.py" fragment="run" lang="python" >}}
 
+### System retries
+
+`retries=N` covers failures of *your task* — exceptions, non-zero exits, timeouts you've configured.
+Failures caused by the underlying infrastructure (a node disappearing, ephemeral storage running out, a spot instance getting preempted, and so on) are handled separately. The platform retries these on its own and they do not consume your `retries=N` budget.
+
+The platform does, however, eventually give up — a persistent infrastructure problem will still terminate the task. You don't configure this from Python; it's a platform-level concern.
+
+For workloads on spot/preemptible compute, see also [Spot to on-demand fallback](./interruptible-tasks-and-queues#spot-to-on-demand-fallback), which describes how interruptible tasks transition to on-demand on their final attempt.
+
 ## Timeouts
 
 The `timeout` parameter sets limits on how long a task can run, preventing resource waste from stuck processes.


### PR DESCRIPTION
## Summary

Closes [DOC-1186](https://linear.app/unionai/issue/DOC-1186/update-documentation-with-new-retry-policy-details). Fills three gaps in Flyte 2 retry coverage that surfaced from a Slack thread where a user saw a task retry 15 times (vs. v1's implicit 3-attempt cap):

- **`user-guide/task-configuration/retries-and-timeouts`** — new "System retries" subsection distinguishing the user-budget (`retries=N`) from platform-handled infra failures.
- **`user-guide/task-configuration/interruptible-tasks-and-queues`** — new "Spot to on-demand fallback" subsection: the final attempt of an interruptible task runs on on-demand, so single-attempt `interruptible=True` tasks are effectively on-demand. Existing preemption NOTE got a one-line pointer to disambiguate from medium selection.
- **`api-reference/migration/examples-and-gotchas`** — new gotcha "Retries have no platform cap" covering the v1 → v2 behavior change. Old gotcha #9 (Type annotations) renumbered to #10.

Per the project rules, the writing keeps to user-observable behavior — no references to propeller knobs (`InterruptibleFailureThreshold`, `MaxNodeRetriesOnSystemFailures`), no quoted system-retry counts, no implication that any of this is tunable from the Python SDK.

The "System retries" wording was calibrated against the actual deployed retry budgets in `unionai/cloud`: the leasor layer's `DefaultMaxSystemRetries` runs at `30` (unoverridden in any cluster YAML), and propeller's `MaxNodeRetriesOnSystemFailures` sits at `3–5` depending on cluster. So the docs say the platform "eventually gives up, but only after many retries" and tell users to abort manually if they see a persistent infra error.

## Test plan

- [x] `make dev` builds clean
- [x] Anchor `id="spot-to-on-demand-fallback"` exists on the rendered interruptible page
- [x] `#system-retries` anchor exists on the retries page
- [x] Migration page H3 ids: `…7-entrypoint-task-naming`, `8-memory-parameter-name`, `9-retries-have-no-platform-cap`, `10-type-annotations` — renumbering is consistent
- [x] Cross-links from retries page and migration page both resolve to `interruptible-tasks-and-queues#spot-to-on-demand-fallback`
- [x] "Platform eventually gives up" wording calibrated against `unionai/cloud` retry budgets

🤖 Generated with [Claude Code](https://claude.com/claude-code)