### PR TITLE
Reframe running-devbox intro for the Union variant

### DIFF
--- a/content/user-guide/run-modes/running-devbox.md
+++ b/content/user-guide/run-modes/running-devbox.md
@@ -6,7 +6,18 @@ variants: +flyte +union
 
 # Running on the devbox
 
+{{< variant union >}}
+{{< markdown >}}
+**The Flyte 2 devbox is a great way to try out a simplified version of the full Union.ai product on your local machine.**
+
+The devbox is a lightweight local cluster that runs on your machine with Docker. It includes a UI preview, scheduler, and object store, so you can test remote execution without deploying to a real cluster.
+{{< /markdown >}}
+{{< /variant >}}
+{{< variant flyte >}}
+{{< markdown >}}
 The Flyte devbox is a lightweight local cluster that runs on your machine with Docker. It gives you a full Flyte environment — including the UI, scheduler, and object store — so you can test remote execution without deploying to a real cluster.
+{{< /markdown >}}
+{{< /variant >}}
 
 ## What you'll need
 


### PR DESCRIPTION
## Summary
- Reframes the Union variant's intro on `user-guide/run-modes/running-devbox` to promote the Flyte 2 devbox as a way to try a simplified version of the full Union.ai product. Sibling-page titles (`Running locally` / `Running on the devbox` / `Running on a remote cluster`) are preserved, so the H1 stays "Running on the devbox" and the new framing lives in a bolded lede sentence above the existing description.
- The Flyte variant intro is unchanged in meaning (just split into its own `{{< variant flyte >}}` block).
- Context: Slack thread with Zach Johnson — devbox is becoming the primary CTA on union.ai and the Union version of this page needed updating ahead of more traffic.

## Test plan
- [ ] `make dev` and visit `/v2/union/user-guide/run-modes/running-devbox/` — bolded lede + Union-flavored intro appear under the H1.
- [ ] Switch to the Flyte variant — intro unchanged from main.
- [ ] Verify rest of page (Install, Start, Configure, Run, Stop, etc.) is untouched in both variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)