### PR TITLE
Link Cloudflare Tunnel-with-firewall guide from egress section (DOC-1185)

### DIFF
--- a/content/security/architecture/network.md
+++ b/content/security/architecture/network.md
@@ -67,6 +67,8 @@ Each region has its own dedicated control plane endpoint hostname.
 
 For customers with strict egress controls, outbound traffic can be limited to Cloudflare's published CIDR blocks. These blocks can be further restricted to specific Cloudflare regions to minimize the allowed egress surface. Cloudflare publishes its IP ranges at [cloudflare.com/ips](https://www.cloudflare.com/ips/).
 
+For firewall rules that permit `cloudflared` egress while blocking all ingress, see Cloudflare's [Tunnel with firewall](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-with-firewall/) guide.
+
 ## Communication paths
 
 All communication paths in the system use encryption. No unencrypted communication paths exist.

--- a/content/security/architecture/network.md
+++ b/content/security/architecture/network.md
@@ -18,7 +18,7 @@ The trust model is customer-initiated: the data plane decides when and whether t
 
 ## Cloudflare Tunnel
 
-The Cloudflare Tunnel is an outbound-only encrypted connection from the customer's cluster to the Cloudflare edge network, which then routes to the Union.ai control plane. It is initiated by a `cloudflared` sidecar in the data plane and lets the control plane reach data plane services without any inbound firewall rules.
+The Cloudflare Tunnel is an outbound-only encrypted connection from the customer's cluster to the Cloudflare edge network, which then routes to the Union.ai control plane. It is initiated by a `cloudflared` sidecar in the data plane and lets the control plane reach data plane services without any inbound firewall rules. For background on the underlying connector, see Cloudflare's [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/) documentation.
 
 All traffic through the tunnel is encrypted using a layered transport: TLS with mutual authentication (X.509 client certificates), Cloudflare Access service tokens for application-layer authentication, and Cloudflare Tunnel encryption for the network path. Tunnel tokens are rotated automatically: the data plane operator periodically polls the control plane and picks up updated tokens when issued.
 


### PR DESCRIPTION
## Summary
- Adds a pointer to Cloudflare's [Tunnel with firewall](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-with-firewall/) guide from the "Egress configuration" section of `security/architecture/network.md`.
- Restores a Cloudflare reference link that existed in the Nelson-era docs but was dropped during the migration.
- Lives next to the existing Cloudflare CIDR-block guidance — the operational context the Cloudflare doc speaks to.

Linear: [DOC-1185](https://linear.app/unionai/issue/DOC-1185/add-link-to-outbound-connectivity-on-cloudflare)
Origin: Slack request from Chris Matteson

## Test plan
- [ ] Preview renders the new sentence in the Egress configuration section
- [ ] Outbound link resolves to the Cloudflare doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)