### PR TITLE
Tweak running-devbox lede wording

### DIFF
--- a/content/user-guide/run-modes/running-devbox.md
+++ b/content/user-guide/run-modes/running-devbox.md
@@ -8,7 +8,7 @@ variants: +flyte +union
 
 {{< variant union >}}
 {{< markdown >}}
-**The Flyte 2 devbox is a great way to try out a simplified version of the full Union.ai product on your local machine.**
+**The Flyte 2 devbox is a great way to demo a simplified version of Union.ai on your local machine.**
 
 The devbox is a lightweight local cluster that runs on your machine with Docker. It includes a UI preview, scheduler, and object store, so you can test remote execution without deploying to a real cluster.
 {{< /markdown >}}


### PR DESCRIPTION
## Summary
- Follow-up to #1037. Tweaks the Union-variant lede sentence on `running-devbox`: "try out a simplified version of the full Union.ai product" → "demo a simplified version of Union.ai".

## Test plan
- [ ] `make dev` and visit `/v2/union/user-guide/run-modes/running-devbox/` — updated lede appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)