### PR TITLE
Vary running-devbox H1 by variant

### DIFF
--- a/content/user-guide/run-modes/running-devbox.md
+++ b/content/user-guide/run-modes/running-devbox.md
@@ -4,10 +4,10 @@ weight: 5
 variants: +flyte +union
 ---
 
-# Running on the devbox
-
 {{< variant union >}}
 {{< markdown >}}
+# Running on the devbox: Demo Union.ai on your local machine
+
 **The Flyte 2 devbox is a great way to demo a simplified version of Union.ai on your local machine.**
 
 The devbox is a lightweight local cluster that runs on your machine with Docker. It includes a UI preview, scheduler, and object store, so you can test remote execution without deploying to a real cluster.
@@ -15,6 +15,8 @@ The devbox is a lightweight local cluster that runs on your machine with Docker.
 {{< /variant >}}
 {{< variant flyte >}}
 {{< markdown >}}
+# Running on the devbox
+
 The Flyte devbox is a lightweight local cluster that runs on your machine with Docker. It gives you a full Flyte environment — including the UI, scheduler, and object store — so you can test remote execution without deploying to a real cluster.
 {{< /markdown >}}
 {{< /variant >}}


### PR DESCRIPTION
## Summary
- Follow-up to #1037 / #1040. Moves the H1 of `user-guide/run-modes/running-devbox` into the existing per-variant intro blocks so Union readers see a marketing-aligned H1 while Flyte readers see the original.
  - Union: `# Running on the devbox: Demo Union.ai on your local machine` + existing bold lede.
  - Flyte: `# Running on the devbox` (unchanged).
- Frontmatter `title` stays `Running on the devbox` in both variants — preserves the sidebar's sibling-section symmetry (`Running locally` / `Running on the devbox` / `Running on a remote cluster`).
- No URL change, no inbound-link fanout: the canonical `…/run-modes/running-devbox/` URL is preserved, so Zach's planned CTA target and the 9 existing `./running-devbox` links across the user guide continue to work.

## Test plan
- [ ] `make dev`, visit Union variant — H1 reads "Running on the devbox: Demo Union.ai on your local machine".
- [ ] Switch to Flyte variant — H1 reads "Running on the devbox" (unchanged).
- [ ] Sidebar entry reads "Running on the devbox" in both variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)