### PR TITLE
selfhosted: document vendored CRD install path

### DIFF
--- a/content/deployment/selfhosted/getting-started.md
+++ b/content/deployment/selfhosted/getting-started.md
@@ -30,7 +30,7 @@ Two notes on conventions used below:
 
 ## Deployment overview
 
-1. Add Helm repositories and install ScyllaDB CRDs.
+1. Add Helm repositories and install vendored CRDs.
 2. Create namespaces and the registry image pull secret.
 3. Generate TLS certificates.
 4. Create the database password secret.
@@ -50,12 +50,29 @@ helm repo add flyte https://helm.flyte.org
 helm repo update
 ```
 
-If you plan to use the embedded ScyllaDB (default), install its CRDs:
+Several operators bundled with the control plane (kube-prometheus-stack, scylla-operator, envoy-gateway) ship CustomResourceDefinitions whose OpenAPI v3 schemas exceed Kubernetes' 256 KiB per-annotation limit. Applying them via a default Helm install overflows `kubectl.kubernetes.io/last-applied-configuration` and fails with `metadata.annotations: Too long`. To avoid this, the chart no longer renders these CRDs as part of the install; they are vendored under `helm-charts/crds/<name>/` and must be applied up-front via **server-side apply**.
+
+Install only the CRD sets you intend to enable. Each CRD file carries an `argocd.argoproj.io/sync-options: ServerSideApply=true` annotation so an ArgoCD adoption later on continues to manage them via SSA:
 
 ```shell
-cd helm-charts/charts/controlplane
-./scripts/install-scylla-crds.sh
+# Required when monitoring.enabled=true on either the control plane or the
+# data plane. Skip if your cluster already runs kube-prometheus-stack from
+# another source AND that installation manages these CRDs.
+kubectl apply --server-side --force-conflicts -f helm-charts/crds/kube-prometheus-stack/
+
+# Required when using the embedded ScyllaDB (default). Skip if you bring
+# your own scylla-operator install that manages these CRDs.
+kubectl apply --server-side --force-conflicts -f helm-charts/crds/scylla-operator/
+
+# Required when envoy-gateway.enabled=true. SKIP if your cluster already
+# has Gateway API CRDs (gateway.networking.k8s.io) installed from another
+# source — this directory bundles both the standard Gateway API CRDs and
+# envoy-specific (gateway.envoyproxy.io) CRDs together, and double-installing
+# the Gateway API CRDs causes field-manager conflicts between owners.
+kubectl apply --server-side --force-conflicts -f helm-charts/crds/envoy-gateway/
 ```
+
+`--force-conflicts` is required only on first install (or when adopting CRDs previously owned by a Helm-installed copy). It tells the API server to transfer SSA field ownership to the new `kubectl` field manager.
 
 ## Step 2: Namespaces and registry pull secret
 
@@ -233,6 +250,7 @@ helm upgrade --install unionai-controlplane unionai/controlplane \
   --create-namespace \
   -f values.aws.selfhosted-intracluster.yaml \
   -f my-overrides.yaml \
+  --skip-crds \
   --timeout 15m --wait
 ```
 
@@ -249,6 +267,7 @@ helm upgrade --install unionai-controlplane unionai/controlplane \
   --create-namespace \
   -f values.gcp.selfhosted-intracluster.yaml \
   -f my-overrides.yaml \
+  --skip-crds \
   --timeout 15m --wait
 ```
 
@@ -303,6 +322,7 @@ helm upgrade --install unionai-dataplane unionai/dataplane \
   --create-namespace \
   -f values.aws.selfhosted-intracluster.yaml \
   -f dataplane-overrides.yaml \
+  --skip-crds \
   --timeout 10m --wait
 ```
 
@@ -336,6 +356,7 @@ helm upgrade --install unionai-dataplane unionai/dataplane \
   --create-namespace \
   -f values.gcp.selfhosted-intracluster.yaml \
   -f dataplane-overrides.yaml \
+  --skip-crds \
   --timeout 10m --wait
 ```
 

--- a/content/deployment/selfhosted/operations/troubleshooting.md
+++ b/content/deployment/selfhosted/operations/troubleshooting.md
@@ -131,3 +131,17 @@ Backend service accounts need `roles/storage.objectAdmin` (or equivalent) on the
 ## Authentication
 
 See the [Authentication troubleshooting](../authentication#troubleshooting) section.
+
+## CRD install fails with `metadata.annotations: Too long: may not be more than 262144 bytes`
+
+Several operator CRDs bundled with the control plane (`prometheuses.monitoring.coreos.com`, `alertmanagerconfigs.monitoring.coreos.com`, `scylladbclusters.scylla.scylladb.com`, several `gateway.networking.k8s.io` and `gateway.envoyproxy.io` types) have OpenAPI v3 schemas larger than Kubernetes' 256 KiB per-annotation limit. Applying them with a default `kubectl apply` or `helm install` writes the entire spec into `kubectl.kubernetes.io/last-applied-configuration` and the API server rejects the request.
+
+The fix is to apply these CRDs with **server-side apply**, which tracks ownership via `metadata.managedFields` instead and never constructs the oversized annotation:
+
+```shell
+kubectl apply --server-side --force-conflicts -f helm-charts/crds/kube-prometheus-stack/
+kubectl apply --server-side --force-conflicts -f helm-charts/crds/scylla-operator/
+kubectl apply --server-side --force-conflicts -f helm-charts/crds/envoy-gateway/
+```
+
+Then `helm install`/`upgrade` the control plane and data plane charts with `--skip-crds` so Helm does not try to re-apply the bundled copies client-side. See [Getting started → Step 1](../getting-started#step-1-helm-repositories-and-crds) for the full sequence.


### PR DESCRIPTION
> Depends on [unionai/helm-charts#396](https://github.com/unionai/helm-charts/pull/396) — that PR vendors the CRDs this guide tells customers to install.

## Summary

Several operator CRDs (`prometheuses.monitoring.coreos.com`, `alertmanagerconfigs.monitoring.coreos.com`, `scylladbclusters.scylla.scylladb.com`, several `gateway.networking.k8s.io` and `gateway.envoyproxy.io` types) have OpenAPI v3 schemas larger than Kubernetes' 256 KiB per-annotation limit. A default `kubectl apply` or `helm install` overflows `kubectl.kubernetes.io/last-applied-configuration` and fails with `metadata.annotations: Too long`.

This PR documents the install path that sidesteps the overflow.

## Changes

- **`getting-started.md` Step 1**: replaces `install-scylla-crds.sh` with three `kubectl apply --server-side --force-conflicts -f helm-charts/crds/<name>/` commands, with per-component install/skip notes (skip kube-prometheus-stack / scylla-operator / Gateway API CRDs if you already manage them from another source).
- **`getting-started.md` install commands** (4 total — CP+DP across AWS/GCP): add `--skip-crds` so Helm doesn't re-apply the bundled copies client-side.
- **`troubleshooting.md`**: new entry mapping the `metadata.annotations: Too long: may not be more than 262144 bytes` error to the fix, with a back-link to Step 1.

## Test plan

- [x] Markdown renders correctly in `make dev` preview.
- [ ] Reviewer sanity-checks the command sequence on a clean cluster.

## Targets

Base branch: `peeter/selfhosted-docs-v2` (rides along with the broader selfhosted docs restructure).