### PR TITLE
Restore Union variant H1 subtitle on running-devbox

### DIFF
--- a/content/user-guide/run-modes/running-devbox.md
+++ b/content/user-guide/run-modes/running-devbox.md
@@ -5,23 +5,14 @@ variants: +flyte +union
 ---
 
 {{< variant union >}}
-
-{{< note >}}
-
-💻 **Demo a full Union.ai cluster locally**
-
-The Flyte 2 devbox is a great way to demo a simplified version of Union.ai on your local machine.
-
-{{< /note >}}
-
 {{< markdown >}}
-# Run on the devbox
+# Run on the devbox: Demo Union.ai locally
+
+**The Flyte 2 devbox is a great way to demo a simplified version of Union.ai on your local machine.**
 
 The devbox is a lightweight local cluster that runs on your machine with Docker. It includes a UI preview, scheduler, and object store, so you can test remote execution without deploying to a real cluster.
 {{< /markdown >}}
-
 {{< /variant >}}
-
 {{< variant flyte >}}
 {{< markdown >}}
 # Run on the devbox


### PR DESCRIPTION
## Summary

Reverts the `content/user-guide/run-modes/running-devbox.md` portion of #1051.

#1051 replaced the Union variant H1 `# Run on the devbox: Demo Union.ai locally` with `# Run on the devbox` and moved the marketing line into a `{{< note >}}` callout above the H1 — undoing the colon-subtitle pattern deliberately shipped in #1042. This PR restores the #1042 state for that one file. The rest of #1051 (api-ref regen) is untouched.

## Test plan

- [ ] Hugo build green on both variants
- [ ] Union variant page renders H1 as `Run on the devbox: Demo Union.ai locally` with bold lede underneath
- [ ] Flyte variant page unchanged (H1 stays `Run on the devbox`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)