### PR TITLE
Split run-modes intro by variant (flyte: two modes, union: three)

### DIFF
--- a/content/user-guide/run-modes/_index.md
+++ b/content/user-guide/run-modes/_index.md
@@ -6,7 +6,16 @@ variants: +flyte +union
 
 # Run modes
 
-Flyte supports three execution modes, letting you choose the right trade-off between speed and fidelity at each stage of development:
+{{< variant flyte >}}
+{{< markdown >}}
+Flyte OSS currently supports two execution modes — Local and Devbox (Remote execution is coming soon):
+{{< /markdown >}}
+{{< /variant >}}
+{{< variant union >}}
+{{< markdown >}}
+Union.ai supports three execution modes, letting you choose the right trade-off between speed and fidelity at each stage of development:
+{{< /markdown >}}
+{{< /variant >}}
 
 {{< grid cols=3 >}}
 
@@ -21,7 +30,7 @@ Run tasks and apps in a lightweight Flyte cluster using Docker. Get the full Fly
 {{< variant union >}}
 
 {{< link-card target="running-remote" icon="cloud" title="Remote" >}}
-Run tasks and apps on a remote Flyte or Union cluster with full production capabilities including GPUs, distributed compute, and cloud-scale resources.
+Run tasks and apps on a remote cluster with full production capabilities including GPUs, distributed compute, and cloud-scale resources.
 {{< /link-card >}}
 
 {{< /variant >}}
@@ -40,7 +49,7 @@ Run tasks and apps on a remote Flyte or Union cluster with full production capab
 | **🔀 Parallelism** | Sequential | Cluster-level |
 | **⭐️ Best for** | Fast iteration, debugging | Testing container builds, full Flyte features |
 
-The same task code runs unchanged across all the two modes. Start local for fast feedback, move to the devbox to validate containerized execution, then deploy to a remote cluster for production.
+The same task code runs unchanged in both modes.
 
 {{< /markdown >}}
 {{< /variant >}}
@@ -57,7 +66,7 @@ The same task code runs unchanged across all the two modes. Start local for fast
 | **🔀 Parallelism** | Sequential | Cluster-level | Cluster-level |
 | **⭐️ Best for** | Fast iteration, debugging | Testing container builds, full Flyte features | Production, GPUs, scale |
 
-The same task code runs unchanged across all three modes. Start local for fast feedback, move to the devbox to validate containerized execution, then deploy to a remote cluster for production.
+The same task code runs unchanged across all three modes. Start with local execution for fast feedback, move to the Devbox to validate containerized execution, then deploy to a remote cluster for production.
 
 {{< /markdown >}}
 {{< /variant >}}


### PR DESCRIPTION
## Summary

The **Run modes** landing page presented three execution modes (Local, Devbox, Remote) unconditionally, but the `flyte` (OSS) variant only supports Local and Devbox today — Remote is not yet available there. This gates the intro and summary by variant so each variant shows the correct mode count.

## Changes

- Split the intro line by variant: `flyte` now reads "two execution modes — Local and Devbox (Remote execution is coming soon)"; `union` keeps the three-mode framing.
- The Remote link-card and the Remote table column were already `union`-gated; this aligns the surrounding prose with that gating.
- Genericized the Remote card copy ("remote cluster" rather than "remote Flyte or Union cluster").
- Cleaned up the closing summary wording in both variants (fixed "across all the two modes" → "across both modes").

## Notes

- Known cosmetic: the card grid is `cols=3` in both variants, so the `flyte` variant renders two cards in a three-column grid. Left as-is intentionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)