### PR TITLE
ci: scope check-* workflows to PRs + main pushes

### DIFF
--- a/.github/workflows/check-api-docs.yml
+++ b/.github/workflows/check-api-docs.yml
@@ -1,6 +1,9 @@
 name: Check API Docs
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches: [main]
 
 jobs:
   check-api-docs:

--- a/.github/workflows/check-generated-content.yml
+++ b/.github/workflows/check-generated-content.yml
@@ -1,6 +1,9 @@
 name: Check Generated Content
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches: [main]
 
 jobs:
   check-generated-content:

--- a/.github/workflows/check-helm-docs.yml
+++ b/.github/workflows/check-helm-docs.yml
@@ -1,6 +1,9 @@
 name: Check Helm Docs
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches: [main]
 
 jobs:
   check-helm-docs:

--- a/.github/workflows/check-images.yml
+++ b/.github/workflows/check-images.yml
@@ -1,6 +1,9 @@
 name: Check Images Health
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches: [main]
 
 jobs:
   check-images:

--- a/.github/workflows/check-jupyter.yml
+++ b/.github/workflows/check-jupyter.yml
@@ -1,6 +1,9 @@
 name: Check Jupyter Notebooks
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches: [main]
 
 jobs:
   check-jupyter:

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,6 +1,9 @@
 name: Check Internal Links
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches: [main]
 
 jobs:
   check-links:

--- a/.github/workflows/check-llm-bundle-notes.yml
+++ b/.github/workflows/check-llm-bundle-notes.yml
@@ -1,6 +1,9 @@
 name: Check LLM Bundle Notes
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches: [main]
 
 jobs:
   check-llm-bundle-notes:

--- a/.github/workflows/check-redirects.yml
+++ b/.github/workflows/check-redirects.yml
@@ -1,6 +1,9 @@
 name: Check Redirects
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches: [main]
 
 jobs:
   check-redirects:

--- a/.github/workflows/deploy-redirects.yml
+++ b/.github/workflows/deploy-redirects.yml
@@ -27,7 +27,7 @@ jobs:
             echo "Manual trigger, proceeding with deploy."
             exit 0
           fi
-          # For push events, check if the infra submodule ref changed and
+          # For push events, check if the unionai-docs-infra submodule ref changed and
           # whether that change includes redirects.csv
           OLD_REF=$(git diff HEAD~1 HEAD -- unionai-docs-infra | grep "^-Subproject" | awk '{print $3}' || true)
           NEW_REF=$(git diff HEAD~1 HEAD -- unionai-docs-infra | grep "^+Subproject" | awk '{print $3}' || true)


### PR DESCRIPTION
## What

Rescope all 8 `check-*` workflows from bare `on: [push]` to:

```yaml
on:
  pull_request:
  push:
    branches: [main]
```

## Why

`on: [push]` fires on **every push to every branch** — including throwaway feature branches with no PR open. *Check Internal Links* alone logged **100+ runs in one month**; across all 8 checks that's **~700+ runs/month**, mostly redundant with the checks that already run on the PR.

This runs them where they matter — on the PR (so results gate review) and once on `main` after merge — and stops the feature-branch noise.

## Safety

`main` has **no required status checks** configured (only PR review is required), so this changes nothing about merge gating. Pure CI-noise / minutes reduction.

Files: `check-api-docs`, `check-generated-content`, `check-helm-docs`, `check-images`, `check-jupyter`, `check-links`, `check-llm-bundle-notes`, `check-redirects`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)