### PR TITLE
ci: scope check-* workflows to PRs + v1 pushes

### DIFF
--- a/.github/workflows/check-api-docs.yml
+++ b/.github/workflows/check-api-docs.yml
@@ -1,6 +1,9 @@
 name: Check API Docs
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches: [v1]
 
 jobs:
   check-api-docs:

--- a/.github/workflows/check-generated-content.yml
+++ b/.github/workflows/check-generated-content.yml
@@ -1,6 +1,9 @@
 name: Check Generated Content
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches: [v1]
 
 jobs:
   check-generated-content:

--- a/.github/workflows/check-images.yml
+++ b/.github/workflows/check-images.yml
@@ -1,6 +1,9 @@
 name: Check Images Health
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches: [v1]
 
 jobs:
   check-images:

--- a/.github/workflows/check-jupyter.yml
+++ b/.github/workflows/check-jupyter.yml
@@ -1,6 +1,9 @@
 name: Check Jupyter Notebooks
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches: [v1]
 
 jobs:
   check-jupyter:

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,6 +1,9 @@
 name: Check Internal Links
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches: [v1]
 
 jobs:
   check-links:

--- a/.github/workflows/check-llm-bundle-notes.yml
+++ b/.github/workflows/check-llm-bundle-notes.yml
@@ -1,6 +1,9 @@
 name: Check LLM Bundle Notes
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches: [v1]
 
 jobs:
   check-llm-bundle-notes:

--- a/.github/workflows/check-redirects.yml
+++ b/.github/workflows/check-redirects.yml
@@ -1,6 +1,9 @@
 name: Check Redirects
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches: [v1]
 
 jobs:
   check-redirects:


### PR DESCRIPTION
## What

Rescope all 7 `check-*` workflows from bare `on: [push]` to:

```yaml
on:
  pull_request:
  push:
    branches: [v1]
```

## Why

`on: [push]` fires on **every push to every branch** — including throwaway feature branches with no PR open — mostly redundant with the checks that already run on the PR. This runs them on the PR (gating review) and once on `v1` after merge, and stops the feature-branch noise.

## Safety

`v1` has no branch protection, so this changes nothing about merge gating. Pure CI-noise / minutes reduction.

v1 counterpart of #1065 (main). Files: `check-api-docs`, `check-generated-content`, `check-images`, `check-jupyter`, `check-links`, `check-llm-bundle-notes`, `check-redirects` (no `check-helm-docs` on v1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)