### PR TITLE
ci: make API/Helm doc-freshness checks advisory (non-blocking)

### DIFF
--- a/.github/workflows/check-api-docs.yml
+++ b/.github/workflows/check-api-docs.yml
@@ -1,4 +1,4 @@
-name: Check API Docs
+name: "Advisory: API docs freshness"
 
 on:
   pull_request:
@@ -7,6 +7,7 @@ on:
 
 jobs:
   check-api-docs:
+    name: "API docs vs PyPI (advisory, non-blocking)"
     runs-on: ubuntu-latest
 
     steps:
@@ -23,5 +24,25 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
 
-      - name: Check API docs are up-to-date
-        run: make check-api-docs
+      # Advisory only. This compares committed API docs against the latest
+      # PyPI releases, so it can go out of date with no change to this repo.
+      # It must NOT block PRs: on drift we surface a warning + job summary
+      # and exit 0. Fix by running `make update-api-docs` in a separate
+      # regen PR. See cleanup-gha CLAUDE.md for the in-repo vs upstream-tracker
+      # distinction.
+      - name: Check API docs freshness (advisory)
+        run: |
+          if make check-api-docs; then
+            echo "API docs are up to date with the latest PyPI releases."
+          else
+            echo "::warning title=API docs lag PyPI (advisory, non-blocking)::Committed API reference docs are behind the latest PyPI releases. This does NOT block your PR and is not caused by your changes. A maintainer should run 'make update-api-docs' and open a separate regen PR."
+            {
+              echo "### ⚠️ API docs are behind upstream — advisory, non-blocking"
+              echo ""
+              echo "The committed API reference docs lag the latest \`flytekit\` / \`union\` / plugin releases on PyPI."
+              echo ""
+              echo "**This does not block your PR and is not caused by your changes.** This check tracks upstream package releases, not anything in this repository."
+              echo ""
+              echo "To resolve (maintainers): run \`make update-api-docs\` and open a separate regen PR."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/check-helm-docs.yml
+++ b/.github/workflows/check-helm-docs.yml
@@ -1,4 +1,4 @@
-name: Check Helm Docs
+name: "Advisory: Helm docs freshness"
 
 on:
   pull_request:
@@ -7,6 +7,7 @@ on:
 
 jobs:
   check-helm-docs:
+    name: "Helm docs vs helm-charts (advisory, non-blocking)"
     runs-on: ubuntu-latest
 
     steps:
@@ -23,7 +24,27 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
 
-      - name: Check Helm docs are up-to-date
+      # Advisory only. This compares the committed chart_version: frontmatter
+      # against the latest Chart.yaml in unionai/helm-charts, so it can go out
+      # of date with no change to this repo. It must NOT block PRs: on drift we
+      # surface a warning + job summary and exit 0. Fix by running
+      # `make update-helm-docs` in a separate regen PR. See cleanup-gha
+      # CLAUDE.md for the in-repo vs upstream-tracker distinction.
+      - name: Check Helm docs freshness (advisory)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: make check-helm-docs
+        run: |
+          if make check-helm-docs; then
+            echo "Helm docs are up to date with the latest helm-charts release."
+          else
+            echo "::warning title=Helm docs lag helm-charts (advisory, non-blocking)::Committed Helm chart docs are behind the latest unionai/helm-charts release. This does NOT block your PR and is not caused by your changes. A maintainer should run 'make update-helm-docs' and open a separate regen PR."
+            {
+              echo "### ⚠️ Helm docs are behind upstream — advisory, non-blocking"
+              echo ""
+              echo "The committed \`chart_version:\` frontmatter lags the latest \`Chart.yaml\` in \`unionai/helm-charts\`."
+              echo ""
+              echo "**This does not block your PR and is not caused by your changes.** This check tracks upstream chart releases, not anything in this repository."
+              echo ""
+              echo "To resolve (maintainers): run \`make update-helm-docs\` and open a separate regen PR."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
## What

Turn the two **upstream-version-tracker** checks into clearly-advisory, non-blocking checks:

- **`check-api-docs`** — compares committed API docs vs latest on **PyPI**
- **`check-helm-docs`** — compares committed chart docs vs latest `Chart.yaml` in **`unionai/helm-charts`**

Changes per workflow:
1. Rename the displayed check → `… (advisory, non-blocking)` (workflow + job `name:`).
2. On drift: emit a `::warning::` annotation + a `$GITHUB_STEP_SUMMARY` note that says it does **not** block the PR and points at the regen fix (`make update-api-docs` / `make update-helm-docs`), then **exit 0** so the check is green, not a red ✗.

## Why

Both query an external source for "latest", so they go red whenever an upstream package/chart ships — independent of anything in the PR. That reads as "you broke something / you're blocked" to contributors. They're already non-required in branch protection; this makes the intent visible and stops the false alarm.

In-repo correctness checks (`check-links`, `check-images`, `check-jupyter`, `check-redirects`, `check-generated-content`, `build-and-deploy`) are unchanged and remain blocking.

This PR: `check-api-docs` + `check-helm-docs` (main). v1 counterpart (api-docs only) in the paired PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)