### PR TITLE
ci: make API doc-freshness check advisory (non-blocking)

### DIFF
--- a/.github/workflows/check-api-docs.yml
+++ b/.github/workflows/check-api-docs.yml
@@ -1,4 +1,4 @@
-name: Check API Docs
+name: "Advisory: API docs freshness"
 
 on:
   pull_request:
@@ -7,6 +7,7 @@ on:
 
 jobs:
   check-api-docs:
+    name: "API docs vs PyPI (advisory, non-blocking)"
     runs-on: ubuntu-latest
 
     steps:
@@ -23,5 +24,25 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
 
-      - name: Check API docs are up-to-date
-        run: make check-api-docs
+      # Advisory only. This compares committed API docs against the latest
+      # PyPI releases, so it can go out of date with no change to this repo.
+      # It must NOT block PRs: on drift we surface a warning + job summary
+      # and exit 0. Fix by running `make update-api-docs` in a separate
+      # regen PR. See cleanup-gha CLAUDE.md for the in-repo vs upstream-tracker
+      # distinction.
+      - name: Check API docs freshness (advisory)
+        run: |
+          if make check-api-docs; then
+            echo "API docs are up to date with the latest PyPI releases."
+          else
+            echo "::warning title=API docs lag PyPI (advisory, non-blocking)::Committed API reference docs are behind the latest PyPI releases. This does NOT block your PR and is not caused by your changes. A maintainer should run 'make update-api-docs' and open a separate regen PR."
+            {
+              echo "### ⚠️ API docs are behind upstream — advisory, non-blocking"
+              echo ""
+              echo "The committed API reference docs lag the latest \`flytekit\` / \`union\` / plugin releases on PyPI."
+              echo ""
+              echo "**This does not block your PR and is not caused by your changes.** This check tracks upstream package releases, not anything in this repository."
+              echo ""
+              echo "To resolve (maintainers): run \`make update-api-docs\` and open a separate regen PR."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
## What

Turn `check-api-docs` (committed API docs vs latest on **PyPI**) into a clearly-advisory, non-blocking check:

1. Rename the displayed check → `API docs vs PyPI (advisory, non-blocking)`.
2. On drift: emit a `::warning::` annotation + `$GITHUB_STEP_SUMMARY` note that it does **not** block the PR and points at the regen fix (`make update-api-docs`), then **exit 0** (green, not red ✗).

## Why

It queries PyPI for "latest", so it goes red whenever an upstream package ships — independent of the PR. Already non-required in branch protection; this makes the intent visible and stops the false alarm. (v1 has no `check-helm-docs`.)

v1 counterpart of #1067 (main, which also covers `check-helm-docs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)