### PR TITLE
ci: human-readable display + job names for all workflows

### DIFF
--- a/.github/workflows/block-v1-to-main.yml
+++ b/.github/workflows/block-v1-to-main.yml
@@ -1,4 +1,4 @@
-name: block-v1-to-main
+name: Block v1 → main
 on:
   pull_request:
     branches: [main]

--- a/.github/workflows/block-v1-to-main.yml
+++ b/.github/workflows/block-v1-to-main.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   block-v1-to-main:
+    name: "Block v1 → main"
     runs-on: ubuntu-latest
     steps:
       - name: Block v1 branch from merging into main

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -50,6 +50,7 @@ concurrency:
 
 jobs:
   build-and-deploy:
+    name: "Build and deploy docs"
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/.github/workflows/check-generated-content.yml
+++ b/.github/workflows/check-generated-content.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   check-generated-content:
+    name: "Check Generated Content"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/check-images.yml
+++ b/.github/workflows/check-images.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   check-images:
+    name: "Check Images Health"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/check-jupyter.yml
+++ b/.github/workflows/check-jupyter.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   check-jupyter:
+    name: "Check Jupyter Notebooks"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   check-links:
+    name: "Check Internal Links"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/check-llm-bundle-notes.yml
+++ b/.github/workflows/check-llm-bundle-notes.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   check-llm-bundle-notes:
+    name: "Check LLM Bundle Notes"
     runs-on: ubuntu-latest
     continue-on-error: true
 

--- a/.github/workflows/check-redirects.yml
+++ b/.github/workflows/check-redirects.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   check-redirects:
+    name: "Check Redirects"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy-redirects.yml
+++ b/.github/workflows/deploy-redirects.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   deploy-redirects:
+    name: "Deploy Redirects"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/generate-helm-docs.yml
+++ b/.github/workflows/generate-helm-docs.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   generate:
+    name: "Generate Helm Docs"
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Makes every check in the Actions UI read naturally instead of showing a kebab-case tail.

Two parts:
1. **Workflow name**: `block-v1-to-main` → `Block v1 → main` (it was the only workflow whose top-level `name:` was the raw filename stem).
2. **Job names**: add `jobs.<id>.name` (= workflow name) to all 10 bare main workflows, so the check label becomes `<workflow> / <job>` instead of `<workflow> / <kebab-job-id>`.

The check label / branch-protection context is the **job name**, which falls back to the job id only when unset. Only `check-api-docs` / `check-helm-docs` had explicit job names; this brings the rest in line.

**Renames status-check contexts**, so branch protection on `main` is updated in lockstep to the new required contexts:
`Build and deploy docs`, `Check Internal Links`, `Check Redirects`, `Check Images Health`, `Check Jupyter Notebooks`, `Check Generated Content`.

v1 mirror: companion PR on the `v1` branch. No behavior change — triggers/steps untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)