### PR TITLE
ci: human-readable job names for all workflows (v1)

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -50,6 +50,7 @@ concurrency:
 
 jobs:
   build-and-deploy:
+    name: "Build and deploy docs"
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/.github/workflows/check-generated-content.yml
+++ b/.github/workflows/check-generated-content.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   check-generated-content:
+    name: "Check Generated Content"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/check-images.yml
+++ b/.github/workflows/check-images.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   check-images:
+    name: "Check Images Health"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/check-jupyter.yml
+++ b/.github/workflows/check-jupyter.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   check-jupyter:
+    name: "Check Jupyter Notebooks"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   check-links:
+    name: "Check Internal Links"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/check-llm-bundle-notes.yml
+++ b/.github/workflows/check-llm-bundle-notes.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   check-llm-bundle-notes:
+    name: "Check LLM Bundle Notes"
     runs-on: ubuntu-latest
     continue-on-error: true
 

--- a/.github/workflows/check-redirects.yml
+++ b/.github/workflows/check-redirects.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   check-redirects:
+    name: "Check Redirects"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy-redirects.yml
+++ b/.github/workflows/deploy-redirects.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   deploy-redirects:
+    name: "Deploy Redirects"
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
v1 mirror of #1070. Adds `jobs.<id>.name` (= workflow name) to the 8 bare v1 workflows so every check renders as **`<workflow> / <job>`** instead of a kebab tail (`check-links` → `Check Internal Links`, etc.).

**Renames status-check contexts**, so branch protection on `v1` is updated in lockstep to the new required contexts:
`Build and deploy docs`, `Check Internal Links`, `Check Redirects`, `Check Images Health`, `Check Jupyter Notebooks`, `Check Generated Content`.

No behavior change — triggers/steps untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)