### PR TITLE
add flyte agents docs

### DIFF
--- a/content/user-guide/_index.md
+++ b/content/user-guide/_index.md
@@ -101,7 +101,7 @@ Define `AppEnvironment`s with ports, autoscaling, custom domains, and authentica
 Build dashboards, REST APIs, and model endpoints with FastAPI, Streamlit, vLLM, and more.
 {{< /link-card >}}
 
-{{< link-card target="native-app-integrations" icon="code" title="Native app integrations" >}}
+{{< link-card target="native-app-integrations" icon="plugin" title="Native app integrations" >}}
 Use pre-built environments for popular frameworks like Streamlit, FastAPI, vLLM, and SGLang.
 {{< /link-card >}}
 
@@ -119,6 +119,10 @@ Build durable, self-healing agents using tasks and apps as building blocks.
 
 {{< link-card target="build-agent" icon="robot" title="Build agents" >}}
 Implement ReAct, Plan-and-Execute, and other agent patterns with full observability.
+{{< /link-card >}}
+
+{{< link-card target="agent-framework-integrations" icon="plugin" title="Agent framework integrations" >}}
+Integrate with third-party agent frameworks like LangGraph, PydanticAI, and OpenAI Agents SDK.
 {{< /link-card >}}
 
 {{< link-card target="sandboxing" icon="box" title="Sandboxing" >}}

--- a/content/user-guide/agent-framework-integrations/_index.md
+++ b/content/user-guide/agent-framework-integrations/_index.md
@@ -33,7 +33,7 @@ Whichever model your framework uses, the integration is the same in spirit: the 
 - [**PydanticAI**](./pydantic-ai) — type-safe agents whose tools delegate to durable tasks.
 - [**OpenAI Agents SDK**](./openai-agents-sdk) — expose durable tasks as Agents SDK tools with `flyteplugins-openai`.
 
-Don't see your framework? The same pattern — invoke the framework from inside an `@env.task` and trace its calls — applies to any Python agent library.
+Don't see your framework? The same pattern — invoke the framework from inside an `@env.task` and trace its calls — applies to any Python agent library. See [Bring your own framework](./bring-your-own-framework) for a framework-agnostic template.
 
 ## Next steps
 

--- a/content/user-guide/agent-framework-integrations/_index.md
+++ b/content/user-guide/agent-framework-integrations/_index.md
@@ -1,0 +1,42 @@
+---
+title: Agent framework integrations
+weight: 19
+variants: +flyte +serverless +union
+sidebar_expanded: true
+---
+
+# Agent framework integrations
+
+**Any Python-based agent framework works with {{< key product_name >}}.** {{< key product_name >}} doesn't replace your framework — it provides the production layer around it. You write your agent with whatever framework you prefer, then invoke it from inside an `@env.task`, where it runs in a sandboxed container with durable checkpointing and full observability. Each LLM call, tool call, and routing decision can be captured as a span in the {{< key product_name >}} dashboard.
+
+Because the framework drives the loop and {{< key product_name >}} wraps it, you don't need a dedicated plugin for a framework to use it — if it runs in Python, it runs on {{< key product_name >}}.
+
+{{< note >}}
+The `flyte` SDK provides a [native agent harness](../build-agent/flyte-agents) that you can use to build your own agent loop.
+{{< /note >}}
+
+## How much control does the framework give you?
+
+Frameworks differ in how much of the agent loop they own, which determines how you integrate them with {{< key product_name >}}:
+
+| Level of control | What it means | Example | Integration pattern |
+|------------------|---------------|---------|---------------------|
+| **You own the loop** | The framework gives you primitives (graph nodes, tools) and you wire the control flow | [LangGraph](./langgraph) | Decorate nodes with `@flyte.trace`; run the compiled graph inside a task |
+| **The framework owns the loop, you own the tools** | The framework runs the tool-calling loop; you provide tools as plain functions | [PydanticAI](./pydantic-ai) | Have tools delegate to durable `@env.task`s |
+| **First-party tool adapter** | {{< key product_name >}} ships a decorator that turns a task into a framework tool | [OpenAI Agents SDK](./openai-agents-sdk) | Stack `function_tool` on `@env.task` |
+
+Whichever model your framework uses, the integration is the same in spirit: the framework decides *what* the agent does next, and {{< key product_name >}} decides *where and how durably* each step runs.
+
+## Supported frameworks
+
+- [**LangGraph**](./langgraph) — run compiled graphs inside tasks and fan them out in parallel.
+- [**PydanticAI**](./pydantic-ai) — type-safe agents whose tools delegate to durable tasks.
+- [**OpenAI Agents SDK**](./openai-agents-sdk) — expose durable tasks as Agents SDK tools with `flyteplugins-openai`.
+
+Don't see your framework? The same pattern — invoke the framework from inside an `@env.task` and trace its calls — applies to any Python agent library.
+
+## Next steps
+
+- [Deploy an agent as a service](../build-agent/deploy-agent-as-service): run your agent on a schedule or behind a webhook.
+- [Build an agent with pure Python](../build-agent/python-agents): roll the loop yourself with no framework at all.
+- [The Flyte Agent harness](../build-agent/flyte-agents): the built-in, batteries-included agent loop.

--- a/content/user-guide/agent-framework-integrations/_index.md
+++ b/content/user-guide/agent-framework-integrations/_index.md
@@ -7,7 +7,7 @@ sidebar_expanded: false
 
 # Agent framework integrations
 
-**Any Python-based agent framework works with {{< key product_name >}}.** {{< key product_name >}} doesn't replace your framework — it provides the production layer around it. You write your agent with whatever framework you prefer, then invoke it from inside an `@env.task`, where it runs in a sandboxed container with durable checkpointing and full observability. Each LLM call, tool call, and routing decision can be captured as a span in the {{< key product_name >}} dashboard.
+**Any Python-based agent framework works with {{< key product_name >}}.** {{< key product_name >}} doesn't replace your framework — it provides the production layer around it. You write your agent with whatever framework you prefer, then invoke it from inside an `@env.task`, where it runs in a container with durable checkpointing and full observability. Each LLM call, tool call, and routing decision can be captured as a span in the {{< key product_name >}} dashboard.
 
 Because the framework drives the loop and {{< key product_name >}} wraps it, you don't need a dedicated plugin for a framework to use it — if it runs in Python, it runs on {{< key product_name >}}.
 

--- a/content/user-guide/agent-framework-integrations/_index.md
+++ b/content/user-guide/agent-framework-integrations/_index.md
@@ -2,7 +2,7 @@
 title: Agent framework integrations
 weight: 19
 variants: +flyte +serverless +union
-sidebar_expanded: true
+sidebar_expanded: false
 ---
 
 # Agent framework integrations

--- a/content/user-guide/agent-framework-integrations/bring-your-own-framework.md
+++ b/content/user-guide/agent-framework-integrations/bring-your-own-framework.md
@@ -13,7 +13,7 @@ This page is a framework-agnostic template. Drop in any library — [CrewAI](htt
 
 ## The core pattern
 
-Put your framework's agent invocation inside an `@env.task`. The task gives you a sandboxed container, durable inputs/outputs, retries, and a span in the dashboard. Everything inside the task is ordinary Python, so the framework behaves exactly as it does locally.
+Put your framework's agent invocation inside an `@env.task`. The task gives you a container, durable inputs/outputs, retries, and a span in the dashboard. Everything inside the task is ordinary Python, so the framework behaves exactly as it does locally.
 
 ```python
 import flyte
@@ -120,7 +120,7 @@ async def run_one(task_input: str) -> str:
 
 @env.task
 async def run_many(inputs: list[str]) -> list[str]:
-    # Each run_one call lands in its own sandboxed container.
+    # Each run_one call lands in its own container.
     results = await asyncio.gather(*[run_one(i) for i in inputs])
     return list(results)
 ```

--- a/content/user-guide/agent-framework-integrations/bring-your-own-framework.md
+++ b/content/user-guide/agent-framework-integrations/bring-your-own-framework.md
@@ -1,0 +1,143 @@
+---
+title: Bring your own framework
+weight: 4
+variants: +flyte +serverless +union
+mermaid: true
+---
+
+# Bring your own framework
+
+The dedicated pages ([LangGraph](./langgraph), [PydanticAI](./pydantic-ai), [OpenAI Agents SDK](./openai-agents-sdk)) are just worked examples of one underlying idea: **{{< key product_name >}} is the runtime, your framework is the loop.** If your agent library is written in Python, it runs on {{< key product_name >}} with no special plugin.
+
+This page is a framework-agnostic template. Drop in any library — [CrewAI](https://docs.crewai.com/), [AutoGen](https://microsoft.github.io/autogen/), [smolagents](https://github.com/huggingface/smolagents), [Atomic Agents](https://github.com/BrainBlend-AI/atomic-agents), a raw provider SDK, or your own homegrown loop — wherever the comments say so.
+
+## The core pattern
+
+Put your framework's agent invocation inside an `@env.task`. The task gives you a sandboxed container, durable inputs/outputs, retries, and a span in the dashboard. Everything inside the task is ordinary Python, so the framework behaves exactly as it does locally.
+
+```python
+import flyte
+
+# 1. Declare the runtime: image (with YOUR framework's deps), resources, secrets.
+env = flyte.TaskEnvironment(
+    name="my-agent",
+    image=flyte.Image.from_debian_base(python_version=(3, 13)).with_pip_packages(
+        # --> your agent framework + its provider packages go here, e.g.:
+        # "crewai", "smolagents", "autogen-agentchat", ...
+    ),
+    resources=flyte.Resources(cpu=1, memory="1Gi"),
+    secrets=[flyte.Secret(key="ANTHROPIC_API_KEY")],  # --> your model provider key(s)
+)
+
+
+@env.task(report=True)
+async def run_agent(prompt: str) -> str:
+    # 2. Build/configure your framework's agent exactly as you would locally.
+    #    --> your framework setup goes here
+    # agent = MyFramework.Agent(model=..., tools=[...], instructions=...)
+
+    # 3. Run it. Use the framework's own (sync or async) entry point.
+    #    --> invoke your framework here
+    # result = await agent.run(prompt)
+
+    # 4. Return a serializable value (str, pydantic model, dataclass, ...).
+    # return result.output
+    ...
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(run_agent, prompt="...")  # --> your prompt / inputs
+    print(run.url)
+```
+
+That is the whole integration. The remaining sections are optional enhancements that make the framework more durable and observable.
+
+## Make tools durable
+
+Most frameworks let a tool be any Python callable. To make a tool durable, retryable, and independently observable, have the framework's tool delegate to an `@env.task`. The framework still "owns" the tool; the heavy lifting runs on-cluster.
+
+```python
+# A durable task that does the real work (IO, compute, external calls).
+@env.task
+async def fetch_data(source: str) -> dict:
+    # --> your real tool implementation (API call, DB query, scrape, ...)
+    ...
+
+
+# Register it with your framework using whatever tool API it exposes.
+# The body just awaits the durable task.
+#
+#   @my_framework.tool                  # --> your framework's tool decorator/registration
+#   async def get_data(source: str) -> dict:
+#       """Tool description the LLM sees."""
+#       return await fetch_data(source)   # runs as a Flyte task, durable + traced
+```
+
+> [!TIP]
+> Reach for an `@env.task` when a tool does real work you want retried, cached, or run on its own hardware (GPU, more memory). For lightweight in-process helpers, a plain `@flyte.trace` function (below) is enough.
+
+## Trace the framework's internals
+
+If your framework exposes hooks, callbacks, or lets you wrap its node/step functions, decorate those with `@flyte.trace` to turn each LLM call, tool call, and routing decision into a span — with inputs and outputs captured and checkpointed.
+
+```python
+@flyte.trace
+async def call_model(messages: list[dict]) -> str:
+    # --> wrap the framework's model call (or pass this as the framework's LLM hook)
+    ...
+
+
+@flyte.trace
+async def route(state) -> str:
+    # --> wrap a routing / decision function so the branch is visible in the dashboard
+    ...
+```
+
+For frameworks that don't expose hooks, wrap the whole run in `flyte.group(...)` to keep its trace tidy:
+
+```python
+@env.task(report=True)
+async def run_agent(prompt: str) -> str:
+    with flyte.group("my-framework-run"):  # groups everything below under one span
+        # --> your framework invocation
+        ...
+```
+
+## Fan out across containers
+
+Run many independent agents in parallel — each in its own container — with `asyncio.gather()`. This works for any framework because each call is just an awaited task.
+
+```python
+import asyncio
+
+
+@env.task
+async def run_one(task_input: str) -> str:
+    # --> one self-contained agent run for a single input
+    ...
+
+
+@env.task
+async def run_many(inputs: list[str]) -> list[str]:
+    # Each run_one call lands in its own sandboxed container.
+    results = await asyncio.gather(*[run_one(i) for i in inputs])
+    return list(results)
+```
+
+## Checklist
+
+To bring any Python agent framework onto {{< key product_name >}}:
+
+1. **Wrap the run** — call the framework's entry point inside an `@env.task`.
+2. **Declare deps** — add the framework + provider packages to the task's `image`.
+3. **Supply secrets** — mount model-provider API keys via `flyte.Secret`.
+4. **(Optional) Durable tools** — have tools delegate to `@env.task`s.
+5. **(Optional) Observe** — decorate hooks/steps with `@flyte.trace`, or wrap in `flyte.group(...)`.
+6. **(Optional) Scale** — fan out with `asyncio.gather()` for parallel, per-container runs.
+
+## Next steps
+
+- [Deploy an agent as a service](../build-agent/deploy-agent-as-service): run your agent on a schedule or behind a webhook.
+- [The Flyte Agent harness](../build-agent/flyte-agents): a built-in, batteries-included loop if you'd rather not bring a framework.
+- [Build an agent with pure Python](../build-agent/python-agents): hand-roll the loop with no framework at all.

--- a/content/user-guide/agent-framework-integrations/langgraph.md
+++ b/content/user-guide/agent-framework-integrations/langgraph.md
@@ -115,7 +115,7 @@ research_workflow (orchestrator)
   └── synthesize    → LLM combines reports into final answer      [container 5]
 ```
 
-- **Fan-out:** `asyncio.gather()` launches all research tasks in parallel, each in its own sandboxed container.
+- **Fan-out:** `asyncio.gather()` launches all research tasks in parallel, each in its own container.
 - **Tool calling inside each graph:** The LangGraph agent calls Tavily web search, observes results, reasons, and loops until done.
 - **Observability:** `@flyte.trace` on the LangGraph nodes makes every LLM call, tool call, and routing decision visible as a span.
 - **Durable checkpointing:** Each task's output is persisted. If `synthesize` fails, re-running skips completed steps (with caching enabled).

--- a/content/user-guide/agent-framework-integrations/langgraph.md
+++ b/content/user-guide/agent-framework-integrations/langgraph.md
@@ -1,0 +1,126 @@
+---
+title: LangGraph agents
+weight: 1
+variants: +flyte +serverless +union
+mermaid: true
+---
+
+# LangGraph agents
+
+If you already build agents with [LangGraph](https://langchain-ai.github.io/langgraph/), you can run them on {{< key product_name >}} unchanged. {{< key product_name >}} doesn't replace your graph — it provides the production layer around it: each graph runs inside a sandboxed `@env.task` container, and you can fan out many graphs in parallel, one container each.
+
+The pattern is: define your LangGraph graph as you normally would, then invoke it from inside a task. Decorate the graph's nodes with `@flyte.trace` so each LLM call, tool call, and routing decision shows up as a span in the {{< key product_name >}} dashboard.
+
+## A single LangGraph agent in a task
+
+Put your graph behind an `@env.task`. The `langgraph` and `langchain` dependencies live in the task's image, isolated from the rest of your project:
+
+{{< code file="/unionai-examples/v2/user-guide/build-agent/frameworks/langgraph_agent.py" fragment="all" lang="python" >}}
+
+## Plan-and-Execute: fan out LangGraph agents in parallel
+
+A common production pattern is to plan a set of sub-topics, run a LangGraph research agent on each in parallel, then synthesize. {{< key product_name >}} handles the parallelization — each `research` call gets its own container via `asyncio.gather()`.
+
+First, the graph (`graph.py`), a LangGraph agent with web-search tool calling:
+
+```python
+import flyte
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import SystemMessage
+from langgraph.graph import StateGraph, MessagesState
+from langgraph.prebuilt import ToolNode
+from langchain_community.tools.tavily_search import TavilySearchResults
+
+def build_research_graph(openai_key: str, tavily_key: str):
+    tools = [TavilySearchResults(max_results=2, tavily_api_key=tavily_key)]
+    llm = ChatOpenAI(model="gpt-4.1-nano", api_key=openai_key).bind_tools(tools)
+
+    @flyte.trace
+    async def agent(state: MessagesState):
+        msgs = [SystemMessage(content="Research the topic. Use search, then summarize.")] + state["messages"]
+        return {"messages": [await llm.ainvoke(msgs)]}
+
+    @flyte.trace
+    async def route(state: MessagesState):
+        last = state["messages"][-1]
+        return "tools" if getattr(last, "tool_calls", None) else "__end__"
+
+    g = StateGraph(MessagesState)
+    g.add_node("agent", agent)
+    g.add_node("tools", ToolNode(tools))
+    g.set_entry_point("agent")
+    g.add_conditional_edges("agent", route, {"tools": "tools", "__end__": "__end__"})
+    g.add_edge("tools", "agent")
+    return g.compile()
+```
+
+Then the workflow (`workflow.py`), which plans, fans out, and synthesizes:
+
+```python
+import os, json, asyncio, flyte
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
+from graph import build_research_graph
+
+env = flyte.TaskEnvironment(
+    name="research_env",
+    image=flyte.Image.from_debian_base(python_version=(3, 13))
+        .with_pip_packages("openai", "langchain-openai", "langchain-community", "langgraph", "tavily-python"),
+    resources=flyte.Resources(cpu=2, memory="2Gi"),
+    secrets=[flyte.Secret(key="OPENAI_API_KEY"), flyte.Secret(key="TAVILY_API_KEY")],
+)
+
+@env.task
+async def plan(query: str, n: int = 3) -> list[str]:
+    """Split query into sub-topics."""
+    r = await ChatOpenAI(model="gpt-4.1-nano", api_key=os.environ["OPENAI_API_KEY"]).ainvoke(
+        f'Break into exactly {n} sub-topics. Return ONLY a JSON array of strings.\n\n{query}')
+    return json.loads(r.content)[:n]
+
+@env.task
+async def research(topic: str) -> str:
+    """Run the LangGraph agent on one topic (each call = its own container)."""
+    graph = build_research_graph(os.environ["OPENAI_API_KEY"], os.environ["TAVILY_API_KEY"])
+    result = await graph.ainvoke({"messages": [HumanMessage(content=f"Research: {topic}")]})
+    return json.dumps({"topic": topic, "report": result["messages"][-1].content})
+
+@env.task
+async def synthesize(query: str, reports: list[str]) -> str:
+    """Combine sub-reports into a final summary."""
+    parsed = [json.loads(r) for r in reports]
+    sections = "\n\n".join(f"## {r['topic']}\n{r['report']}" for r in parsed)
+    r = await ChatOpenAI(model="gpt-4.1-nano", api_key=os.environ["OPENAI_API_KEY"]).ainvoke(
+        f"Synthesize reports on: {query}\n\n{sections}\n\nKey takeaways:")
+    return r.content
+
+@env.task
+async def research_workflow(query: str, num_topics: int = 3) -> str:
+    topics = await plan(query, num_topics)
+    reports = list(await asyncio.gather(*[research(t) for t in topics]))  # parallel fan-out
+    return await synthesize(query, reports)
+```
+
+```bash
+flyte run workflow.py research_workflow --query "Impact of storms on travel insurance payouts"
+```
+
+**What's happening under the hood:**
+
+```
+research_workflow (orchestrator)
+  ├── plan          → LLM breaks query into N sub-topics          [container 1]
+  ├── research(t1)  → LangGraph agent loop with web search tools  [container 2]  ┐
+  ├── research(t2)  → LangGraph agent loop with web search tools  [container 3]  ├ parallel
+  ├── research(t3)  → LangGraph agent loop with web search tools  [container 4]  ┘
+  └── synthesize    → LLM combines reports into final answer      [container 5]
+```
+
+- **Fan-out:** `asyncio.gather()` launches all research tasks in parallel, each in its own sandboxed container.
+- **Tool calling inside each graph:** The LangGraph agent calls Tavily web search, observes results, reasons, and loops until done.
+- **Observability:** `@flyte.trace` on the LangGraph nodes makes every LLM call, tool call, and routing decision visible as a span.
+- **Durable checkpointing:** Each task's output is persisted. If `synthesize` fails, re-running skips completed steps (with caching enabled).
+
+## Next steps
+
+- [Deploy an agent as a service](../build-agent/deploy-agent-as-service): run your LangGraph agent on a schedule or behind a webhook.
+- [PydanticAI](./pydantic-ai) and [OpenAI Agents SDK](./openai-agents-sdk): the same pattern for other frameworks.

--- a/content/user-guide/agent-framework-integrations/openai-agents-sdk.md
+++ b/content/user-guide/agent-framework-integrations/openai-agents-sdk.md
@@ -1,0 +1,29 @@
+---
+title: OpenAI agents
+weight: 3
+variants: +flyte +serverless +union
+mermaid: true
+---
+
+# OpenAI agents
+
+The [OpenAI Agents SDK](https://openai.github.io/openai-agents-python/) is a lightweight framework for building multi-tool, multi-agent applications. {{< key product_name >}} ships a first-party integration, `flyteplugins-openai`, that lets you expose durable Flyte tasks as Agents SDK tools with a single decorator.
+
+The integration provides `function_tool` from `flyteplugins.openai.agents`. Stack it on top of `@env.task` and the resulting object is both a durable Flyte task and an OpenAI Agents SDK tool. When the agent calls the tool, it executes on-cluster — durable, retryable, and observable in the dashboard.
+
+## Tools that are also durable tasks
+
+Each tool below is a Flyte task wrapped as an Agents SDK tool. The `agent` task builds an Agents SDK `Agent`, hands it the tools, and runs it with `Runner.run`:
+
+{{< code file="/unionai-examples/v2/user-guide/build-agent/frameworks/openai_agents_agent.py" fragment="all" lang="python" >}}
+
+**What's happening under the hood:**
+
+- `@function_tool` (from `flyteplugins.openai.agents`) adapts the durable `@env.task` into an OpenAI Agents SDK tool, so the agent can call it through the SDK's normal tool-calling mechanism.
+- Each tool call executes as a Flyte task on the cluster — durable and observable — even though the agent loop itself orchestrates them.
+- `flyte.group(...)` groups each agent's tool calls under a named span, and `asyncio.gather()` fans out the per-goal agents in parallel, each in its own container.
+
+## Next steps
+
+- [Deploy an agent as a service](../build-agent/deploy-agent-as-service): run your Agents SDK agent on a schedule or behind a webhook.
+- [LangGraph](./langgraph) and [PydanticAI](./pydantic-ai): the same pattern for other frameworks.

--- a/content/user-guide/agent-framework-integrations/pydantic-ai.md
+++ b/content/user-guide/agent-framework-integrations/pydantic-ai.md
@@ -7,7 +7,7 @@ mermaid: true
 
 # PydanticAI agents
 
-[PydanticAI](https://ai.pydantic.dev/) is a type-safe agent framework from the Pydantic team. As with any Python agent framework, you run a PydanticAI agent on {{< key product_name >}} by invoking it from inside an `@env.task` — the framework drives the loop, while {{< key product_name >}} gives you a sandboxed container, durable checkpointing, and observability.
+[PydanticAI](https://ai.pydantic.dev/) is a type-safe agent framework from the Pydantic team. As with any Python agent framework, you run a PydanticAI agent on {{< key product_name >}} by invoking it from inside an `@env.task` — the framework drives the loop, while {{< key product_name >}} gives you a container, durable checkpointing, and observability.
 
 The key integration point: PydanticAI tools are just Python functions, so a tool can delegate to a durable `@env.task`. That gives you the best of both worlds — PydanticAI's typed tool-calling and {{< key product_name >}}'s durable, observable, on-cluster tool execution.
 
@@ -19,7 +19,7 @@ Define a PydanticAI [Agent](https://pydantic.dev/docs/ai/api/pydantic-ai/agent/#
 
 **What's happening under the hood:**
 
-- `run_agent` runs in a sandboxed container with only `pydantic-ai-slim` installed.
+- `run_agent` runs in a container with only `pydantic-ai-slim` installed.
 - PydanticAI drives its own typed tool-call loop. Each tool delegates to an `@env.task`, so `fetch_weather` and `add` execute durably on the cluster and appear in the {{< key product_name >}} dashboard.
 - `flyte.group("pydantic-ai-run")` groups the loop's tool calls under one span for readability.
 - The task's input prompt and final output are durably persisted for end-to-end inspection.

--- a/content/user-guide/agent-framework-integrations/pydantic-ai.md
+++ b/content/user-guide/agent-framework-integrations/pydantic-ai.md
@@ -1,0 +1,47 @@
+---
+title: PydanticAI agents
+weight: 2
+variants: +flyte +serverless +union
+mermaid: true
+---
+
+# PydanticAI agents
+
+[PydanticAI](https://ai.pydantic.dev/) is a type-safe agent framework from the Pydantic team. As with any Python agent framework, you run a PydanticAI agent on {{< key product_name >}} by invoking it from inside an `@env.task` — the framework drives the loop, while {{< key product_name >}} gives you a sandboxed container, durable checkpointing, and observability.
+
+The key integration point: PydanticAI tools are just Python functions, so a tool can delegate to a durable `@env.task`. That gives you the best of both worlds — PydanticAI's typed tool-calling and {{< key product_name >}}'s durable, observable, on-cluster tool execution.
+
+## A PydanticAI agent in a task
+
+Define a PydanticAI [Agent](https://pydantic.dev/docs/ai/api/pydantic-ai/agent/#pydantic_ai.agent.Agent), register tools that call your durable Flyte tasks, and run it from an `@env.task`:
+
+{{< code file="/unionai-examples/v2/user-guide/build-agent/frameworks/pydantic_ai_agent.py" fragment="all" lang="python" >}}
+
+**What's happening under the hood:**
+
+- `run_agent` runs in a sandboxed container with only `pydantic-ai-slim` installed.
+- PydanticAI drives its own typed tool-call loop. Each tool delegates to an `@env.task`, so `fetch_weather` and `add` execute durably on the cluster and appear in the {{< key product_name >}} dashboard.
+- `flyte.group("pydantic-ai-run")` groups the loop's tool calls under one span for readability.
+- The task's input prompt and final output are durably persisted for end-to-end inspection.
+
+> [!TIP]
+> For lighter, in-process tools you don't need to promote to tasks, decorate them with `@flyte.trace` instead of `@env.task` to still capture them as spans.
+
+## Parallel agents
+
+To run many PydanticAI agents concurrently — each in its own container — fan out with `asyncio.gather()`:
+
+```python
+import asyncio
+
+
+@env.task
+async def run_many(prompts: list[str]) -> list[str]:
+    results = await asyncio.gather(*[run_agent(p) for p in prompts])
+    return list(results)
+```
+
+## Next steps
+
+- [Deploy an agent as a service](../build-agent/deploy-agent-as-service): run your PydanticAI agent on a schedule or behind a webhook.
+- [LangGraph](./langgraph) and [OpenAI Agents SDK](./openai-agents-sdk): the same pattern for other frameworks.

--- a/content/user-guide/authenticating.md
+++ b/content/user-guide/authenticating.md
@@ -1,6 +1,6 @@
 ---
 title: Authenticating
-weight: 20
+weight: 30
 variants: -flyte +union
 ---
 

--- a/content/user-guide/build-agent/_index.md
+++ b/content/user-guide/build-agent/_index.md
@@ -10,11 +10,16 @@ llm_readable_bundle: true
 
 {{< llm-bundle-note >}}
 
-This section covers how to build, deploy, and run agentic AI applications on {{< key product_name >}}. You'll learn how to implement common agent patterns like ReAct and Plan-and-Execute and deploy agents as hosted services.
+This section covers how to build, deploy, and run agentic AI applications on {{< key product_name >}}.
 
-## Quickstart
+Building an agent on {{< key product_name >}} breaks down into two **orthogonal** choices:
 
-Here's how {{< key product_name >}} maps to the agentic world:
+1. **How you build the agent loop** — plain Python, the built-in `flyte.ai.agents.Agent` harness, or a third-party framework (LangGraph, PydanticAI, OpenAI Agents SDK).
+2. **How you deploy and run it** — as a task you invoke on demand, as a scheduled task driven by a `flyte.Trigger`, or as a long-running app (e.g. a webhook or chat UI).
+
+Any agent from axis (1) can be deployed via any pattern in axis (2). The two are independent, so you can start with a pure-Python loop run on demand and later move it behind a schedule or a webhook without rewriting the agent.
+
+## How {{< key product_name >}} maps to the agentic world
 
 - **`TaskEnvironment`**: The sandboxed execution environment for your agent steps. It configures the container image, hardware resources (CPU, GPU), and secrets (API keys). Think of it as defining "where this code runs."
 - **`@env.task`**: Turns any Python function into a remotely-executed step. Each task runs in its own container with the resources you specified. This is the equivalent of a node in LangGraph or n8n.
@@ -24,8 +29,25 @@ Here's how {{< key product_name >}} maps to the agentic world:
 > [!TIP]
 > See the [{{< key product_name >}} Quickstart](../quickstart) for a hands-on walkthrough.
 
-## Next steps
+## Ways to build an agent
 
-- [**Deploy an agent as a service**](./deploy-agent-as-service): Host a FastAPI app, webhook pattern, model serving
-- [**Building agents on {{< key product_name >}}**](./building-agents): ReAct pattern, Plan-and-Execute with fan-out, LangGraph integration, and more patterns
-- [**Build an MCP server**](../build-mcp/_index): Serve Model Context Protocol servers for AI assistants to interact with Flyte
+| Approach | When to use it | Guide |
+|----------|----------------|-------|
+| **Pure Python** | You want full control over the loop and the lightest possible dependency footprint | [Build an agent with pure Python](./python-agents) |
+| **The `Agent` harness** | You want a batteries-included tool-use loop with tools, MCP servers, memory, and HITL built in | [The Flyte Agent harness](./flyte-agents) |
+| **Third-party frameworks** | You already have agents written with LangGraph, PydanticAI, or the OpenAI Agents SDK | [Agent framework integrations](../agent-framework-integrations/_index) |
+
+The `Agent` harness has a few dedicated guides of its own:
+
+- [**Extend the Agent class**](./flyte-agents#extending-the-agent-class): customize the loop by overriding `run`.
+- [**Agent memory**](./agent-memory): persist conversation history and artifacts across runs with `MemoryStore`.
+- [**Add a chat UI**](./agent-chat-ui): give any agent a hosted chat interface.
+
+## Deploying an agent
+
+Once you've built an agent, [**Deploy an agent as a service**](./deploy-agent-as-service) covers running it as a task, on a schedule via `flyte.Trigger`, and behind an `AppEnvironment` webhook.
+
+## Related
+
+- [**Sandboxing**](../sandboxing/_index): safely execute LLM-generated code.
+- [**Build an MCP server**](../build-mcp/_index): serve Model Context Protocol servers for AI assistants to interact with {{< key product_name >}}.

--- a/content/user-guide/build-agent/agent-chat-ui.md
+++ b/content/user-guide/build-agent/agent-chat-ui.md
@@ -1,0 +1,126 @@
+---
+title: Agent chat UI
+weight: 5
+variants: +flyte +serverless +union
+mermaid: true
+---
+
+# Agent chat UI
+
+A useful way to interact with an agent is through a chat interface. Because {{< key product_name >}} can [host apps](../build-apps/_index) behind a URL, you can serve a chat UI for your agent with no separate infrastructure. There are two approaches:
+
+1. **`AgentChatAppEnvironment`** — the fastest path. Any agent that implements the `AgentProtocol` (including the built-in `Agent` and `CodeModeAgent`) gets a hosted chat shell, tool sidebar, and streaming for free.
+2. **A custom FastAPI app** — full control over the UI. Wrap the agent in a `FastAPIAppEnvironment` and serve your own HTML/CSS/JS.
+
+Both reuse the same agent object, so you can start with the built-in shell and graduate to a custom UI later.
+
+## Option 1: the built-in chat UI
+
+`flyte.ai.chat.AgentChatAppEnvironment` wraps an agent in a hosted chat app. Since `Agent` implements the `AgentProtocol`, it plugs straight in:
+
+{{< code file="/unionai-examples/v2/user-guide/build-agent/agent-chat-ui/agent_chat_ui.py" fragment="all" lang="python" >}}
+
+The `task_entrypoint` is a parent task that owns the agent loop, so the nested durable tool tasks run correctly under it. The chat shell streams progress by subscribing to the agent's `agent_progress_cb` events.
+
+## Option 2: a custom FastAPI chat app
+
+When you want to control the look and feel, wrap any `AgentProtocol`-compatible agent in a `FastAPIAppEnvironment` and serve your own UI. This is the pattern used by the `CodeModeAgent` chat app: a single LLM call generates Python code, runs it in a [sandbox](../sandboxing/_index), and returns charts + a summary, all behind a conversational web interface.
+
+The architecture is small:
+
+```
+Browser (Chat UI)
+  ├── GET  /            -> embedded HTML/CSS/JS chat interface
+  ├── GET  /api/tools   -> JSON list of available tool descriptions
+  └── POST /api/chat    -> { message, history } -> { code, charts, summary, error }
+           └── CodeModeAgent.run(message, history)
+```
+
+The app itself is just a FastAPI server. The endpoints call the agent's `run.aio` and `tool_descriptions` methods:
+
+```python
+import pathlib
+
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
+from pydantic import BaseModel
+
+import flyte
+from flyte.ai.agents import CodeModeAgent
+from flyte.app.extras import FastAPIAppEnvironment
+
+app = FastAPI(title="Chat Data Analytics Agent")
+
+env = FastAPIAppEnvironment(
+    name="chat-analytics-agent",
+    app=app,
+    image=flyte.Image.from_debian_base().with_pip_packages(
+        "fastapi", "uvicorn", "httpx", "pydantic-monty", "litellm",
+    ),
+    secrets=flyte.Secret(key="internal-anthropic-api-key", as_env_var="ANTHROPIC_API_KEY"),
+    scaling=flyte.app.Scaling(replicas=1),
+)
+
+agent = CodeModeAgent(tools=ALL_TOOLS, max_retries=2)
+
+
+class ChatRequest(BaseModel):
+    message: str
+    history: list[dict] = []
+
+
+class ChatResponse(BaseModel):
+    code: str = ""
+    charts: list[str] = []
+    summary: str = ""
+    error: str = ""
+
+
+@app.get("/api/tools")
+async def get_tools() -> list[dict]:
+    """Return JSON descriptions of available tool functions (for the sidebar)."""
+    return agent.tool_descriptions()
+
+
+@app.post("/api/chat")
+async def chat(req: ChatRequest) -> ChatResponse:
+    """Generate code, run it in the sandbox, and return results."""
+    result = await agent.run.aio(req.message, req.history)
+    return ChatResponse(code=result.code, charts=result.charts,
+                        summary=result.summary, error=result.error)
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index() -> HTMLResponse:
+    """Serve the embedded chat UI."""
+    return HTMLResponse(content=CHAT_HTML)
+
+
+if __name__ == "__main__":
+    flyte.init_from_config(root_dir=pathlib.Path(__file__).parent)
+    app_handle = flyte.serve(env)
+    print(f"Deployed Chat Analytics Agent: {app_handle.url}")
+```
+
+`CHAT_HTML` is the embedded front-end (a single HTML string with the chat markup, styles, and a small fetch-based client that POSTs to `/api/chat` and renders the returned charts and summary). `ALL_TOOLS` is the agent's tool registry. Keeping both in their own modules means adding a tool is the only change required — the agent auto-generates its system prompt from each tool's signature and docstring.
+
+Run it locally during development, then deploy with one command:
+
+```bash
+# Local development
+python chat_app.py
+
+# Deploy to {{< key product_name >}}
+flyte deploy chat_app.py env
+```
+
+{{< key product_name >}} assigns a URL, handles TLS, and auto-scales the app.
+
+> [!TIP]
+> Swap `CodeModeAgent` for the [`Agent` harness](./flyte-agents) (or any object implementing the `AgentProtocol`) to serve a tool-use agent behind the same UI. The endpoints only depend on `run.aio` and `tool_descriptions`.
+
+## Next steps
+
+- [The Flyte Agent harness](./flyte-agents): the agent powering the chat UI.
+- [Sandboxing](../sandboxing/_index): how `CodeModeAgent` safely executes generated code.
+- [Deploy an agent as a service](./deploy-agent-as-service): other ways to run an agent (task, schedule, webhook).

--- a/content/user-guide/build-agent/agent-memory.md
+++ b/content/user-guide/build-agent/agent-memory.md
@@ -1,0 +1,95 @@
+---
+title: Agent memory
+weight: 4
+variants: +flyte +serverless +union
+mermaid: true
+---
+
+# Agent memory
+
+By default, an [`Agent`](./flyte-agents) is stateless: each `run` starts from a blank conversation. `MemoryStore` gives an agent continuity across runs by persisting both the conversation transcript and arbitrary path-addressed artifacts to a `flyte.io.Dir`. This is what lets a scheduled or webhook-driven agent remember what it did last time.
+
+Use cases:
+
+- An "inbox triage" agent that recalls which threads it has already responded to.
+- A research agent that builds up a scratchpad over many days.
+- Any sleep/wake pattern where the agent wakes on a schedule and resumes prior context.
+
+## What a `MemoryStore` holds
+
+A `MemoryStore` combines two complementary stores backed by a working directory:
+
+- **`messages`** — the live LLM conversation transcript, managed by the agent. Mutate it only via `append()` / `extend()`.
+- **Path-addressed files** — arbitrary named blobs under the working root. Read and write them with `read_text` / `write_text` / `read_json` / `write_json` / `list_paths`.
+
+The on-disk layout under the root looks like:
+
+```
+<root>/messages.json                           # transcript
+<root>/<your/path>.{txt,json,…}                # path-addressed entries
+<root>/meta/<encoded_path>.json                # per-entry metadata (sha, actor, ts)
+<root>/audit/log.jsonl                         # opt-in audit trail
+<root>/versions/<encoded_path>/<ts>_<sha>.txt  # opt-in version history
+```
+
+## Sync vs async
+
+The path-addressed I/O methods (`read_text`, `read_json`, `write_text`, `write_json`, `get_meta`, `current_sha`) and the lifecycle methods (`create`, `get_or_create`, `save`) are sync-by-default with an `.aio(...)` companion. Inside `async def` tasks, use the `.aio` form.
+
+## Keyed stores: the easy path
+
+For durable agent memory, use a **keyed store**. `MemoryStore.get_or_create(key=...)` loads an existing store if present, otherwise creates a new one, saving to a deterministic blob-store namespace under the active {{< key product_name >}} raw-data root:
+
+```
+{storage_root}/agents/memory-store/v0/{org}/{project}/{domain}/{key}
+```
+
+Reuse the same `key` across runs to keep continuity. The chat task below picks up where the previous run left off (see the [full example](https://github.com/unionai/unionai-examples/tree/main/v2/user-guide/build-agent/agent-memory/agent_with_memory.py) for the `agent` and `TaskEnvironment` setup):
+
+{{< code file="/unionai-examples/v2/user-guide/build-agent/agent-memory/agent_with_memory.py" fragment="chat" lang="python" >}}
+
+The first run records facts; a later run with the same `memory_key` recalls them — no extra plumbing required.
+
+## Path-addressed artifacts
+
+Beyond the transcript, tools can persist structured artifacts. Every write is recorded in a metadata sidecar (sha256, actor, timestamp) and, by default, appended to an audit log. The tools below read and write a `notes/notes.json` artifact, using optimistic concurrency (covered next) to avoid lost updates:
+
+{{< code file="/unionai-examples/v2/user-guide/build-agent/agent-memory/agent_with_memory.py" fragment="tools" lang="python" >}}
+
+## Optimistic concurrency
+
+When several tasks or agents share one keyed store (e.g. parallel tool calls, or a sleep/wake pattern), guard against lost updates by passing `expected_sha=`. The write succeeds only if the current content still matches; otherwise it raises `ConcurrencyError`:
+
+```python
+from flyte.ai.agents import ConcurrencyError
+
+notes = await memory.read_json.aio("notes/notes.json", default=[])
+sha = await memory.current_sha.aio("notes/notes.json")
+notes.append(note)
+try:
+    await memory.write_json.aio("notes/notes.json", notes, expected_sha=sha, reason="agent note")
+except ConcurrencyError:
+    # Another writer updated the file between our read and write.
+    return "Memory changed while saving the note; please retry."
+```
+
+## Optional capabilities
+
+`MemoryStore` (and `create` / `get_or_create`) accept a few flags:
+
+| Option | Default | What it does |
+|--------|---------|--------------|
+| `audit` | `True` | Append every successful write to `audit/log.jsonl`. Inspect with `audit_tail(n)`. |
+| `keep_versions` | `False` | Snapshot every write under `versions/` for full history (≈ 2× storage per write). |
+| `read_only_prefixes` | `()` | Reject direct writes into the given prefixes (e.g. `("memory/",)`), so the agent must stage proposals elsewhere and a trusted pipeline promotes them. |
+
+The internal `audit/`, `meta/`, and `versions/` prefixes and `messages.json` are reserved — writes to them are rejected, and they're excluded from `list_paths`.
+
+## Lower-level usage (without a key)
+
+You can also construct a `MemoryStore` directly against a working `root` and call `save(remote_destination=...)` yourself. This is useful for one-off persistence or when you manage the destination path. When omitted, a temporary working directory is created and cleaned up automatically.
+
+## Next steps
+
+- [The Flyte Agent harness](./flyte-agents): how the agent loop uses `memory`.
+- [Deploy an agent as a service](./deploy-agent-as-service): schedule a memory-backed agent so it resumes context on each wakeup.

--- a/content/user-guide/build-agent/deploy-agent-as-service.md
+++ b/content/user-guide/build-agent/deploy-agent-as-service.md
@@ -1,124 +1,92 @@
 ---
 title: Deploy an agent as a service
-weight: 2
+weight: 10
 variants: +flyte +serverless +union
 mermaid: true
 ---
 
 # Deploy an agent as a service
 
-{{< key product_name >}} makes it straightforward to deploy internal apps (chatbots, dashboards, API endpoints) behind a URL, with no separate infrastructure. This is how you turn an agent into a hosted service that your team (or other agents) can call.
+Once you've built an agent — with [pure Python](./python-agents), the [`Agent` harness](./flyte-agents), or a [third-party framework](../agent-framework-integrations/_index) — *how* you run it is an independent choice. The same agent object can be deployed in several ways:
 
-## Chat agent with Gradio
+| Pattern | When to use it | What invokes the agent |
+|---------|----------------|------------------------|
+| **As a task** | On-demand runs from the CLI, a notebook, or another service | `flyte.run(...)` |
+| **As a scheduled task** | Recurring autonomous wakeups (triage, monitoring, reports) | A `flyte.Trigger` (cron or fixed-rate) |
+| **Behind a webhook** | React to external events (GitHub, paging tools, CI) | An HTTP `POST` to an `AppEnvironment` |
 
-This example takes the ReAct agent from [Building agentic workflows](./building-agents) and wraps it in a Gradio chat interface, deployed as a {{< key product_name >}} app. Users interact in the browser, and each reasoning step streams back in real time.
+All three wrap the agent loop in a regular Flyte task, so every run is durable, retryable, and observable in the {{< key product_name >}} dashboard. The examples below use the `Agent` harness, but the pattern is identical for any agent — just call your agent's entry point inside the task.
+
+## As a task
+
+The simplest deployment: put the agent loop in an `@env.task` and invoke it on demand. This works for any agent.
 
 ```python
-# app.py
-import json
-
-import gradio as gr
-
 import flyte
-from flyte.app import AppEnvironment
-from openai import AsyncOpenAI
+from flyte.ai.agents import Agent
 
-# --- ReAct agent (same pattern as the ReAct agent in Building agentic workflows on {{< key product_name >}}) ---
-
-TOOLS = {"add": lambda a, b: a + b, "multiply": lambda a, b: a * b}
-
-async def reason(goal: str, history: str) -> dict:
-    """LLM picks a tool or returns a final answer."""
-    r = await AsyncOpenAI().chat.completions.create(
-        model="gpt-4.1-nano",
-        response_format={"type": "json_object"},
-        messages=[
-            {"role": "system", "content":
-                f"Tools: {list(TOOLS)}. Respond JSON: "
-                '{"thought":..,"tool":..,"args":{}} or '
-                '{"thought":..,"done":true,"answer":..}'},
-            {"role": "user", "content": f"Goal: {goal}\n\n{history}\nWhat next?"},
-        ],
-    )
-    return json.loads(r.choices[0].message.content)
-
-async def act(tool: str, args: dict) -> str:
-    """Execute the chosen tool."""
-    return str(TOOLS[tool](**args))
-
-async def react_agent(message: str, history: list):
-    """ReAct loop that streams intermediate steps, then the final answer."""
-    output, trace = "", ""
-    for step in range(1, 11):
-        decision = await reason(message, trace)
-        if decision.get("done"):
-            yield output + f"\n\n**Answer:** {decision['answer']}"
-            return
-        result = await act(decision["tool"], decision["args"])
-        trace += (
-            f"Step {step}: {decision['thought']} "
-            f"-> {decision['tool']}({decision['args']}) = {result}\n"
-        )
-        output += (
-            f"**Step {step}:** {decision['thought']}\n"
-            f"`{decision['tool']}({decision['args']})` -> `{result}`\n\n"
-        )
-        yield output
-    yield output + "\n\nMax steps reached."
-
-# --- Deploy as a {{< key product_name >}} app ---
-
-serving_env = AppEnvironment(
-    name="react-agent-chat",
-    image=flyte.Image.from_debian_base(python_version=(3, 12)).with_pip_packages(
-        "gradio", "openai",
-    ),
-    secrets=[flyte.Secret(key="OPENAI_API_KEY")],
-    resources=flyte.Resources(cpu=1, memory="512Mi"),
-    requires_auth=False,
-    port=7860,
+env = flyte.TaskEnvironment(
+    name="concierge-agent",
+    image=flyte.Image.from_debian_base().with_pip_packages("litellm"),
+    secrets=[flyte.Secret(key="internal-anthropic-api-key", as_env_var="ANTHROPIC_API_KEY")],
 )
 
-@serving_env.server
-def server():
-    gr.ChatInterface(
-        react_agent,
-        title="ReAct Agent",
-        examples=["What is (12 + 8) * 3?", "Add 99 and 1, then multiply by 5"],
-    ).launch(server_name="0.0.0.0", server_port=7860)
+agent = Agent(
+    name="customer-concierge",
+    instructions="You are a customer-service concierge.",
+    tools=[...],
+)
 
-if __name__ == "__main__":
-    flyte.init_from_config()
-    flyte.serve(serving_env)
+
+@env.task(report=True)
+async def concierge(request: str) -> str:
+    """Run the agent for a single request."""
+    result = await agent.run.aio(request)
+    return result.summary or result.error
 ```
 
-Run locally, then deploy to {{< key product_name >}} with one command:
+Run it on demand:
 
 ```bash
-# Local development
-python app.py
-
-# Deploy to {{< key product_name >}}
-flyte deploy app.py serving_env
+flyte run agent.py concierge --request "Refund order #12345 to the customer."
 ```
 
-{{< key product_name >}} assigns a URL, handles TLS, and auto-scales the app.
+Or from Python with `flyte.run(concierge, request="...")`. To register a stable, deployed version of the task, use `flyte deploy agent.py env`.
 
-**What's happening under the hood:**
+## As a scheduled task (via `Trigger`)
 
-- `AppEnvironment` defines the container image, secrets, resources, and port for the app
-- `@serving_env.server` marks the function that {{< key product_name >}} calls on remote deployment
-- `gr.ChatInterface` with an async generator gives streaming output: users see each reasoning step appear as the agent works
-- `requires_auth=False` makes the app publicly accessible; set to `True` to require {{< key product_name >}} authentication
+To run an agent autonomously on a schedule, attach a `flyte.Trigger` to the task. The "wakeup" is a regular Flyte task — the agent loop runs inside it, so every tool call is durable, observable, and retryable. Pair this with [agent memory](./agent-memory) so the agent resumes prior context on each wakeup.
 
-## Other deployment patterns
+{{< code file="/unionai-examples/v2/user-guide/build-agent/deploy/scheduled_triage_agent.py" fragment="scheduled" lang="python" >}}
 
-**FastAPI endpoint:** For API-first agents, use `FastAPIAppEnvironment` to expose your agent behind a REST endpoint that other services or agents can call programmatically.
+The agent's tools (`list_open_issues`, `classify_issue`, `post_digest`) are durable `@env.task`s; see the [full example](https://github.com/unionai/unionai-examples/tree/main/v2/user-guide/build-agent/deploy/scheduled_triage_agent.py) for their definitions.
 
-**Webhook-triggered workflows:** [Deploy a FastAPI app](../native-app-integrations/fastapi-app) that receives webhooks and calls `flyte.run()` on a [remote task](../task-programming/remote-tasks) to kick off longer agentic workflows as background tasks.
+Deploying the task registers the trigger; from then on {{< key product_name >}} wakes the agent on schedule. Use `flyte.Cron(...)` for calendar schedules or `flyte.FixedRate(...)` for fixed intervals. The `flyte.TriggerTime` input is filled with the scheduled fire time. See [Triggers](../task-configuration/triggers) for the full schedule reference.
 
-**Model serving:** [Serve open-weight LLMs](../native-app-integrations/vllm-app) on GPUs behind an OpenAI-compatible API with `VLLMAppEnvironment` or `SGLangAppEnvironment`.
+## Behind a webhook (`AppEnvironment`)
+
+To kick off an agent run in response to an external event, deploy a small FastAPI app via an `AppEnvironment` that exposes an HTTP endpoint. The endpoint launches the agent task with `flyte.run.aio(...)`, so the long-running agent loop executes durably in the background while the webhook returns immediately with a run URL.
+
+{{< code file="/unionai-examples/v2/user-guide/build-agent/deploy/webhook_agent.py" fragment="webhook" lang="python" >}}
+
+The agent and its tools (`fetch_pr`, `post_comment`) are defined in the [full example](https://github.com/unionai/unionai-examples/tree/main/v2/user-guide/build-agent/deploy/webhook_agent.py).
+
+Once deployed, point your external system at the `/trigger` URL:
+
+```bash
+curl -X POST -H "Content-Type: application/json" \
+    -d '{"repository": "flyteorg/flyte", "pull_request": {"number": 123}, "action": "opened"}' \
+    https://<subdomain>.apps.<endpoint>/trigger
+```
+
+> [!NOTE]
+> When the webhook app submits runs on behalf of incoming requests, it needs valid {{< key product_name >}} credentials. Use passthrough auth (a `FastAPIPassthroughAuthMiddleware` and `flyte.init_passthrough`) so the run is submitted with the caller's identity. See [FastAPI apps](../native-app-integrations/fastapi-app).
+
+## Chat and other app patterns
+
+- **Chat UI:** To let users converse with the agent in a browser, serve it behind a chat interface. See [Add a chat UI](./agent-chat-ui).
+- **FastAPI endpoint:** For API-first agents, expose your agent behind a REST endpoint with `FastAPIAppEnvironment` so other services or agents can call it programmatically.
+- **Model serving:** [Serve open-weight LLMs](../native-app-integrations/vllm-app) on GPUs behind an OpenAI-compatible API with `VLLMAppEnvironment` or `SGLangAppEnvironment`.
 
 > [!TIP]
-> See [Build Apps](../build-apps/_index) and [Configure Apps](../configure-apps/_index) for more details.
-> For a hands-on example with a research agent Gradio UI, see [workshops/starter-examples/flyte-local-dev](https://github.com/unionai/workshops/tree/main/tutorials/starter-examples/flyte-local-dev).
+> See [Build Apps](../build-apps/_index) and [Configure Apps](../configure-apps/_index) for more details on hosting services on {{< key product_name >}}.

--- a/content/user-guide/build-agent/flyte-agents.md
+++ b/content/user-guide/build-agent/flyte-agents.md
@@ -1,0 +1,241 @@
+---
+title: Flyte-native agents
+weight: 2
+variants: +flyte +serverless +union
+mermaid: true
+---
+
+# Flyte-native agents
+
+`flyte.ai.agents.Agent` is a flyte-native, batteries-included agent harness. Instead of hand-rolling the tool-call loop (as in [Build an agent with pure Python](./python-agents)), you declare a set of tools and instructions, and the harness drives a robust LLM ↔ tool loop for you.
+
+The harness deeply integrates with {{< key product_name >}}:
+
+- **Tools** can be plain Python callables, `@flyte.trace` helpers, `@env.task` durable tasks, `LazyEntity` remote-task references, or pre-built `AgentTool` instances.
+- **MCP servers** (Slack, GitHub, Linear, filesystem, …) are first-class: pass a `MCPServerSpec` and their tools are loaded into the catalog automatically.
+- **Memory** persists across runs via `flyte.io.Dir`. See [Agent memory](./agent-memory).
+- **HITL** support pauses the loop and asks a human for approval before sensitive tools execute.
+
+## How it works
+
+`Agent(...)` collapses heterogeneous tool sources into a single tool registry plus an auto-generated system prompt. `agent.run(message)` then drives an LLM ↔ tool-call loop:
+
+1. Send the conversation and tool catalog to the LLM.
+2. If the assistant returns tool calls, execute each one (sequentially or concurrently), append the results back into the message history, and loop.
+3. Stop when the assistant returns a plain-text reply (no tool calls) or when `max_turns` is reached.
+
+```mermaid
+flowchart TB
+    inputs["tools (fn / task / MCP),<br/> skills, memory, and instructions"]
+    inputs --> agent[["Agent<br/>(tool registry, skills, system prompt)"]]
+
+    subgraph loop["agent.run(message)  ·  agent.run.aio(message) in async code"]
+      direction TB
+      llm["call_llm"] --loop max_turns times--> branch{"tool_calls?"}
+      branch -- yes --> exec["execute tools<br/>(optional HITL approval)"]
+      exec --> llm
+      branch -- no --> done["final reply"]
+    end
+
+    user(["user message"]) --> llm
+    agent --> llm
+    done --> result(["AgentResult<br/>+ persisted memory"])
+```
+
+The call returns an `AgentResult` with the final `summary`, an `error` string (empty on success), and the number of `attempts` (turns) taken.
+
+### Sync vs async
+
+`agent.run` is synchronous by default. Inside `async def` code — Flyte tasks, FastAPI handlers, etc. — use the `.aio(...)` companion instead.
+
+| Context | Call |
+|---------|------|
+| Scripts, notebooks, sync code | `result = agent.run(message)` |
+| `async def` tasks / handlers | `result = await agent.run.aio(message)` |
+
+## A minimal agent
+
+Declare a few tools as plain async functions, build an `Agent`, and call `run`. The harness reads each tool's signature and docstring to build the JSON schema and description the LLM sees, so well-documented tools work best.
+
+{{< code file="/unionai-examples/v2/user-guide/build-agent/agent-harness/basic_agent.py" fragment="all" lang="python" >}}
+
+Call it synchronously, or with `await agent.run.aio(message)` inside async code:
+
+```python
+result = agent.run("What's 17 * 23 plus the temperature in NYC?")
+print(result.summary)
+```
+
+## Tools
+
+The `tools=` argument accepts a sequence (or a `{name: tool}` mapping) of any mix of:
+
+| Tool source | What it is | When to use it |
+|-------------|------------|----------------|
+| Plain callable | A sync or async Python function | Lightweight, in-process helpers |
+| `@flyte.trace` helper | A traced function | In-process helpers you want as spans in the dashboard |
+| `@env.task` template | A durable Flyte task | Heavy compute / IO that should run on-cluster, be retryable, and observable |
+| `LazyEntity` | A reference to a remote deployed task | Calling already-deployed tasks by name |
+| `AgentTool` | A pre-built tool descriptor | Renaming, custom schema, or HITL gating |
+
+Pass a mapping to expose a tool under a different name to the LLM:
+
+```python
+agent = Agent(
+    name="ticket-shepherd",
+    tools={"fetch_data": durable_fetch_with_retries, "summarize": summarize},
+)
+```
+
+When a tool is an `@env.task`, the harness invokes it with `task.aio(...)`, so each tool call executes durably on the cluster and shows up in the {{< key product_name >}} dashboard.
+
+### Customizing a tool with `tool(...)`
+
+Use the `tool` decorator/wrapper to rename a tool, override its description, or gate it behind human approval, without writing an `AgentTool` by hand:
+
+```python
+from flyte.ai.agents import tool
+
+
+@tool(requires_approval=True)
+@env.task
+async def issue_refund(order_id: str, amount_usd: float) -> dict:
+    """Issue a refund to the customer."""
+    ...
+```
+
+When the LLM tries to call a tool marked `requires_approval=True`, the harness invokes the agent's `approval_callback` and waits for a boolean decision before executing. The default callback raises a human-input request via the `flyteplugins-hitl` plugin and blocks until a human approves or denies. If denied, the agent receives a synthetic tool message explaining the rejection so it can recover gracefully.
+
+## MCP integration
+
+The harness can connect to one or more [Model Context Protocol (MCP)](https://modelcontextprotocol.io) servers and surface their tools transparently. On the first `run` call, the harness connects to each server, lists its tools, and registers them in the catalog.
+
+Declare servers with `MCPServerSpec` — either an HTTP(S) `url` (for streamable-http / SSE transports) or a `command` (for stdio servers):
+
+```python
+from flyte.ai.agents import Agent, MCPServerSpec
+
+agent = Agent(
+    name="release-shepherd",
+    instructions="Inspect recent PRs, score release risk, and post a digest.",
+    tools=[compute_release_score],          # local durable task tool
+    mcp_servers=[
+        MCPServerSpec(
+            name="github",
+            url="https://<host>/mcp/mcp",
+            transport="streamable-http",
+            tool_prefix="gh_",               # avoid name collisions
+            tool_filter=["list_pull_requests", "comment_on_pull_request"],  # allowlist
+        ),
+        MCPServerSpec(
+            name="github-stdio",
+            command=["uvx", "mcp-server-github"],
+        ),
+    ],
+)
+```
+
+Useful `MCPServerSpec` knobs:
+
+- `tool_prefix` — prepend a prefix to every tool name from this server to avoid collisions.
+- `tool_filter` — an allowlist of tool names to expose to the LLM (`None` exposes all).
+- `headers` — HTTP headers (e.g. `Authorization`) for authenticated servers.
+
+MCP support requires the `mcp` package: `pip install 'flyte[mcp]'`. To serve your own MCP servers on {{< key product_name >}}, see [Build an MCP](../build-mcp/_index).
+
+## Skills
+
+Pass extra context to append to the system prompt via `skills=`. Each entry is either a literal string or a `pathlib.Path` to a local text file:
+
+```python
+import pathlib
+
+agent = Agent(
+    name="ticket-shepherd",
+    instructions="You triage support tickets.",
+    tools=[list_open_tickets, summarize],
+    skills=[pathlib.Path("TICKETING_HANDBOOK.md")],
+)
+```
+
+## Observability
+
+Every step of the loop emits a typed `AgentEvent` (`agent_start`, `turn_start`, `tool_start`, `tool_end`, `approval_request`, …). Subscribe by setting the `agent_progress_cb` context variable to forward events to logs, NDJSON streams, websockets, or {{< key product_name >}} reports. The built-in chat UI uses this hook to stream progress; see [Add a chat UI](./agent-chat-ui).
+
+## Extending the Agent class
+
+The default loop is robust, but sometimes you need custom behavior around it: input guardrails, output post-processing, a different control flow, or extra bookkeeping. The cleanest way to do this is to subclass `Agent` and override its `run` method.
+
+`Agent` is a [dataclass](https://docs.python.org/3/library/dataclasses.html), and `run` is the single public entry point that drives the loop. There are two common strategies:
+
+1. **Wrap the built-in loop** — add logic before and after `super().run(...)`. Best when you mostly want the default behavior plus pre/post steps.
+2. **Replace the loop entirely** — implement `run` (and `tool_descriptions`) yourself. Best when you need a fundamentally different control flow but still want to plug into the rest of the ecosystem (e.g. the chat UI).
+
+### `run` is sync-by-default
+
+`Agent.run` is wrapped with `@syncify`, which means callers can use it synchronously (`agent.run(...)`) or await the async companion (`await agent.run.aio(...)`). When you override `run`, decorate your async implementation with `@syncify` to keep the same dual interface, and call the parent loop via `await super().run.aio(...)`.
+
+### Strategy 1: wrap the built-in loop
+
+Subclass `Agent` as a dataclass so you can add your own fields, then override `run` to add an input guardrail and post-process the answer:
+
+{{< code file="/unionai-examples/v2/user-guide/build-agent/extending-the-agent/guarded_agent.py" fragment="guarded" lang="python" >}}
+
+Instantiate and call it just like a regular `Agent`:
+
+```python
+agent = GuardedAgent(
+    name="guarded-helper",
+    instructions="You are a careful assistant.",
+    tools=[...],
+    banned_terms=("ssn", "password"),
+    signature="GuardedAgent",
+)
+
+result = agent.run("Summarize today's open tickets.")
+```
+
+Because `GuardedAgent` still subclasses `Agent`, every other feature — tools, MCP servers, memory, HITL — keeps working unchanged.
+
+### Strategy 2: implement `run` from scratch
+
+If you want a completely custom loop, implement the `AgentProtocol`: a class exposing `run(message, history) -> AgentResult` and `tool_descriptions() -> list[dict]`. Any object satisfying this protocol can be used anywhere the harness is accepted, including the [chat UI](./agent-chat-ui).
+
+```python
+from __future__ import annotations
+
+from flyte.ai.agents.protocol import AgentResult
+from flyte.syncify import syncify
+
+
+class MyCustomAgent:
+    """A fully custom agent that implements the AgentProtocol."""
+
+    def __init__(self, tools: dict):
+        self._tools = tools
+
+    @syncify
+    async def run(self, message: str, history: list[dict] | None = None) -> AgentResult:
+        # Your own control flow: reasoning, routing, tool calls, retries, etc.
+        answer = await self._my_loop(message, history or [])
+        return AgentResult(summary=answer)
+
+    def tool_descriptions(self) -> list[dict[str, str]]:
+        return [
+            {"name": name, "signature": f"{name}(...)", "description": fn.__doc__ or ""}
+            for name, fn in self._tools.items()
+        ]
+```
+
+> [!NOTE]
+> `AgentResult` carries `summary`, `error`, `attempts`, and (for code-generating agents) `code` and `charts`. Populate the fields relevant to your loop; downstream consumers like the chat UI read `summary` and `error`.
+
+### Choosing between subclassing and composition
+
+Subclassing is the right tool when you need to change *how the loop runs*. If you only need to change *what happens around a run* — for example, looping the agent until a condition is met, or combining several agents — prefer plain composition: call `agent.run.aio(...)` from inside your own `@env.task`. This keeps the harness untouched and your orchestration logic explicit and observable in the dashboard.
+
+## Next steps
+
+- [Agent memory](./agent-memory): persist transcript and artifacts across runs.
+- [Add a chat UI](./agent-chat-ui): wrap the agent in a hosted chat interface.
+- [Deploy an agent as a service](./deploy-agent-as-service): run on a schedule or behind a webhook.

--- a/content/user-guide/build-agent/python-agents.md
+++ b/content/user-guide/build-agent/python-agents.md
@@ -1,13 +1,15 @@
 ---
-title: Building agentic workflows
+title: Pure Python agents
 weight: 1
 variants: +flyte +serverless +union
 mermaid: true
 ---
 
-# Building agentic workflows on {{< key product_name >}}
+# Pure Python agents
 
-{{< key product_name >}} is framework-agnostic: use any Python LLM library (OpenAI SDK, Anthropic SDK, LangChain, LiteLLM, etc.) inside your tasks. The platform provides the production infrastructure layer: sandboxed execution, parallel fan-out, durable checkpointing, and observability for every step of the agent loop.
+The lightest way to build an agent on {{< key product_name >}} is to write the loop yourself in plain Python. {{< key product_name >}} is framework-agnostic: use any Python LLM library (OpenAI SDK, Anthropic SDK, LiteLLM, etc.) inside your tasks. The platform provides the production infrastructure layer: sandboxed execution, parallel fan-out, durable checkpointing, and observability for every step of the agent loop.
+
+This approach gives you full control over the loop and the smallest possible dependency footprint. If you'd rather not hand-roll the tool-call loop, see [The Flyte Agent harness](./flyte-agents), which provides a batteries-included loop with tools, MCP servers, memory, and HITL. If you already have agents written in a third-party framework, see [Agent framework integrations](../agent-framework-integrations/_index) for [LangGraph](../agent-framework-integrations/langgraph), [PydanticAI](../agent-framework-integrations/pydantic-ai), and [OpenAI Agents SDK](../agent-framework-integrations/openai-agents-sdk).
 
 Two decorators are all you need:
 
@@ -24,58 +26,7 @@ The [ReAct pattern](https://arxiv.org/abs/2210.03629) is the most common agent a
 Thought → Action → Observation → repeat until done
 ```
 
-```python
-# agent.py
-import json
-from pydantic import BaseModel
-
-import flyte
-from openai import AsyncOpenAI
-
-env = flyte.TaskEnvironment(
-    name="agent_env",
-    image=flyte.Image.from_debian_base(python_version=(3, 13)).with_pip_packages("openai"),
-    resources=flyte.Resources(cpu=2, memory="2Gi"),
-    secrets=[flyte.Secret(key="OPENAI_API_KEY")],
-)
-
-TOOLS = {"add": lambda a, b: a + b, "multiply": lambda a, b: a * b}
-
-@flyte.trace                                       # each call = a span in {{< key product_name >}} dashboard
-async def reason(goal: str, history: str) -> dict:
-    """LLM picks a tool or returns a final answer."""
-    r = await AsyncOpenAI().chat.completions.create(
-        model="gpt-4.1-nano",
-        response_format={"type": "json_object"},
-        messages=[
-            {"role": "system", "content":
-                f"Tools: {list(TOOLS)}. Respond JSON: "
-                '{"thought":..,"tool":..,"args":{}} or {"thought":..,"done":true,"answer":..}'},
-            {"role": "user", "content": f"Goal: {goal}\n\n{history}\nWhat next?"},
-        ],
-    )
-    return json.loads(r.choices[0].message.content)
-
-@flyte.trace
-async def act(tool: str, args: dict) -> str:
-    """Execute the chosen tool."""
-    return str(TOOLS[tool](**args))
-
-class AgentResult(BaseModel):
-    answer: str
-    steps: int
-
-@env.task                                          # runs in its own sandboxed container
-async def react_agent(goal: str, max_steps: int = 10) -> AgentResult:
-    history = ""
-    for step in range(1, max_steps + 1):           # the agent loop
-        decision = await reason(goal, history)      # Thought
-        if decision.get("done"):
-            return AgentResult(answer=str(decision["answer"]), steps=step)
-        result = await act(decision["tool"], decision["args"])  # Action
-        history += f"Step {step}: {decision['thought']} -> {decision['tool']}({decision['args']}) = {result}\n"  # Observation
-    return AgentResult(answer="Max steps reached", steps=max_steps)
-```
+{{< code file="/unionai-examples/v2/user-guide/build-agent/building-agents/react_agent.py" fragment="all" lang="python" >}}
 
 ```bash
 flyte run agent.py react_agent --goal "What is (12 + 8) * 3?"
@@ -91,82 +42,48 @@ flyte run agent.py react_agent --goal "What is (12 + 8) * 3?"
 > [!TIP]
 > See the [Agentic Refinement docs](../advanced-project/agentic-refinement), [Traces docs](../task-programming/traces), and [more patterns (planner, debate, etc.)](https://github.com/unionai/workshops/tree/main/tutorials/multi-agent-workflows).
 
-## Plan-and-Execute with parallel fan-out (LangGraph on {{< key product_name >}})
+## Plan-and-Execute with parallel fan-out
 
-The [Plan-and-Execute pattern](https://blog.langchain.com/plan-and-execute-agents/) splits a complex query into sub-tasks, fans them out in parallel, then synthesizes the results. This example runs a LangGraph research agent with web search tool calling, and {{< key product_name >}} handles the parallelization, giving each sub-task its own container.
-
-Here's `graph.py`, a LangGraph agent with tool calling (search the web, then summarize):
+The [Plan-and-Execute pattern](https://blog.langchain.com/plan-and-execute-agents/) splits a complex query into sub-tasks, fans them out in parallel, then synthesizes the results. With {{< key product_name >}} the fan-out is just `asyncio.gather()`, and each sub-task gets its own container, giving you true parallelism on separate hardware.
 
 ```python
-import flyte
-from langchain_openai import ChatOpenAIe
-from langchain_core.messages import SystemMessage
-from langgraph.graph import StateGraph, MessagesState
-from langgraph.prebuilt import ToolNode
-from langchain_community.tools.tavily_search import TavilySearchResults
-
-def build_research_graph(openai_key: str, tavily_key: str):
-    tools = [TavilySearchResults(max_results=2, tavily_api_key=tavily_key)]
-    llm = ChatOpenAI(model="gpt-4.1-nano", api_key=openai_key).bind_tools(tools)
-
-    @flyte.trace
-    async def agent(state: MessagesState):
-        msgs = [SystemMessage(content="Research the topic. Use search, then summarize.")] + state["messages"]
-        return {"messages": [await llm.ainvoke(msgs)]}
-
-    @flyte.trace
-    async def route(state: MessagesState):
-        last = state["messages"][-1]
-        return "tools" if getattr(last, "tool_calls", None) else "__end__"
-
-    g = StateGraph(MessagesState)
-    g.add_node("agent", agent)
-    g.add_node("tools", ToolNode(tools))
-    g.set_entry_point("agent")
-    g.add_conditional_edges("agent", route, {"tools": "tools", "__end__": "__end__"})
-    g.add_edge("tools", "agent")
-    return g.compile()
-```
-
-And `workflow.py`, which plans topics, fans out research in parallel, and synthesizes:
-
-```python
+# workflow.py
 import os, json, asyncio, flyte
-from langchain_openai import ChatOpenAI
-from langchain_core.messages import HumanMessage
-from graph import build_research_graph
+from openai import AsyncOpenAI
 
 env = flyte.TaskEnvironment(
     name="research_env",
-    image=flyte.Image.from_debian_base(python_version=(3, 13))
-        .with_pip_packages("openai", "langchain-openai", "langchain-community", "langgraph", "tavily-python"),
+    image=flyte.Image.from_debian_base(python_version=(3, 13)).with_pip_packages("openai"),
     resources=flyte.Resources(cpu=2, memory="2Gi"),
-    secrets=[flyte.Secret(key="OPENAI_API_KEY"), flyte.Secret(key="TAVILY_API_KEY")],
+    secrets=[flyte.Secret(key="OPENAI_API_KEY")],
 )
+
+@flyte.trace
+async def llm(prompt: str) -> str:
+    r = await AsyncOpenAI().chat.completions.create(
+        model="gpt-4.1-nano",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return r.choices[0].message.content
 
 @env.task
 async def plan(query: str, n: int = 3) -> list[str]:
-    """Split query into sub-topics."""
-    r = await ChatOpenAI(model="gpt-4.1-nano", api_key=os.environ["OPENAI_API_KEY"]).ainvoke(
-        f"Break into exactly {n} sub-topics. Return ONLY a JSON array of strings, e.g. [\"topic1\", \"topic2\"]. No objects.\n\n{query}")
-    topics = json.loads(r.content)[:n]
-    return [t if isinstance(t, str) else str(t.get("sub_topic", t)) for t in topics]
+    """Split the query into sub-topics."""
+    raw = await llm(
+        f'Break this into exactly {n} sub-topics. Return ONLY a JSON array of strings.\n\n{query}'
+    )
+    return json.loads(raw)[:n]
 
 @env.task
 async def research(topic: str) -> str:
-    """Run LangGraph agent on one topic (each call = separate container)."""
-    graph = build_research_graph(os.environ["OPENAI_API_KEY"], os.environ["TAVILY_API_KEY"])
-    result = await graph.ainvoke({"messages": [HumanMessage(content=f"Research: {topic}")]})
-    return json.dumps({"topic": topic, "report": result["messages"][-1].content})
+    """Research one sub-topic (each call = its own container)."""
+    return await llm(f"Write a short, factual report on: {topic}")
 
 @env.task
 async def synthesize(query: str, reports: list[str]) -> str:
-    """Combine sub-reports into a final summary."""
-    parsed = [json.loads(r) for r in reports]
-    sections = "\n\n".join(f"## {r['topic']}\n{r['report']}" for r in parsed)
-    r = await ChatOpenAI(model="gpt-4.1-nano", api_key=os.environ["OPENAI_API_KEY"]).ainvoke(
-        f"Synthesize reports on: {query}\n\n{sections}\n\nKey takeaways:")
-    return r.content
+    """Combine the sub-reports into a final answer."""
+    sections = "\n\n".join(reports)
+    return await llm(f"Synthesize a final answer to '{query}' from:\n\n{sections}")
 
 @env.task
 async def research_workflow(query: str, num_topics: int = 3) -> str:
@@ -183,17 +100,19 @@ flyte run workflow.py research_workflow --query "Impact of storms on travel insu
 
 ```
 research_workflow (orchestrator)
-  ├── plan          → LLM breaks query into N sub-topics          [container 1]
-  ├── research(t1)  → LangGraph agent loop with web search tools  [container 2]  ┐
-  ├── research(t2)  → LangGraph agent loop with web search tools  [container 3]  ├ parallel
-  ├── research(t3)  → LangGraph agent loop with web search tools  [container 4]  ┘
-  └── synthesize    → LLM combines reports into final answer      [container 5]
+  ├── plan          → LLM breaks query into N sub-topics      [container 1]
+  ├── research(t1)  → researches one sub-topic                [container 2]  ┐
+  ├── research(t2)  → researches one sub-topic                [container 3]  ├ parallel
+  ├── research(t3)  → researches one sub-topic                [container 4]  ┘
+  └── synthesize    → LLM combines reports into final answer  [container 5]
 ```
 
 - **Fan-out:** `asyncio.gather()` launches all research tasks in parallel, each in its own sandboxed container
-- **Tool calling inside each research task:** The LangGraph agent calls Tavily web search, observes results, reasons about them, and loops until it has enough information (the inner agentic loop)
-- **Observability:** `@flyte.trace` on the LangGraph nodes means every LLM call, every tool call, and every routing decision is visible as a span in the {{< key product_name >}} dashboard
+- **Observability:** `@flyte.trace` on each LLM call means every prompt and response is visible as a span in the {{< key product_name >}} dashboard
 - **Durable checkpointing:** Each task's output is persisted. If `synthesize` fails, re-running skips the completed `plan` and `research` steps (with caching enabled)
+
+> [!TIP]
+> The same fan-out works with any framework inside the `research` task. See [LangGraph](../agent-framework-integrations/langgraph) for a version that runs a LangGraph research agent (with web-search tool calling) inside each parallel container.
 
 ## More agentic patterns
 
@@ -227,3 +146,8 @@ If you're coming from LangGraph, CrewAI, OpenAI Agents SDK, or similar framework
 **Guardrails and validation** are Python code between steps: `if/else` checks, Pydantic validation, structured output parsing, or libraries like NeMo Guardrails. Raise an exception to fail a step and trigger retries.
 
 **Observability:** The {{< key product_name >}} dashboard shows the full execution tree with per-step inputs, outputs, logs, resource usage, and timing. `@flyte.trace` adds spans within a task for fine-grained visibility into individual LLM calls and tool invocations. For LLM-specific metrics (token usage, cost per call), integrate with Langfuse or LangSmith from within your tasks.
+
+## Next steps
+
+- [The Flyte Agent harness](./flyte-agents): skip the boilerplate with a built-in tool-use loop.
+- [Deploy an agent as a service](./deploy-agent-as-service): run this agent on a schedule or behind a webhook.

--- a/content/user-guide/build-agent/python-agents.md
+++ b/content/user-guide/build-agent/python-agents.md
@@ -34,7 +34,7 @@ flyte run agent.py react_agent --goal "What is (12 + 8) * 3?"
 ```
 
 **What's happening under the hood:**
-- `react_agent` runs in a sandboxed container with only `openai` installed and 2 CPU / 2GB RAM
+- `react_agent` runs in a container with only `openai` installed and 2 CPU / 2GB RAM
 - Each `reason()` and `act()` call is traced, so you see every LLM call, every tool invocation, and every intermediate result in the {{< key product_name >}} dashboard
 - The agent's inputs and final output are durably persisted, letting you inspect any past run end-to-end
 - Swap in your own tools (web search, database queries, API calls) by adding to the `TOOLS` dict
@@ -107,7 +107,7 @@ research_workflow (orchestrator)
   └── synthesize    → LLM combines reports into final answer  [container 5]
 ```
 
-- **Fan-out:** `asyncio.gather()` launches all research tasks in parallel, each in its own sandboxed container
+- **Fan-out:** `asyncio.gather()` launches all research tasks in parallel, each in its own container
 - **Observability:** `@flyte.trace` on each LLM call means every prompt and response is visible as a span in the {{< key product_name >}} dashboard
 - **Durable checkpointing:** Each task's output is persisted. If `synthesize` fails, re-running skips the completed `plan` and `research` steps (with caching enabled)
 

--- a/content/user-guide/build-mcp/_index.md
+++ b/content/user-guide/build-mcp/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Build an MCP
-weight: 19
+weight: 20
 variants: +flyte +union
 ---
 

--- a/content/user-guide/sandboxing/_index.md
+++ b/content/user-guide/sandboxing/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Sandboxing
-weight: 20
+weight: 21
 variants: +flyte +union
 llm_readable_bundle: true
 ---

--- a/content/user-guide/user-management.md
+++ b/content/user-guide/user-management.md
@@ -1,6 +1,6 @@
 ---
 title: User management
-weight: 21
+weight: 40
 variants: -flyte +union
 ---
 


### PR DESCRIPTION
This pull request introduces a new section to the user guide documenting how to integrate third-party agent frameworks (LangGraph, PydanticAI, OpenAI Agents SDK) with the platform, and reorganizes the agent documentation for clarity and discoverability. It adds dedicated guides for each framework, a new agent chat UI guide, and updates the main agent documentation to clarify the distinction between agent construction and deployment. Minor UI and navigation tweaks (such as icon changes and sidebar ordering) are also included.

**New agent framework integrations documentation:**

* Added a new section `agent-framework-integrations` with an overview and dedicated guides for [LangGraph](./agent-framework-integrations/langgraph.md), [PydanticAI](./agent-framework-integrations/pydantic-ai.md), and [OpenAI Agents SDK](./agent-framework-integrations/openai-agents-sdk.md), including code examples and integration patterns for each framework. [[1]](diffhunk://#diff-1454b5a6c78b59c79a098080347e7ad14703b8ae9154791abb936bb63ce85941R1-R42) [[2]](diffhunk://#diff-7503c4ff32db493effc5f86bfc13f86cbfabf9193a6afba2ac423b63b40c45e0R1-R126) [[3]](diffhunk://#diff-1b9ca1767e0f16dab747d937834ce09819405411433cac3657250e0ea2d25858R1-R47) [[4]](diffhunk://#diff-f2942d3a01ae2813202cbb7bbd7bcf4a11920f176bab53beb440e14ad2a3f1d0R1-R29)

**Agent documentation improvements:**

* Refactored the main agent documentation (`build-agent/_index.md`) to clearly separate agent construction (agent loop) from deployment patterns, and added a comparison table for different agent-building approaches. [[1]](diffhunk://#diff-cab912da545f660ee77ea437fc93aa9ddaf651e172a5c1aac10a7d4a5c7f9fc6L13-R22) [[2]](diffhunk://#diff-cab912da545f660ee77ea437fc93aa9ddaf651e172a5c1aac10a7d4a5c7f9fc6L27-R53)
* Added a new guide for serving agents with a chat UI, covering both the built-in and custom FastAPI approaches.

**Navigation and UI updates:**

* Added a new link card for "Agent framework integrations" to the user guide landing page, and updated the icon for "Native app integrations." [[1]](diffhunk://#diff-312535289ee39dd4e59ecf5f51af26ff1c5c3e072e4e31504cfeb106f52a369dL104-R104) [[2]](diffhunk://#diff-312535289ee39dd4e59ecf5f51af26ff1c5c3e072e4e31504cfeb106f52a369dR124-R127)
* Adjusted the sidebar ordering for the authentication guide to accommodate new sections.