### PR TITLE
deployment: align architecture pages with zero-trust security model

### DIFF
--- a/content/deployment/_index.md
+++ b/content/deployment/_index.md
@@ -54,7 +54,7 @@ When you run your workflow:
 4. Container images are pulled down from the registry for each pod as needed
 5. Containers load their inputs from, and save their outputs to, the object store
 
-All of this happens in the data plane, with the control plane aware only of the workflow execution state, and not the code, data, logs, secrets, or any other proprietary information. The data plane communicates with the control plane through an outbound-only gRPC channel. There is no open incoming port to the data plane.
+All of this happens in the data plane, with the control plane aware only of the workflow execution state, and not the code, data, logs, secrets, or any other proprietary information. The data plane initiates an outbound-only connection to the control plane. There is no open incoming port to the data plane.
 
 ## Control plane
 

--- a/content/deployment/_index.md
+++ b/content/deployment/_index.md
@@ -54,7 +54,7 @@ When you run your workflow:
 4. Container images are pulled down from the registry for each pod as needed
 5. Containers load their inputs from, and save their outputs to, the object store
 
-All of this happens in the data plane, with the control plane aware only of the workflow execution state, and not the code, data, logs, secrets, or any other proprietary information. The data plane communicates with the control plane through an outgoing port through a zero trust proxy. There is no open incoming port to the data plane.
+All of this happens in the data plane, with the control plane aware only of the workflow execution state, and not the code, data, logs, secrets, or any other proprietary information. The data plane communicates with the control plane through an outbound-only gRPC channel. There is no open incoming port to the data plane.
 
 ## Control plane
 

--- a/content/deployment/byoc/enabling-aws-resources/enabling-aws-secrets-manager.md
+++ b/content/deployment/byoc/enabling-aws-resources/enabling-aws-secrets-manager.md
@@ -161,5 +161,5 @@ def t1():
 ```
 
 > [!WARNING]
-> Do not return secret values from tasks, as this will expose secrets to the control plane.
+> Do not return secret values from tasks. Returned values are stored in plaintext in your data plane's object store and shown in the UI and to downstream tasks, defeating the secret store's protections.
 

--- a/content/deployment/byoc/enabling-gcp-resources/enabling-google-secret-manager.md
+++ b/content/deployment/byoc/enabling-gcp-resources/enabling-google-secret-manager.md
@@ -133,5 +133,5 @@ def t1():
 ```
 
 > [!WARNING]
-> Do not return secret values from tasks, as this will expose secrets to the control plane.
+> Do not return secret values from tasks. Returned values are stored in plaintext in your data plane's object store and shown in the UI and to downstream tasks, defeating the secret store's protections.
 

--- a/content/deployment/byoc/platform-architecture.md
+++ b/content/deployment/byoc/platform-architecture.md
@@ -88,11 +88,11 @@ They are fetched directly from the data-plane object store via presigned URLs is
 * Primitive execution inputs (int, string... etc.)
 * JSON-serializable dataclasses
 
-These small values are passed by value rather than as a reference to a separately offloaded object. Like raw data, they are stored in the object store in your data plane -- inlined within the run's `inputs.pb`/`outputs.pb` payload -- and the control plane stores only a URI pointer to them.
+These small values are passed by value rather than as a reference to a separately offloaded object. Like raw data, they are stored in the object store in your data plane — inlined within the run's `inputs.pb`/`outputs.pb` payload — and the control plane stores only a URI pointer to them.
 
 For the developer-facing map of which specific records live in the control-plane database versus the data-plane bucket — including what "metadata" means in different contexts — see [Where your data lives](../../user-guide/core-concepts/where-data-lives).
 
 ## Data privacy
 
-All runtime execution data -- both raw and literal inputs and outputs -- is stored in the object store in your data plane, never in the control plane. The control plane holds orchestration metadata only: task definitions (which include default input values, environment variables, and SQL statements), run state, and error messages (which may include data from Python tracebacks).
+All runtime execution data — both raw and literal inputs and outputs — is stored in the object store in your data plane, never in the control plane. The control plane holds orchestration metadata only: task definitions (which include default input values, environment variables, and SQL statements), run state, and error messages (which may include data from Python tracebacks).
 

--- a/content/deployment/byoc/platform-architecture.md
+++ b/content/deployment/byoc/platform-architecture.md
@@ -88,11 +88,11 @@ They are fetched directly from the data-plane object store via presigned URLs is
 * Primitive execution inputs (int, string... etc.)
 * JSON-serializable dataclasses
 
-These are passed by value, not by reference, and may be stored in the {{< key product_name >}} control plane.
+These small values are passed by value rather than as a reference to a separately offloaded object. Like raw data, they are stored in the object store in your data plane -- inlined within the run's `inputs.pb`/`outputs.pb` payload -- and the control plane stores only a URI pointer to them.
 
 For the developer-facing map of which specific records live in the control-plane database versus the data-plane bucket — including what "metadata" means in different contexts — see [Where your data lives](../../user-guide/core-concepts/where-data-lives).
 
 ## Data privacy
 
-If you are concerned with maintaining strict data privacy, be sure not to pass private information in literal form between tasks.
+All runtime execution data -- both raw and literal inputs and outputs -- is stored in the object store in your data plane, never in the control plane. The control plane holds orchestration metadata only: task definitions (which include default input values, environment variables, and SQL statements), run state, and error messages (which may include data from Python tracebacks).
 

--- a/content/deployment/byoc/platform-architecture.md
+++ b/content/deployment/byoc/platform-architecture.md
@@ -81,7 +81,7 @@ Raw data is composed of:
 * Python-pickled types
 
 These are passed by reference between tasks and are always stored in an object store in your data plane.
-This type of data is read by (and may be temporarily cached) by the control plane as needed, but is never stored there.
+They are fetched directly from the data-plane object store via presigned URLs issued by the data-plane `dataproxy` service; the bytes never pass through the control plane.
 
 ### Literal data
 

--- a/content/deployment/selfmanaged/architecture/overview.md
+++ b/content/deployment/selfmanaged/architecture/overview.md
@@ -80,9 +80,9 @@ They are fetched directly from the data-plane object store via presigned URLs is
 * Primitive execution inputs (int, string... etc.)
 * JSON-serializable dataclasses
 
-These are passed by value, not by reference, and may be stored in the {{< key product_name >}} control plane.
+These small values are passed by value rather than as a reference to a separately offloaded object. Like raw data, they are stored in the object store in your data plane -- inlined within the run's `inputs.pb`/`outputs.pb` payload -- and the control plane stores only a URI pointer to them.
 
 ## Data privacy
 
-If you are concerned with maintaining strict data privacy, be sure not to pass private information in literal form between tasks.
+All runtime execution data -- both raw and literal inputs and outputs -- is stored in the object store in your data plane, never in the control plane. The control plane holds orchestration metadata only: task definitions (which include default input values, environment variables, and SQL statements), run state, and error messages (which may include data from Python tracebacks).
 

--- a/content/deployment/selfmanaged/architecture/overview.md
+++ b/content/deployment/selfmanaged/architecture/overview.md
@@ -73,7 +73,7 @@ Raw data is comprised of:
 * Python-pickled types
 
 These are passed by reference between tasks and are always stored in an object store in your data plane.
-This type of data is read by (and may be temporarily cached) by the control plane as needed, but is never stored there.
+They are fetched directly from the data-plane object store via presigned URLs issued by the data-plane `dataproxy` service; the bytes never pass through the control plane.
 
 ### Literal data
 

--- a/content/deployment/selfmanaged/architecture/overview.md
+++ b/content/deployment/selfmanaged/architecture/overview.md
@@ -80,9 +80,9 @@ They are fetched directly from the data-plane object store via presigned URLs is
 * Primitive execution inputs (int, string... etc.)
 * JSON-serializable dataclasses
 
-These small values are passed by value rather than as a reference to a separately offloaded object. Like raw data, they are stored in the object store in your data plane -- inlined within the run's `inputs.pb`/`outputs.pb` payload -- and the control plane stores only a URI pointer to them.
+These small values are passed by value rather than as a reference to a separately offloaded object. Like raw data, they are stored in the object store in your data plane — inlined within the run's `inputs.pb`/`outputs.pb` payload — and the control plane stores only a URI pointer to them.
 
 ## Data privacy
 
-All runtime execution data -- both raw and literal inputs and outputs -- is stored in the object store in your data plane, never in the control plane. The control plane holds orchestration metadata only: task definitions (which include default input values, environment variables, and SQL statements), run state, and error messages (which may include data from Python tracebacks).
+All runtime execution data — both raw and literal inputs and outputs — is stored in the object store in your data plane, never in the control plane. The control plane holds orchestration metadata only: task definitions (which include default input values, environment variables, and SQL statements), run state, and error messages (which may include data from Python tracebacks).
 

--- a/content/deployment/selfmanaged/configuration/data-retention.md
+++ b/content/deployment/selfmanaged/configuration/data-retention.md
@@ -15,9 +15,9 @@ It helps to be precise about what "metadata" means here, because the term is use
 
 **Metadata in {{< key product_name >}} lives in the control plane database.** It includes:
 
-- Task, trigger and app definitions.
+- Task, trigger and app definitions (including their default input values).
 - Execution status, history, schedules, and audit trail.
-- The literal values of task inputs and outputs — primitives (ints, strings, etc.), JSON-serializable dataclasses, and similar small values that are passed *by value* between tasks. The DB stores these values directly.
+- Pointers (URIs) to each run's `inputs.pb` / `outputs.pb` — the database records *where* each task's inputs and outputs live, not the values themselves.
 
 **Raw data lives in the data plane object-store bucket.** It includes:
 
@@ -27,7 +27,7 @@ It helps to be precise about what "metadata" means here, because the term is use
 - `Deck` data and artifact payloads.
 - [Trace](../../../user-guide/task-programming/traces) checkpoints.
 
-When a task input or output is *too large to be passed inline as a literal value*, it is offloaded: the bytes are written to the bucket as raw data, and the literal that the DB stores becomes a **pointer** (URI) into the bucket. The DB still holds the canonical record of the input/output — it just holds a reference instead of the value.
+Every task's inputs and outputs are serialized to `inputs.pb` / `outputs.pb` in the data plane object-store bucket, and the database stores only a **pointer** (URI) to them. Within those files, small values (primitives, small dataclasses) are inlined *by value*, while values too large to inline — `flyte.io.File`, `flyte.io.DataFrame`, models, and similar — are offloaded to separate objects in the bucket and referenced by URI. Either way, the values themselves live in the data plane; the control plane holds only the pointer.
 
 ## Impact of raw data loss
 
@@ -39,7 +39,7 @@ A retention policy that purges raw data leaves the metadata in the control plane
 | **Execution engine** | Re-runs or downstream tasks that consume a purged upstream output fail at runtime. In-flight tasks that depend on a node whose output was just purged fail. |
 | **Caching** | A cache hit may resolve to a pointer whose underlying raw data has been purged, producing cache misses, task re-execution, or failure. |
 | **Traces** | [Trace](../../../user-guide/task-programming/traces) checkpoints used by `@flyte.trace` for fine-grained recovery are stored in the bucket; if purged, resume-from-checkpoint is not possible for affected executions. |
-| **Operations** | The DB record of what ran, when, and with what *small literal* inputs/outputs is preserved. The record of what *large offloaded* inputs/outputs each task produced is lost wherever the raw data has been purged. |
+| **Operations** | The DB record of what ran, when, and the pointers to each task's inputs/outputs is preserved. The input/output *values* themselves — which live in the bucket — are lost wherever the raw data has been purged. |
 
 ## Applying retention deliberately
 

--- a/content/deployment/selfmanaged/configuration/data-retention.md
+++ b/content/deployment/selfmanaged/configuration/data-retention.md
@@ -39,7 +39,7 @@ A retention policy that purges raw data leaves the metadata in the control plane
 | **Execution engine** | Re-runs or downstream tasks that consume a purged upstream output fail at runtime. In-flight tasks that depend on a node whose output was just purged fail. |
 | **Caching** | A cache hit may resolve to a pointer whose underlying raw data has been purged, producing cache misses, task re-execution, or failure. |
 | **Traces** | [Trace](../../../user-guide/task-programming/traces) checkpoints used by `@flyte.trace` for fine-grained recovery are stored in the bucket; if purged, resume-from-checkpoint is not possible for affected executions. |
-| **Operations** | The DB record of what ran, when, and the pointers to each task's inputs/outputs is preserved. The input/output *values* themselves — which live in the bucket — are lost wherever the raw data has been purged. |
+| **Operations** | The DB record of what ran and when, the pointers to each task's inputs/outputs, and the small inline values in `inputs.pb`/`outputs.pb` are preserved. The *large offloaded* inputs/outputs are lost wherever the raw data has been purged. |
 
 ## Applying retention deliberately
 

--- a/content/integrations/bigquery/_index.md
+++ b/content/integrations/bigquery/_index.md
@@ -63,7 +63,7 @@ if __name__ == "__main__":
     # Run locally (connector runs in-process, requires credentials locally)
     run = flyte.with_runcontext(mode="local").run(count_users)
 
-    # Run remotely (connector runs on the control plane)
+    # Run remotely (connector runs as a service in your data plane)
     run = flyte.with_runcontext(mode="remote").run(count_users)
 
     print(run.url)

--- a/content/integrations/snowflake/_index.md
+++ b/content/integrations/snowflake/_index.md
@@ -70,14 +70,14 @@ if __name__ == "__main__":
     # Run locally (connector runs in-process, requires credentials and packages locally)
     run = flyte.with_runcontext(mode="local").run(count_users)
 
-    # Run remotely (connector runs on the control plane)
+    # Run remotely (connector runs as a service in your data plane)
     run = flyte.with_runcontext(mode="remote").run(count_users)
 
     print(run.url)
 ```
 
 > [!NOTE]
-> The `TaskEnvironment` created by `from_task` does not need an image or pip packages. Snowflake tasks are connector tasks, which means the query executes on the connector service, not in your task container. In `local` mode, the connector runs in-process and requires `flyteplugins-snowflake` and credentials to be available on your machine. In `remote` mode, the connector runs on the control plane.
+> The `TaskEnvironment` created by `from_task` does not need an image or pip packages. Snowflake tasks are connector tasks, which means the query executes on the connector service, not in your task container. In `local` mode, the connector runs in-process and requires `flyteplugins-snowflake` and credentials to be available on your machine. In `remote` mode, the connector runs as a service in your data plane.
 
 ## Configuration
 

--- a/content/user-guide/core-concepts/where-data-lives.md
+++ b/content/user-guide/core-concepts/where-data-lives.md
@@ -14,7 +14,7 @@ When you run a Flyte task, your data ends up in two stores: a **database** in th
 | | Control-plane database | Data-plane object store |
 |---|---|---|
 | **Backing tech** | Postgres (plus a few internal coordination stores) | S3, GCS, or ABS bucket |
-| **What's in it** | Every record Flyte uses to *describe* your runs | Every byte of *content* that's too big to put in the database |
+| **What's in it** | Every record Flyte uses to *describe* your runs, plus pointers to where each run's inputs and outputs live | Every run's inputs and outputs, and all bulk/offloaded content |
 | **Lifetime** | Durable; long-lived history | Durable, but you can apply lifecycle/retention rules |
 
 {{< variant union >}}
@@ -26,25 +26,25 @@ When you run a Flyte task, your data ends up in two stores: a **database** in th
 {{< /markdown >}}
 {{< /variant >}}
 
-The database is the **source of truth for what executed**. The bucket is **where the actual bytes live** when those bytes are too big to inline.
+The database is the **source of truth for what executed**. The bucket is **where your runs' actual input and output values live**.
 
 ## What goes in the database
 
-The control-plane database holds everything Flyte needs to enumerate, schedule, and replay your work — but only the *small* values directly. Specifically:
+The control-plane database holds everything Flyte needs to enumerate, schedule, and replay your work. Specifically:
 
-- **Registrations** — every task you've deployed, every trigger you've registered, every project and domain.
+- **Registrations** — every task you've deployed, every trigger you've registered, every project and domain. A task's definition includes its *default* input values, which are stored inline as part of the registration.
 - **Execution records** — every run, every action (task / trace / condition) inside that run, attempts, phases, timing, error messages, parent/child relationships.
 - **Schedules and triggers** — `Cron`, event triggers, and their revision history.
-- **Small input/output values** — primitives (`int`, `str`, `bool`), small JSON-serializable dataclasses, and other values that fit inline as a protobuf literal. These are stored *by value* in the database.
+- **Pointers to runtime inputs and outputs** — the database stores the *URI* of each run's `inputs.pb` / `outputs.pb`, not the values themselves. (One exception: an awaited *condition* / approval action stores the value that satisfies it inline.)
 - **Caches** — the cache key → output-URI mapping for `@env.task(cache=...)`.
 
-That last one matters: if your task takes an `int` and returns an `int`, those numbers are in the database, not the bucket.
+The values your tasks actually pass at runtime — even a bare `int` — do **not** live in the database. They are written to `inputs.pb` / `outputs.pb` in the bucket, and the database keeps only the pointer. See the next section.
 
 (Internally, Flyte uses several backing databases — Postgres for registrations and run history, separate stores for in-flight action coordination and caches. For developer purposes the only thing that matters is that they're all small-record, structured stores; none of them hold bulk content.)
 
 ## What goes in the bucket
 
-Anything too large to inline gets written to the bucket, and the database stores a **pointer** (URI) to it. In particular:
+Every run's inputs and outputs are written to the bucket as `inputs.pb` / `outputs.pb`, and the database stores a **pointer** (URI) to them. Within those files, small scalar values are inlined directly while large values are offloaded to separate objects and referenced by URI. The bucket holds:
 
 - **Task inputs**, serialized as `inputs.pb` per run.
 - **Task outputs**, serialized as `outputs.pb` per attempt.
@@ -62,7 +62,7 @@ The word "metadata" appears in several places and means a different thing each t
 
 ### 1. "Metadata" as in the control-plane database (Flyte's usage)
 
-When Flyte documentation says **"metadata is preserved"** or **"metadata lives in the control plane,"** it means the database records above: registrations, run history, status, small literal values. It does **not** mean "the contents of the bucket."
+When Flyte documentation says **"metadata is preserved"** or **"metadata lives in the control plane,"** it means the database records above: registrations (including task default values), run history, and status. It does **not** mean "the contents of the bucket."
 
 This is the sense most relevant to you: the database is durable, and losing the bucket does not lose your execution history — it loses the *large values* those history records pointed at.
 
@@ -97,7 +97,7 @@ See [Run context](../task-deployment/run-context) for the full set of `with_runc
 If a retention rule deletes objects out of the bucket, the database records that pointed at them are **not** deleted — but their pointers now dangle. Concretely:
 
 - Execution history, status, timing, structure: **still visible** in the UI. They come from the database.
-- Input/output **previews of offloaded values, Deck views, artifact payloads**: show "not found" if the underlying bytes were purged.
+- Input/output **previews, Deck views, artifact payloads**: show "not found" if the underlying bytes were purged.
 - **Cache hits** for purged outputs: the cached pointer is dead, the task re-executes.
 - **Trace resumption**: not possible if the checkpoint blob is gone.
 - **Re-running an old execution**: fails if any input it needs has been purged.
@@ -114,7 +114,7 @@ For how retention policies are configured in your deployment, see [BYOC data ret
 
 ## The short version
 
-- **Database** = the system of record. Holds registrations, run history, schedules, and small inline values.
-- **Bucket** = the object-store bucket. Holds large inputs/outputs, Decks, checkpoints, code bundles, and offloaded `File` / `Dir` / `DataFrame` contents.
+- **Database** = the system of record. Holds registrations (including task default values), run history, schedules, and pointers to each run's inputs/outputs.
+- **Bucket** = the object-store bucket. Holds every run's `inputs.pb`/`outputs.pb`, Decks, checkpoints, code bundles, and offloaded `File` / `Dir` / `DataFrame` contents.
 - **"Metadata" in docs** usually means database-side records. **"Metadata bucket" in Helm/ops** is legacy naming for the data-plane bucket — it does *not* hold database metadata.
 - **`flyte.with_runcontext(raw_data_path=...)`** is your knob to send offloaded data elsewhere per run.

--- a/content/user-guide/task-configuration/secrets.md
+++ b/content/user-guide/task-configuration/secrets.md
@@ -104,4 +104,4 @@ For example:
 > A `TaskEnvironment` can only access a secret if the scope of the secret includes the project and domain where the `TaskEnvironment` is deployed.
 
 > [!WARNING]
-> Do not return secret values from tasks, as this will expose secrets to the control plane.
+> Do not return secret values from tasks. Returned values are stored in plaintext in your data plane's object store and shown in the UI and to downstream tasks, defeating the secret store's protections.


### PR DESCRIPTION
Follow-on consistency pass over the **deployment** section after the security restructure ([#1043](https://github.com/unionai/unionai-docs/pull/1043)). Reviewed the section against the shipped two-plane separation; both architecture diagrams check out, and there are no broken cross-refs to the deleted security pages.

### 1. Control plane no longer described as reading/caching raw data
`byoc/platform-architecture.md` and `selfmanaged/architecture/overview.md` (a near-duplicate "Execution data" section) said raw data *"is read by (and may be temporarily cached) by the control plane."* This contradicts the canonical claim (*"Not in flight. Not at rest. Not ever."*) and `security/data-protection/classification-and-residency.md`, where bulk data is served via signed URL direct to/from object store and never enters the control plane. Reworded: fetched directly from the data-plane object store via presigned URLs issued by the data-plane `dataproxy` service.

### 2. Dropped surviving "zero trust proxy" brand phrasing
`deployment/_index.md` described the inter-plane link as *"an outgoing port through a zero trust proxy."* The "Zero Trust" brand name was scrubbed from public docs during the restructure; this was the only surviving hit in the deployment tree. Now describes the outbound-only gRPC channel directly.

### 3. Corrected literal-data residency (was deferred; now resolved via a code dive)
The deployment pages claimed small **literal** values *"may be stored in the control plane,"* which agreed with `user-guide/core-concepts/where-data-lives.md` but conflicted with `classification-and-residency.md`. A static read of the Flyte 2 backend (`unionai/cloud`) settled it: **runtime task inputs/outputs — even small scalars — are not stored in the control-plane database.** They are serialized to `inputs.pb`/`outputs.pb` in the data-plane object store; the control plane keeps only URI pointers plus orchestration metadata.

Evidence: `workflow/service/data_offloader.go` always writes I/O to `DataPlaneObjectStore()` (no size threshold); `run_service.go` uploads inputs then stores `InputUri`; the Scylla `actions` schema has `output_uri text` and an inline `output blob` the model marks *"ConditionAction only"*; the event proto's inline `input_data`/`output_data` LiteralMaps have no non-generated consumers.

So `classification-and-residency.md` was correct. This PR fixes the two deployment pages (the "Literal data" subsection and the now-false "Data privacy" warning) **and** `where-data-lives.md` (the central DB-vs-bucket claim), and documents the one genuine inline-literal-on-CP case: an awaited *condition* / approval action stores its satisfying value inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)