### PR TITLE
selfhosted: document dataplane self-registration

### DIFF
--- a/content/deployment/selfhosted/getting-started.md
+++ b/content/deployment/selfhosted/getting-started.md
@@ -394,13 +394,13 @@ If authentication is enabled on the control plane, also set `AUTH_CLIENT_ID` in 
 ### Data plane self-registration
 
 > [!NOTE]
-> Self-registration is **opt-in as of 2026.7.0** and becomes the default in a future release; it requires the control plane and data planes on 2026.7.0 or later. Leaving it off preserves the legacy admin-set `DataplaneIngressURL` flow. See the helm-charts [control plane](https://github.com/unionai/helm-charts/releases/tag/controlplane-2026.7.0) and [data plane](https://github.com/unionai/helm-charts/releases/tag/dataplane-2026.7.0) release notes.
+> Self-registration is **opt-in as of 2026.7.0** and becomes the default in a future release; it requires the control plane and data planes on 2026.7.0 or later. Leaving it off keeps the existing behavior — the control plane routes to its statically-configured data plane URL. See the helm-charts [control plane](https://github.com/unionai/helm-charts/releases/tag/controlplane-2026.7.0) and [data plane](https://github.com/unionai/helm-charts/releases/tag/dataplane-2026.7.0) release notes.
 
 The data plane operator self-registers with the control plane on first contact — no manual provisioning step is required. On startup, the operator:
 
 1. Uses its existing OAuth client credentials (configured into the chart via `AUTH_CLIENT_ID` + secret) to authenticate to the control plane.
 2. The control plane's authorizer recognizes the identity (bound to the org admin policy at install time via the control plane chart's `services.authorizer.configMap.authorizer.bootstrap.serviceAccounts` block) and lazily creates the per-cluster authz Resource on the first `Heartbeat` and `UpdateStatus` call.
-3. On every `UpdateStatus` call, the operator reports a `connection_config` blob — the data the control plane needs to dial back to this data plane on the zero-trust execution path. This replaces the previous admin-set ingress URL flow.
+3. On every `UpdateStatus` call, the operator reports a `connection_config` blob — the reachable host and TLS posture the control plane uses to dial this data plane, so it can reach a data plane in a separate cluster without a statically-configured endpoint.
 
 For the third step to take effect, opt in and set the data plane's externally-reachable hostname in the chart's `updateStatus.connectionConfig` block:
 
@@ -422,7 +422,7 @@ updateStatus:
     insecureSkipVerify: false
 ```
 
-If `host` is left empty, the operator skips self-reporting and the control plane falls back to its legacy admin-set `DataplaneIngressURL`.
+If `host` is left empty, the operator skips self-reporting and the control plane routes to its statically-configured data plane URL (the intra-cluster default).
 
 For a control plane serving **multiple** data planes, also set the dataproxy `clusterSelector.type: direct` on the control-plane chart so it routes across data planes using these self-reports; the default `local` does single-data-plane self-resolution only. Once enabled, adding a further data plane needs no control plane re-deploy.
 

--- a/content/deployment/selfhosted/getting-started.md
+++ b/content/deployment/selfhosted/getting-started.md
@@ -393,8 +393,8 @@ If authentication is enabled on the control plane, also set `AUTH_CLIENT_ID` in 
 
 ### Data plane self-registration
 
-> [!NOTE] Available as of the 2026.7.0 release
-> Self-registration requires **both the control plane and the data plane on 2026.7.0 or later**. The ability to read the operator's self-reported `connection_config` and construct the dial-back target is added to the control plane in this release, so update the control plane before (or together with) the data planes that rely on it. On an earlier control plane the self-report is ignored and routing falls back to the admin-set `DataplaneIngressURL`.
+> [!NOTE]
+> Self-registration is **opt-in as of 2026.7.0** and becomes the default in a future release; it requires the control plane and data planes on 2026.7.0 or later. Leaving it off preserves the legacy admin-set `DataplaneIngressURL` flow. See the [release notes](../../release-notes).
 
 The data plane operator self-registers with the control plane on first contact — no manual provisioning step is required. On startup, the operator:
 
@@ -402,11 +402,14 @@ The data plane operator self-registers with the control plane on first contact �
 2. The control plane's authorizer recognizes the identity (bound to the org admin policy at install time via the control plane chart's `services.authorizer.configMap.authorizer.bootstrap.serviceAccounts` block) and lazily creates the per-cluster authz Resource on the first `Heartbeat` and `UpdateStatus` call.
 3. On every `UpdateStatus` call, the operator reports a `connection_config` blob — the data the control plane needs to dial back to this data plane on the zero-trust execution path. This replaces the previous admin-set ingress URL flow.
 
-For the third step to take effect, set the dataplane's externally-reachable hostname in the chart's `updateStatus.connectionConfig` block:
+For the third step to take effect, opt in and set the data plane's externally-reachable hostname in the chart's `updateStatus.connectionConfig` block:
 
 ```yaml
 updateStatus:
   connectionConfig:
+    # Opt in to self-reporting (off by default). Enable only on operator
+    # images that support connection_config.
+    enabled: true
     # DP-reachable hostname the control plane should dial back to reach this
     # data plane. The operator self-reports this bare host in every
     # UpdateStatus call; the control plane (2026.7.0+) constructs the dial
@@ -419,7 +422,9 @@ updateStatus:
     insecureSkipVerify: false
 ```
 
-If `host` is left empty, the operator skips self-reporting and the control plane falls back to its legacy admin-set `DataplaneIngressURL`. Adding a new data plane to a multi-DP installation works the same way — no control plane re-deploy required.
+If `host` is left empty, the operator skips self-reporting and the control plane falls back to its legacy admin-set `DataplaneIngressURL`.
+
+For a control plane serving **multiple** data planes, also set the dataproxy `clusterSelector.type: direct` on the control-plane chart so it routes across data planes using these self-reports; the default `local` does single-data-plane self-resolution only. Once enabled, adding a further data plane needs no control plane re-deploy.
 
 ## Step 9: Verify the installation
 

--- a/content/deployment/selfhosted/getting-started.md
+++ b/content/deployment/selfhosted/getting-started.md
@@ -393,6 +393,9 @@ If authentication is enabled on the control plane, also set `AUTH_CLIENT_ID` in 
 
 ### Data plane self-registration
 
+> [!NOTE] Available as of the 2026.7.0 release
+> Self-registration requires **both the control plane and the data plane on 2026.7.0 or later**. The ability to read the operator's self-reported `connection_config` and construct the dial-back target is added to the control plane in this release, so update the control plane before (or together with) the data planes that rely on it. On an earlier control plane the self-report is ignored and routing falls back to the admin-set `DataplaneIngressURL`.
+
 The data plane operator self-registers with the control plane on first contact — no manual provisioning step is required. On startup, the operator:
 
 1. Uses its existing OAuth client credentials (configured into the chart via `AUTH_CLIENT_ID` + secret) to authenticate to the control plane.
@@ -405,8 +408,9 @@ For the third step to take effect, set the dataplane's externally-reachable host
 updateStatus:
   connectionConfig:
     # DP-reachable hostname the control plane should dial back to reach this
-    # data plane. The chart formats this as `dns:///<host>:443` and the
-    # operator ships it in every UpdateStatus call.
+    # data plane. The operator self-reports this bare host in every
+    # UpdateStatus call; the control plane (2026.7.0+) constructs the dial
+    # target (dns:///<host>:443) and reverse-proxy URL from it.
     host: "dp-1.internal.<your-tenant-domain>"
     # CP dials with plain HTTP/2 when true. Default false.
     insecure: false

--- a/content/deployment/selfhosted/getting-started.md
+++ b/content/deployment/selfhosted/getting-started.md
@@ -391,6 +391,32 @@ helm upgrade --install unionai-dataplane unionai/dataplane \
 
 If authentication is enabled on the control plane, also set `AUTH_CLIENT_ID` in your overrides file. See [Authentication](./authentication).
 
+### Data plane self-registration
+
+The data plane operator self-registers with the control plane on first contact — no manual provisioning step is required. On startup, the operator:
+
+1. Uses its existing OAuth client credentials (configured into the chart via `AUTH_CLIENT_ID` + secret) to authenticate to the control plane.
+2. The control plane's authorizer recognizes the identity (bound to the org admin policy at install time via the control plane chart's `services.authorizer.configMap.authorizer.bootstrap.serviceAccounts` block) and lazily creates the per-cluster authz Resource on the first `Heartbeat` and `UpdateStatus` call.
+3. On every `UpdateStatus` call, the operator reports a `connection_config` blob — the data the control plane needs to dial back to this data plane on the zero-trust execution path. This replaces the previous admin-set ingress URL flow.
+
+For the third step to take effect, set the dataplane's externally-reachable hostname in the chart's `updateStatus.connectionConfig` block:
+
+```yaml
+updateStatus:
+  connectionConfig:
+    # DP-reachable hostname the control plane should dial back to reach this
+    # data plane. The chart formats this as `dns:///<host>:443` and the
+    # operator ships it in every UpdateStatus call.
+    host: "dp-1.internal.<your-tenant-domain>"
+    # CP dials with plain HTTP/2 when true. Default false.
+    insecure: false
+    # CP skips TLS cert validation. Set true for envs where the data plane
+    # presents a self-signed certificate.
+    insecureSkipVerify: false
+```
+
+If `host` is left empty, the operator skips self-reporting and the control plane falls back to its legacy admin-set `DataplaneIngressURL`. Adding a new data plane to a multi-DP installation works the same way — no control plane re-deploy required.
+
 ## Step 9: Verify the installation
 
 ```shell

--- a/content/deployment/selfhosted/getting-started.md
+++ b/content/deployment/selfhosted/getting-started.md
@@ -394,7 +394,7 @@ If authentication is enabled on the control plane, also set `AUTH_CLIENT_ID` in 
 ### Data plane self-registration
 
 > [!NOTE]
-> Self-registration is **opt-in as of 2026.7.0** and becomes the default in a future release; it requires the control plane and data planes on 2026.7.0 or later. Leaving it off preserves the legacy admin-set `DataplaneIngressURL` flow. See the [release notes](../../release-notes).
+> Self-registration is **opt-in as of 2026.7.0** and becomes the default in a future release; it requires the control plane and data planes on 2026.7.0 or later. Leaving it off preserves the legacy admin-set `DataplaneIngressURL` flow. See the helm-charts [control plane](https://github.com/unionai/helm-charts/releases/tag/controlplane-2026.7.0) and [data plane](https://github.com/unionai/helm-charts/releases/tag/dataplane-2026.7.0) release notes.
 
 The data plane operator self-registers with the control plane on first contact — no manual provisioning step is required. On startup, the operator:
 

--- a/content/release-notes/_index.md
+++ b/content/release-notes/_index.md
@@ -7,6 +7,12 @@ top_menu: true
 
 # Release notes
 
+## July 2026
+
+### :gear: Self-Hosted Data Plane Self-Registration (Opt-In)
+
+Self-hosted data planes can now register with the control plane automatically: the operator creates its authorization resources on first contact and self-reports how the control plane should reach it, so routing works without a manual provisioning step or an admin-set ingress URL. This is opt-in in 2026.7.0 and becomes the default in a future release. See [Self-hosted → Getting started](../deployment/selfhosted/getting-started#data-plane-self-registration) for how to enable it.
+
 ## June 2026
 
 

--- a/content/release-notes/_index.md
+++ b/content/release-notes/_index.md
@@ -7,12 +7,6 @@ top_menu: true
 
 # Release notes
 
-## July 2026
-
-### :gear: Self-Hosted Data Plane Self-Registration (Opt-In)
-
-Self-hosted data planes can now register with the control plane automatically: the operator creates its authorization resources on first contact and self-reports how the control plane should reach it, so routing works without a manual provisioning step or an admin-set ingress URL. This is opt-in in 2026.7.0 and becomes the default in a future release. See [Self-hosted → Getting started](../deployment/selfhosted/getting-started#data-plane-self-registration) for how to enable it.
-
 ## June 2026
 
 


### PR DESCRIPTION
## Summary

Extends `selfhosted/getting-started.md` Step 8 with a "Data plane self-registration" section explaining the operator's new self-registration flow:

- Lazy authz Resource creation on the first Heartbeat / UpdateStatus (no manual `provisionctl` or `uctl selfserve` step needed for selfhosted installs).
- The operator self-reports `connection_config` on every UpdateStatus so the control plane can dial back on the zero-trust SelectCluster path.
- The chart's `updateStatus.connectionConfig` block (`host`, `insecure`, `insecureSkipVerify`) drives the operator's self-report.

## Availability

Ships in the **2026.7.0** release. The section notes that self-registration requires **both the control plane and the data plane on 2026.7.0+** — reading the self-reported `connection_config` and constructing the dial-back target is added to the control plane in that release, so the control plane must be updated before (or with) the data planes that depend on it.

## Backward compatibility

The section explicitly notes that empty `host` keeps the legacy admin-set `DataplaneIngressURL` flow intact, so existing installs see no behavior change. The operator self-reports a **bare host**; the control plane constructs the `dns:///<host>:443` dial target and reverse-proxy URL from it (corrected from an earlier draft that said the chart formats the dial target).

## Related

Companion code changes ship in:
- Cloud PR: middleware Org-scope auth, lazy Resource creation, proto + cluster model column + SelectCluster fallback, operator self-reporting, terraform wiring.
- Helm-charts PR: chart values block + connection_config ConfigMap + operator mount.