### PR TITLE
move from metal to custom

### DIFF
--- a/content/deployment/selfmanaged/selfmanaged-coreweave/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-coreweave/deploy-dataplane.md
@@ -33,11 +33,11 @@ If you have not yet set up the required CoreWeave resources (CKS cluster, AI Obj
 
    ```bash
    uctl config init --host=<ORG_NAME>.union.ai
-   uctl selfserve provision-dataplane-resources --clusterName <CLUSTER_NAME> --provider metal
+   uctl selfserve provision-dataplane-resources --clusterName <CLUSTER_NAME> --provider custom
    ```
 
    * The command will output the ID, name, and a secret that will be used by the Union services to communicate with your control plane.
-     It will also generate a YAML values file specific to the `metal` provider.
+     It will also generate a YAML values file specific to the `custom` provider.
 
    * Save the secret that is displayed. Union does not store the credentials; rerunning the same command can be used to retrieve the secret later.
 
@@ -47,7 +47,7 @@ If you have not yet set up the required CoreWeave resources (CKS cluster, AI Obj
    host: <ORG_NAME>.union.ai
    clusterName: <CLUSTER_NAME>
    orgName: <ORG_NAME>
-   provider: metal
+   provider: custom
 
    storage:
      provider: custom

--- a/content/deployment/selfmanaged/selfmanaged-crusoe/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-crusoe/deploy-dataplane.md
@@ -33,15 +33,15 @@ If you have not yet set up the required Crusoe resources (CMK cluster, Cloud Sto
 
    ```bash
    uctl config init --host=<ORG_NAME>.union.ai
-   uctl selfserve provision-dataplane-resources --clusterName <CLUSTER_NAME> --provider metal
+   uctl selfserve provision-dataplane-resources --clusterName <CLUSTER_NAME> --provider custom
    ```
 
    * The command will output the ID, name, and a secret that will be used by the Union services to communicate with your control plane.
-     It will also generate a YAML values file specific to the `metal` provider.
+     It will also generate a YAML values file specific to the `custom` provider.
 
    * Save the secret that is displayed. Union does not store the credentials; rerunning the same command can be used to retrieve the secret later.
 
-   We use `--provider metal` for Crusoe because the Union operator treats Crusoe as a generic S3-compatible / Kubernetes environment rather than a first-class cloud provider integration (like AWS/GCP/Azure).
+   We use `--provider custom` for Crusoe because the Union operator treats Crusoe as a generic S3-compatible / Kubernetes environment rather than a first-class cloud provider integration (like AWS/GCP/Azure).
 
 3. Update the generated values file with your Crusoe-specific storage configuration. Replace the placeholders with your actual credentials and settings.
 
@@ -49,7 +49,7 @@ If you have not yet set up the required Crusoe resources (CMK cluster, Cloud Sto
    host: <ORG_NAME>.union.ai
    clusterName: <CLUSTER_NAME>
    orgName: <ORG_NAME>
-   provider: metal
+   provider: custom
 
    storage:
      provider: custom

--- a/content/deployment/selfmanaged/selfmanaged-generic/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-generic/deploy-dataplane.md
@@ -34,11 +34,11 @@ If you have not yet set up the required resources (Kubernetes cluster, object st
 
    ```bash
    uctl config init --host=<YOUR_UNION_CONTROL_PLANE_URL>
-   uctl selfserve provision-dataplane-resources --clusterName <YOUR_SELECTED_CLUSTERNAME>  --provider metal
+   uctl selfserve provision-dataplane-resources --clusterName <YOUR_SELECTED_CLUSTERNAME>  --provider custom
    ```
 
    * The command will output the ID, name, and a secret that will be used by the Union services to communicate with your control plane.
-     It will also generate a YAML file specific to the provider that you specify, in this case `metal` (bare metal / generic).
+     It will also generate a YAML file specific to the provider that you specify, in this case `custom` (generic / on-premise).
 
    * Save the secret that is displayed. Union does not store the credentials; rerunning the same command can be used to retrieve the secret later.
 

--- a/content/deployment/selfmanaged/selfmanaged-nebius/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-nebius/deploy-dataplane.md
@@ -35,10 +35,10 @@ If you have not yet set up the required Nebius resources (MK8s cluster, Object S
 
    ```bash
    uctl config init --host=<ORG_NAME>.union.ai
-   uctl selfserve provision-dataplane-resources --clusterName <CLUSTER_NAME> --provider metal
+   uctl selfserve provision-dataplane-resources --clusterName <CLUSTER_NAME> --provider custom
    ```
 
-   The command generates a YAML values file specific to the `metal` provider, including the secrets necessary so your data plane can communicate with Union's control plane.
+   The command generates a YAML values file specific to the `custom` provider, including the secrets necessary so your data plane can communicate with Union's control plane.
 
 3. Update the generated values file with your Nebius-specific storage configuration. Replace the placeholders with your actual credentials and settings.
 
@@ -46,7 +46,7 @@ If you have not yet set up the required Nebius resources (MK8s cluster, Object S
    host: <ORG_NAME>.union.ai
    clusterName: <CLUSTER_NAME>
    orgName: <ORG_NAME>
-   provider: metal
+   provider: custom
 
    storage:
      accessKey: <YOUR_BUCKET_ACCESS_KEY>


### PR DESCRIPTION
Update self managed setup instructions for non aws/azure/gcp environments to not use unsupported `metal` provider anymore