### PR TITLE
docs(security): standardize "Zero Trust" capitalization + "Direct-to-Data-Plane"

### DIFF
--- a/content/security/_index.md
+++ b/content/security/_index.md
@@ -1,17 +1,17 @@
 ---
-title: Zero-trust security
+title: Zero Trust security
 weight: 6
 variants: -flyte +union
 top_menu: true
 ---
 
-# Zero-trust security
+# Zero Trust security
 
-Union.ai is built on a **Zero-trust security** model: no component is trusted by default, every request is authenticated and authorized, and customer data, code, and secrets never leave the customer's own data plane.
+Union.ai is built on a **Zero Trust security** model: no component is trusted by default, every request is authenticated and authorized, and customer data, code, and secrets never leave the customer's own data plane.
 This section provides a comprehensive overview of that model — Union.ai's security architecture, practices, and compliance posture — for enterprise security professionals evaluating the platform.
 Beyond describing the model, it provides concrete verification steps so that reviewers can independently confirm each claim against a running system.
 
-> **Zero-trust, in one line:** No customer data, code, or logs ever touch Union.ai's control plane. Not in flight. Not at rest. Not ever.
+> **Zero Trust, in one line:** No customer data, code, or logs ever touch Union.ai's control plane. Not in flight. Not at rest. Not ever.
 
 ## Overview
 
@@ -22,7 +22,7 @@ Enterprise customers can further restrict the client-to-data-plane path with the
 No inbound firewall rules are required on the customer's external network perimeter under either configuration.
 
 **[Data protection](./data-protection/_index)**
-No customer data ever transits Union.ai's control plane. Workflow inputs and outputs, code bundles, secret values, logs, reports, and auxiliary UI traffic are served directly from the customer's data plane through the Direct-to-DataPlane tunnel, with authentication and RBAC enforced by an Envoy router inside the customer's cluster.
+No customer data ever transits Union.ai's control plane. Workflow inputs and outputs, code bundles, secret values, logs, reports, and auxiliary UI traffic are served directly from the customer's data plane through the Direct-to-Data-Plane tunnel, with authentication and RBAC enforced by an Envoy router inside the customer's cluster.
 The control plane holds orchestration metadata only -- run IDs, schedules, phase transitions, task definitions, error messages, and the RBAC graph -- always encrypted at rest.
 
 **[Identity and access](./identity-and-access/_index)**

--- a/content/security/architecture/_index.md
+++ b/content/security/architecture/_index.md
@@ -7,7 +7,7 @@ sidebar_expanded: true
 
 # Architecture
 
-Union.ai's **Zero-trust security** architecture rests on a foundational division between the Union.ai-hosted control plane, which orchestrates execution, and the customer-hosted data plane, where all computation occurs and all customer data resides. Under this model nothing is trusted implicitly: the data plane initiates all communication with the control plane over an outbound-only channel, requiring no inbound firewall rules on the customer side, and every customer-data request is authenticated and authorized inside the customer's cluster.
+Union.ai's **Zero Trust security** architecture rests on a foundational division between the Union.ai-hosted control plane, which orchestrates execution, and the customer-hosted data plane, where all computation occurs and all customer data resides. Under this model nothing is trusted implicitly: the data plane initiates all communication with the control plane over an outbound-only channel, requiring no inbound firewall rules on the customer side, and every customer-data request is authenticated and authorized inside the customer's cluster.
 
 In the BYOC model, Union.ai manages the data plane over a private connection. In the self-managed model, the customer manages the data plane themselves. In both cases, the same security controls apply, and the same [data residency guarantees](../data-protection/classification-and-residency) hold.
 
@@ -19,8 +19,8 @@ This section covers:
 
 * **[Data plane](./data-plane)**: The data plane runs entirely within the customer's cloud account. All computation occurs here and all customer data resides here. It uses workload identity federation (IRSA / Workload Identity / Azure Workload Identity) instead of static credentials, so no long-lived access keys are stored on the data plane.
 
-* **[Network architecture](./network)**: The data plane initiates all communication with Union.ai over an outbound-only direct gRPC connection. Customer-data requests flow client-to-data-plane through the Direct-to-DataPlane tunnel, terminating at an Envoy router inside the customer's cluster. There is no inbound attack surface on the customer's external network and therefore no firewall rules are required at the perimeter.
+* **[Network architecture](./network)**: The data plane initiates all communication with Union.ai over an outbound-only direct gRPC connection. Customer-data requests flow client-to-data-plane through the Direct-to-Data-Plane tunnel, terminating at an Envoy router inside the customer's cluster. There is no inbound attack surface on the customer's external network and therefore no firewall rules are required at the perimeter.
 
-* **[Sovereign Data Plane](./sovereign-data-plane)**: An Enterprise-tier option that replaces the Direct-to-DataPlane tunnel with a customer-managed load balancer inside the customer's VPC, reachable only from the corporate VPN. No third-party network can reach the data plane; Union.ai employees cannot reach customer data even with full Union.ai credentials.
+* **[Sovereign Data Plane](./sovereign-data-plane)**: An Enterprise-tier option that replaces the Direct-to-Data-Plane tunnel with a customer-managed load balancer inside the customer's VPC, reachable only from the corporate VPN. No third-party network can reach the data plane; Union.ai employees cannot reach customer data even with full Union.ai credentials.
 
 * **[Private connectivity (BYOC)](./private-connectivity)**: In the BYOC model, Union.ai manages the customer's Kubernetes cluster via PrivateLink, Private Service Connect, or Azure Private Link. The Kubernetes API is never exposed to the public internet.

--- a/content/security/architecture/control-plane.md
+++ b/content/security/architecture/control-plane.md
@@ -8,7 +8,7 @@ variants: -flyte +union
 
 The control plane is the Union.ai-hosted component that orchestrates task execution, manages user access, and provides the API surface. It runs on AWS infrastructure managed by Union.ai and is covered by Union.ai's SOC 2 Type II certification.
 
-The control plane handles only orchestration metadata. Customer data -- workflow inputs and outputs, code bundles, secret values, logs, reports, and auxiliary UI traffic -- never transits the control plane in any form, not even transiently in memory. Those requests are served directly from the data plane through the [Direct-to-DataPlane tunnel](./network).
+The control plane handles only orchestration metadata. Customer data -- workflow inputs and outputs, code bundles, secret values, logs, reports, and auxiliary UI traffic -- never transits the control plane in any form, not even transiently in memory. Those requests are served directly from the data plane through the [Direct-to-Data-Plane tunnel](./network).
 
 ## What it stores
 

--- a/content/security/architecture/data-plane.md
+++ b/content/security/architecture/data-plane.md
@@ -13,7 +13,7 @@ The data plane runs entirely within the customer's cloud account on a Kubernetes
 
 The data plane consists of several components, each handling a specific aspect of task execution and data management.
 
-**Envoy router** is the AuthN/AuthZ enforcement point that fronts every customer-data request entering the cluster. Under the default tier, it sits at the egress of the Direct-to-DataPlane tunnel; under the [Sovereign Data Plane](./sovereign-data-plane) tier, it sits behind the customer-managed internal load balancer. In either case, every request is authenticated against the requester's Union.ai identity and evaluated against the RBAC policy *inside the customer's cluster* before forwarding to the `dataproxy` service. The Union.ai control plane is not on the path.
+**Envoy router** is the AuthN/AuthZ enforcement point that fronts every customer-data request entering the cluster. Under the default tier, it sits at the egress of the Direct-to-Data-Plane tunnel; under the [Sovereign Data Plane](./sovereign-data-plane) tier, it sits behind the customer-managed internal load balancer. In either case, every request is authenticated against the requester's Union.ai identity and evaluated against the RBAC policy *inside the customer's cluster* before forwarding to the `dataproxy` service. The Union.ai control plane is not on the path.
 
 **Dataproxy service** is the single endpoint for every customer-data request. It handles:
 
@@ -27,7 +27,7 @@ The data plane consists of several components, each handling a specific aspect o
 
 **Image Builder** uses Buildkit running on the customer's Kubernetes cluster to build container images from user-submitted `Image` specifications. Source code and built images never leave the customer's infrastructure. Base images are pulled from customer-configured registries, and built images are pushed to the customer's container registry (ECR, GCR, or ACR).
 
-**Tunnel Service** maintains the outbound-only encrypted Direct-to-DataPlane tunnel (a Cloudflare Tunnel under the hood) from the data plane to the Cloudflare edge under the default tier. This service initiates the tunnel (no inbound ports required), performs health checks and heartbeats, and automatically reconnects if the connection drops. Under the [Sovereign Data Plane](./sovereign-data-plane) tier, the Tunnel Service is replaced by a customer-managed internal load balancer that fronts the Envoy router; the rest of the data-plane components are identical.
+**Tunnel Service** maintains the outbound-only encrypted Direct-to-Data-Plane tunnel (a Cloudflare Tunnel under the hood) from the data plane to the Cloudflare edge under the default tier. This service initiates the tunnel (no inbound ports required), performs health checks and heartbeats, and automatically reconnects if the connection drops. Under the [Sovereign Data Plane](./sovereign-data-plane) tier, the Tunnel Service is replaced by a customer-managed internal load balancer that fronts the Envoy router; the rest of the data-plane components are identical.
 
 In addition to the client-to-data-plane path, the data plane operator establishes a separate outbound gRPC connection (TLS) to the regional control plane endpoint for orchestration RPCs (cluster registration, action lifecycle, event reporting, catalog and artifact lookups, admin RPCs). This channel is outbound-initiated under both tiers and carries no customer data. See [Network architecture](./network) for the channel details.
 

--- a/content/security/architecture/network.md
+++ b/content/security/architecture/network.md
@@ -6,7 +6,7 @@ variants: -flyte +union
 
 # Network architecture
 
-The network architecture reinforces the [two-plane separation](./two-plane-separation) with an outbound-only connectivity model between the data plane and the control plane. The data plane initiates an outbound-only direct gRPC connection to the control plane for orchestration metadata. Client-to-data-plane traffic uses a separate channel: by default, an outbound-initiated Direct-to-DataPlane tunnel terminating at an Envoy router inside the customer's cluster; under the [Sovereign Data Plane](./sovereign-data-plane) tier, a customer-managed load balancer inside the customer's VPC instead. Under either tier, no inbound firewall rules are required on the customer's external perimeter.
+The network architecture reinforces the [two-plane separation](./two-plane-separation) with an outbound-only connectivity model between the data plane and the control plane. The data plane initiates an outbound-only direct gRPC connection to the control plane for orchestration metadata. Client-to-data-plane traffic uses a separate channel: by default, an outbound-initiated Direct-to-Data-Plane tunnel terminating at an Envoy router inside the customer's cluster; under the [Sovereign Data Plane](./sovereign-data-plane) tier, a customer-managed load balancer inside the customer's VPC instead. Under either tier, no inbound firewall rules are required on the customer's external perimeter.
 
 ## Outbound-only model
 
@@ -20,9 +20,9 @@ Under the [Sovereign Data Plane](./sovereign-data-plane) tier, the client-to-dat
 
 The client-to-data-plane path is direct: client → tunnel (or internal load balancer under the Sovereign Data Plane tier) → Envoy router → `dataproxy` → customer storage. Log streaming, structured I/O retrieval, and large input uploads complete with low first-byte and end-to-end latency.
 
-## Direct-to-DataPlane tunnel
+## Direct-to-Data-Plane tunnel
 
-The Direct-to-DataPlane tunnel is an outbound-only encrypted Cloudflare Tunnel from the customer's cluster to the Cloudflare edge network. It is initiated by a `cloudflared` daemon in the data plane and carries only client-to-data-plane traffic; the data-plane-to-control-plane channel is the separate direct gRPC connection described below. The tunnel **terminates inside the customer's cluster** at an Envoy router that authenticates each request against Union identity and enforces RBAC before forwarding to the data-plane `dataproxy` service. The Union.ai control plane is not on this path. For background on the underlying connector, see Cloudflare's [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/) documentation.
+The Direct-to-Data-Plane tunnel is an outbound-only encrypted Cloudflare Tunnel from the customer's cluster to the Cloudflare edge network. It is initiated by a `cloudflared` daemon in the data plane and carries only client-to-data-plane traffic; the data-plane-to-control-plane channel is the separate direct gRPC connection described below. The tunnel **terminates inside the customer's cluster** at an Envoy router that authenticates each request against Union identity and enforces RBAC before forwarding to the data-plane `dataproxy` service. The Union.ai control plane is not on this path. For background on the underlying connector, see Cloudflare's [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/) documentation.
 
 Under the default tier, all traffic through the tunnel is encrypted using a layered transport: TLS 1.3 from the client to the Cloudflare edge, mTLS plus Cloudflare Tunnel encryption from the edge to the data plane, and Cloudflare Access service tokens for application-layer authentication. Tunnel tokens are rotated automatically: the data plane operator periodically polls Union.ai and picks up updated tokens when issued.
 
@@ -36,7 +36,7 @@ In multi-cluster deployments, each data-plane cluster has its own dedicated tunn
 
 ### Sovereign Data Plane
 
-Enterprise customers can replace the Direct-to-DataPlane tunnel entirely with a customer-managed load balancer inside their own VPC, reachable only from the corporate VPN. This makes the data plane unreachable from any third-party network -- including Cloudflare's -- and unreachable to Union.ai employees. See [Sovereign Data Plane](./sovereign-data-plane) for the topology and trade-offs.
+Enterprise customers can replace the Direct-to-Data-Plane tunnel entirely with a customer-managed load balancer inside their own VPC, reachable only from the corporate VPN. This makes the data plane unreachable from any third-party network -- including Cloudflare's -- and unreachable to Union.ai employees. See [Sovereign Data Plane](./sovereign-data-plane) for the topology and trade-offs.
 
 ## Communication paths
 
@@ -45,7 +45,7 @@ All communication paths in the system use encryption. No unencrypted communicati
 | Path | Protocol | Encryption |
 |---|---|---|
 | Client to Control Plane (orchestration API) | HTTPS | TLS 1.2+ |
-| Client to Data Plane (customer-data requests, default tier) | Direct-to-DataPlane tunnel | TLS 1.3 + mTLS |
+| Client to Data Plane (customer-data requests, default tier) | Direct-to-Data-Plane tunnel | TLS 1.3 + mTLS |
 | Client to Data Plane (customer-data requests, Sovereign Data Plane tier) | Customer-managed internal LB (corporate VPN) | TLS (customer-managed) |
 | Data Plane → Control Plane (orchestration metadata, outbound-initiated) | gRPC over TLS | TLS 1.2+ |
 | Client to Object Store | HTTPS (presigned URL) | TLS 1.2+ (cloud provider enforced) |
@@ -83,9 +83,9 @@ For details on the BYOC private management connection, see [Private connectivity
 
 4. (Optional) Run a port scan from an external host against the data plane nodes to confirm no Union.ai-related services are reachable.
 
-### Direct-to-DataPlane tunnel
+### Direct-to-Data-Plane tunnel
 
-**Reviewer focus:** Confirm that bulk data (files, DataFrames, code bundles) transfers directly between clients and the customer's object store via presigned URLs, and that structured task I/O and log streams flow through the Direct-to-DataPlane tunnel directly to the data plane (no Union.ai control plane on the path).
+**Reviewer focus:** Confirm that bulk data (files, DataFrames, code bundles) transfers directly between clients and the customer's object store via presigned URLs, and that structured task I/O and log streams flow through the Direct-to-Data-Plane tunnel directly to the data plane (no Union.ai control plane on the path).
 
 **How to verify:**
 
@@ -99,5 +99,5 @@ For details on the BYOC private management connection, see [Private connectivity
 
 2. Analyze VPC Flow Logs for traffic patterns. Bulk data transfers (files, DataFrames, code bundles) should flow directly between task pods and the customer's object store endpoints (S3/GCS/Azure Blob), not through Cloudflare IPs. Structured task I/O and log streams will flow through the tunnel as documented.
 
-3. Use browser developer tools (Network tab) in the Union.ai UI to confirm that binary output artifacts are fetched via presigned URLs (resolving to the customer's storage domain), while structured outputs are fetched via the data plane through the Direct-to-DataPlane tunnel (resolving to a per-cluster tunnel domain, not a control plane endpoint).
+3. Use browser developer tools (Network tab) in the Union.ai UI to confirm that binary output artifacts are fetched via presigned URLs (resolving to the customer's storage domain), while structured outputs are fetched via the data plane through the Direct-to-Data-Plane tunnel (resolving to a per-cluster tunnel domain, not a control plane endpoint).
 

--- a/content/security/architecture/sovereign-data-plane.md
+++ b/content/security/architecture/sovereign-data-plane.md
@@ -6,7 +6,7 @@ variants: -flyte +union
 
 # Sovereign Data Plane
 
-The Sovereign Data Plane is an Enterprise-tier deployment option that replaces the Direct-to-DataPlane tunnel with a customer-managed load balancer inside the customer's VPC, reachable only from inside the customer's corporate network. In this mode, **the data plane is unreachable from any third-party network -- including Cloudflare's -- and Union.ai employees cannot reach customer data even with full Union.ai credentials.**
+The Sovereign Data Plane is an Enterprise-tier deployment option that replaces the Direct-to-Data-Plane tunnel with a customer-managed load balancer inside the customer's VPC, reachable only from inside the customer's corporate network. In this mode, **the data plane is unreachable from any third-party network -- including Cloudflare's -- and Union.ai employees cannot reach customer data even with full Union.ai credentials.**
 
 This is a strictly stronger network perimeter than the default tier. The identity perimeter (Union RBAC and SSO) is unchanged, and every visualization feature -- input/output inspection, log streaming, auxiliary UIs -- continues to work for users who are connected to the corporate network.
 
@@ -22,9 +22,9 @@ The Sovereign Data Plane is available on the Enterprise tier on customer request
 
 ## How it differs from the default
 
-| | Default (Direct-to-DataPlane) | Sovereign Data Plane |
+| | Default (Direct-to-Data-Plane) | Sovereign Data Plane |
 |---|---|---|
-| Client → data plane path | Direct-to-DataPlane tunnel terminating at the Envoy router inside the customer's cluster | Customer-managed load balancer inside the customer's VPC, terminating at the same Envoy router |
+| Client → data plane path | Direct-to-Data-Plane tunnel terminating at the Envoy router inside the customer's cluster | Customer-managed load balancer inside the customer's VPC, terminating at the same Envoy router |
 | Reachable from | Public internet, gated by Cloudflare + Envoy AuthN/RBAC | Only from inside the customer's corporate network (VPN) |
 | TLS termination | Cloudflare edge, then mTLS to the data plane | Customer-controlled, end-to-end inside the VPC |
 | Who can reach the data plane network | Any authenticated, RBAC-authorized user | Only users on the customer's VPN |
@@ -43,7 +43,7 @@ Switching to the Sovereign Data Plane changes the **network** perimeter only. Ev
 
 ## Topology
 
-The Sovereign Data Plane request flow mirrors the default tier with one substitution: the Direct-to-DataPlane tunnel is replaced by a customer-managed load balancer.
+The Sovereign Data Plane request flow mirrors the default tier with one substitution: the Direct-to-Data-Plane tunnel is replaced by a customer-managed load balancer.
 
 ```
 [Authenticated client on corporate VPN]
@@ -66,7 +66,7 @@ The data plane never accepts a connection from any third-party network. The load
 
 ## Setup
 
-The Sovereign Data Plane is a deployment-time configuration. The customer's SRE/DevOps team provisions a load balancer inside their VPC that is reachable only from the corporate VPN, and the Union.ai data plane is deployed behind it instead of behind the Direct-to-DataPlane tunnel. The exact form of the load balancer (cloud-native, ingress controller, internal ALB/NLB/ILB, route reflector, etc.) depends on the customer's existing infrastructure conventions; Union.ai supports the common patterns.
+The Sovereign Data Plane is a deployment-time configuration. The customer's SRE/DevOps team provisions a load balancer inside their VPC that is reachable only from the corporate VPN, and the Union.ai data plane is deployed behind it instead of behind the Direct-to-Data-Plane tunnel. The exact form of the load balancer (cloud-native, ingress controller, internal ALB/NLB/ILB, route reflector, etc.) depends on the customer's existing infrastructure conventions; Union.ai supports the common patterns.
 
 Existing Union RBAC and SSO continue to apply -- the network perimeter changes, but the identity perimeter does not. Engagement is through Union Solutions Engineering as part of an Enterprise deployment.
 

--- a/content/security/architecture/two-plane-separation.md
+++ b/content/security/architecture/two-plane-separation.md
@@ -8,13 +8,13 @@ variants: -flyte +union
 
 Union.ai's architecture is divided into two distinct planes: a **control plane** hosted by Union.ai on AWS, and a **data plane** that runs on the customer's own Kubernetes cluster within their cloud account.
 
-Two-plane separation is the structural foundation of Union.ai's **Zero-trust security** model: because the control plane never holds customer data, code, or logs, there is no implicit trust to exploit even if the control plane were fully compromised.
+Two-plane separation is the structural foundation of Union.ai's **Zero Trust security** model: because the control plane never holds customer data, code, or logs, there is no implicit trust to exploit even if the control plane were fully compromised.
 
 ## Control plane
 
 The control plane handles workflow orchestration, user management, and the web interface. It stores only the metadata required for these functions; bulk customer data payloads are stored as URI references rather than inline. See [Control plane](./control-plane) for components and infrastructure.
 
-> **Zero-trust, in one line:** No customer data, code, or logs ever touch Union.ai's control plane. Not in flight. Not at rest. Not ever.
+> **Zero Trust, in one line:** No customer data, code, or logs ever touch Union.ai's control plane. Not in flight. Not at rest. Not ever.
 
 ## Data plane
 
@@ -22,7 +22,7 @@ The data plane is where all computation and data handling occurs. It runs entire
 
 ## Risk mitigation
 
-This separation limits the potential impact of a control plane security incident. A compromised control plane would expose only orchestration metadata: run IDs, schedules, phase transitions, task definitions, error messages, and the RBAC graph. It could not expose customer data of any kind -- workflow inputs and outputs, code bundles, log streams, secrets, and auxiliary UI traffic are all served directly from the data plane through the Direct-to-DataPlane tunnel and never enter the control plane in any form.
+This separation limits the potential impact of a control plane security incident. A compromised control plane would expose only orchestration metadata: run IDs, schedules, phase transitions, task definitions, error messages, and the RBAC graph. It could not expose customer data of any kind -- workflow inputs and outputs, code bundles, log streams, secrets, and auxiliary UI traffic are all served directly from the data plane through the Direct-to-Data-Plane tunnel and never enter the control plane in any form.
 
 For the full classification of what data lives in each plane and how each pathway is protected, see [Data classification and residency](../data-protection/classification-and-residency). For a developer-facing view of which records live in the database versus the data-plane bucket, see [Where your data lives](../../user-guide/core-concepts/where-data-lives). For network paths between the planes, see [Network architecture](./network).
 

--- a/content/security/compliance/hipaa.md
+++ b/content/security/compliance/hipaa.md
@@ -8,7 +8,7 @@ variants: -flyte +union
 
 Union.ai supports HIPAA compliance for organizations processing protected health information (PHI). The architectural separation between control plane and data plane described in [Two-plane separation](../architecture/two-plane-separation) is the foundation of HIPAA compliance.
 
-No PHI ever transits Union.ai's control plane. Bulk PHI (files, DataFrames), structured task inputs and outputs, secret values, log streams, and reports are all served directly from the customer's data plane through the Direct-to-DataPlane tunnel; the control plane is not on the data path. PHI written to stdout/stderr flows through the tunnel to the requesting client without traversing Union.ai infrastructure.
+No PHI ever transits Union.ai's control plane. Bulk PHI (files, DataFrames), structured task inputs and outputs, secret values, log streams, and reports are all served directly from the customer's data plane through the Direct-to-Data-Plane tunnel; the control plane is not on the data path. PHI written to stdout/stderr flows through the tunnel to the requesting client without traversing Union.ai infrastructure.
 
 To request a Business Associate Agreement (BAA), submit the request through Union.ai's [Trust Center](https://app.vanta.com/c/union/trust-center).
 

--- a/content/security/data-protection/_index.md
+++ b/content/security/data-protection/_index.md
@@ -9,7 +9,7 @@ sidebar_expanded: true
 
 Union.ai protects customer data through a classification framework, residency guarantees, and cloud-native encryption. All customer data is encrypted both at rest and in transit.
 
-Customer data never transits Union.ai's control plane. Every customer-data request -- bulk artifacts (via presigned URLs), structured task inputs and outputs, secret values, logs, reports, and auxiliary UI traffic -- is served directly from the data plane through the Direct-to-DataPlane tunnel, with authentication and RBAC enforced by an Envoy router inside the customer's cluster. The control plane is not on the data path.
+Customer data never transits Union.ai's control plane. Every customer-data request -- bulk artifacts (via presigned URLs), structured task inputs and outputs, secret values, logs, reports, and auxiliary UI traffic -- is served directly from the data plane through the Direct-to-Data-Plane tunnel, with authentication and RBAC enforced by an Envoy router inside the customer's cluster. The control plane is not on the data path.
 
 This section covers:
 

--- a/content/security/data-protection/classification-and-residency.md
+++ b/content/security/data-protection/classification-and-residency.md
@@ -13,7 +13,7 @@ Every data type in the Union.ai platform is classified by its residency and acce
 | Classification | Data types | At rest | In transit | Enters control plane? |
 |---|---|---|---|---|
 | Bulk Customer Data | Files, directories, DataFrames, code bundles, container images, reports | Customer infrastructure (S3 SSE / GCS / Azure SSE) | HTTPS via presigned URL | **No**: served via signed URL direct to/from object store |
-| Inline Customer Data | Structured task inputs/outputs, secret values (during creation), execution log streams | Customer infrastructure (S3 SSE / GCS / Azure SSE; cloud secret managers) | Direct-to-DataPlane tunnel (default tier) or customer-managed internal LB (Sovereign Data Plane tier) | **No**: served from data plane |
+| Inline Customer Data | Structured task inputs/outputs, secret values (during creation), execution log streams | Customer infrastructure (S3 SSE / GCS / Azure SSE; cloud secret managers) | Direct-to-Data-Plane tunnel (default tier) or customer-managed internal LB (Sovereign Data Plane tier) | **No**: served from data plane |
 | Orchestration Metadata | Task definitions (including env vars, default values, SQL, pod specs), run/action state, error messages, trigger specs | Control plane databases (AES-256/KMS) | TLS (API) + TLS (gRPC events) | **Yes**: read from DB into memory for API responses |
 | Platform Metadata | User identity/RBAC records, cluster records | Control plane databases (AES-256/KMS) | TLS (API) | **Yes**: read from DB into memory for API responses |
 
@@ -22,7 +22,7 @@ Every data type in the Union.ai platform is classified by its residency and acce
 
 **Bulk customer data** (files, directories, DataFrames, code bundles, container images, and reports) is stored exclusively in the customer's infrastructure and never enters the control plane. These objects are accessed via presigned URLs issued by the data-plane `dataproxy`.
 
-**Inline customer data** (structured task inputs and outputs, secret values during creation/update, and execution log streams) is stored at rest in the customer's infrastructure and served directly from the data plane through the Direct-to-DataPlane tunnel. No customer data enters Union.ai's control plane in any form -- not even transiently in memory.
+**Inline customer data** (structured task inputs and outputs, secret values during creation/update, and execution log streams) is stored at rest in the customer's infrastructure and served directly from the data plane through the Direct-to-Data-Plane tunnel. No customer data enters Union.ai's control plane in any form -- not even transiently in memory.
 
 **Orchestration metadata** is stored in the control plane databases (encrypted at rest). This includes task definitions, which contain structural information (container image references, typed interfaces) and fields that may be customer-sensitive: environment variables, default input literal values, SQL query statements, Kubernetes pod specs, plugin configuration, and config key-value pairs. Error messages from task executions (which may contain data from Python tracebacks) are also stored. A full task definition (TaskSpec) is stored on every run submission.
 
@@ -30,7 +30,7 @@ Every data type in the Union.ai platform is classified by its residency and acce
 
 All customer data resides in the customer's own cloud account and region. The customer chooses the region for their data plane deployment, and all data plane resources (object storage, container registry, secrets backend, log aggregator, and compute) are provisioned within that region.
 
-The control plane is available in the following regions: US West (us-west-2), US East (us-east-2), EU West-1 (Ireland), EU West-2 (London), and EU Central (eu-central-1). No customer data of any kind is replicated to, cached in, or routed through Union.ai infrastructure -- inline data is served from the customer's data plane through the Direct-to-DataPlane tunnel and never traverses the control plane region. Only orchestration metadata (run IDs, schedules, phase transitions, task definitions, error messages, and the RBAC graph) resides in the control plane region.
+The control plane is available in the following regions: US West (us-west-2), US East (us-east-2), EU West-1 (Ireland), EU West-2 (London), and EU Central (eu-central-1). No customer data of any kind is replicated to, cached in, or routed through Union.ai infrastructure -- inline data is served from the customer's data plane through the Direct-to-Data-Plane tunnel and never traverses the control plane region. Only orchestration metadata (run IDs, schedules, phase transitions, task definitions, error messages, and the RBAC graph) resides in the control plane region.
 
 Customers whose data-residency policy extends to orchestration metadata (e.g., GDPR, or jurisdiction-specific policies that cover operational records about workflows in addition to the workflow data itself) should select a control plane region consistent with that policy. For EU-deployed data planes using an EU control plane region, all data and metadata (both at rest and in transit) stay within the EU, supporting GDPR data residency requirements.
 

--- a/content/security/data-protection/logging-and-audit.md
+++ b/content/security/data-protection/logging-and-audit.md
@@ -10,11 +10,11 @@ variants: -flyte +union
 
 Logs are collected and shipped to the customer's cloud-native log service: CloudWatch Logs (AWS), Cloud Logging (GCP), or Azure Monitor (Azure). Live logs are streamed directly from the Kubernetes API while a task is running. Persisted logs are read from the cloud log aggregator after a pod terminates.
 
-Log data does not transit the control plane. Live and persisted logs alike are served from the data plane through the Direct-to-DataPlane tunnel directly to the requesting client; no log byte ever passes through Union.ai infrastructure. There is no content filtering or redaction at any layer of the log pipeline. Log lines include structured metadata: timestamp, message content, and originator classification.
+Log data does not transit the control plane. Live and persisted logs alike are served from the data plane through the Direct-to-Data-Plane tunnel directly to the requesting client; no log byte ever passes through Union.ai infrastructure. There is no content filtering or redaction at any layer of the log pipeline. Log lines include structured metadata: timestamp, message content, and originator classification.
 
 ## Observability metrics
 
-A per-cluster monitoring instance stores time-series observability metrics including resource utilization and cost data. Queries are served from the data plane through the Direct-to-DataPlane tunnel. Metrics data never leaves the customer's infrastructure. In BYOC deployments, Union.ai deploys and manages the monitoring stack.
+A per-cluster monitoring instance stores time-series observability metrics including resource utilization and cost data. Queries are served from the data plane through the Direct-to-Data-Plane tunnel. Metrics data never leaves the customer's infrastructure. In BYOC deployments, Union.ai deploys and manages the monitoring stack.
 
 ## Audit trail
 

--- a/content/security/data-protection/secrets.md
+++ b/content/security/data-protection/secrets.md
@@ -6,7 +6,7 @@ variants: -flyte +union
 
 # Secrets management
 
-Union.ai's secrets management system stores secret values exclusively within the customer's infrastructure and exposes them through a write-only API: there is no endpoint that returns a secret value. The `GetSecret` RPC returns only metadata (name, scope, creation time, cluster presence status); Get, List, and Delete operations never expose the value. Secret writes go directly to the data plane through the Direct-to-DataPlane tunnel, so secret values never transit the control plane. Compromising a user account or the control plane API yields no path to read secret values back.
+Union.ai's secrets management system stores secret values exclusively within the customer's infrastructure and exposes them through a write-only API: there is no endpoint that returns a secret value. The `GetSecret` RPC returns only metadata (name, scope, creation time, cluster presence status); Get, List, and Delete operations never expose the value. Secret writes go directly to the data plane through the Direct-to-Data-Plane tunnel, so secret values never transit the control plane. Compromising a user account or the control plane API yields no path to read secret values back.
 
 ## Backends
 
@@ -21,7 +21,7 @@ All four backends are available regardless of deployment model. The choice of ba
 
 ## Secret lifecycle
 
-**Creation:** When a user creates a secret via the UI or CLI, the value is sent directly to the data plane's secrets backend over the client-to-data-plane channel -- the Direct-to-DataPlane tunnel under the default tier, or the customer-managed internal load balancer under the [Sovereign Data Plane](../architecture/sovereign-data-plane) tier -- and stored encrypted at rest in the customer's secret manager (AWS Secrets Manager, GCP Secret Manager, Azure Key Vault, or K8s Secrets). The value never enters Union.ai's control plane in any form. The Envoy router inside the customer's cluster authenticates the request against Union.ai identity and enforces RBAC before the value reaches the secrets backend.
+**Creation:** When a user creates a secret via the UI or CLI, the value is sent directly to the data plane's secrets backend over the client-to-data-plane channel -- the Direct-to-Data-Plane tunnel under the default tier, or the customer-managed internal load balancer under the [Sovereign Data Plane](../architecture/sovereign-data-plane) tier -- and stored encrypted at rest in the customer's secret manager (AWS Secrets Manager, GCP Secret Manager, Azure Key Vault, or K8s Secrets). The value never enters Union.ai's control plane in any form. The Envoy router inside the customer's cluster authenticates the request against Union.ai identity and enforces RBAC before the value reaches the secrets backend.
 
 | Phase | Encrypted? | Details |
 |-------|------------|---------|
@@ -68,7 +68,7 @@ This verification is fully self-service and works immediately. Note that the wri
 
 ### Secret lifecycle
 
-**Reviewer focus:** Confirm that secret values are written directly to the data plane backend through the Direct-to-DataPlane tunnel without traversing the control plane, and are consumed entirely within the data plane at runtime.
+**Reviewer focus:** Confirm that secret values are written directly to the data plane backend through the Direct-to-Data-Plane tunnel without traversing the control plane, and are consumed entirely within the data plane at runtime.
 
 **How to verify:**
 

--- a/content/security/identity-and-access/human-access.md
+++ b/content/security/identity-and-access/human-access.md
@@ -28,7 +28,7 @@ This is distinct from BYOC Kubernetes cluster management access (described above
 
 When Union.ai personnel are granted access to a customer's tenant (in BYOC, or via the optional support service in self-managed), they *can*: view orchestration metadata, view logs relayed through the tunnel, perform administrative operations as authorized by the customer's RBAC policy, and (in BYOC) manage the Kubernetes cluster.
 
-They *cannot*: read secret values (the API is write-only), access bulk data in customer object stores (presigned URLs are per-request and not retained), or access the customer's cloud account, IAM roles, object stores, secrets backends, container registries, or log aggregators. Customer data never transits Union.ai's control plane in any form, so personnel with control plane infrastructure access cannot observe customer data even in flight; every customer-data request is served from the data plane through the Direct-to-DataPlane tunnel, with authentication and RBAC enforced inside the customer's cluster.
+They *cannot*: read secret values (the API is write-only), access bulk data in customer object stores (presigned URLs are per-request and not retained), or access the customer's cloud account, IAM roles, object stores, secrets backends, container registries, or log aggregators. Customer data never transits Union.ai's control plane in any form, so personnel with control plane infrastructure access cannot observe customer data even in flight; every customer-data request is served from the data plane through the Direct-to-Data-Plane tunnel, with authentication and RBAC enforced inside the customer's cluster.
 
 All access by Union.ai personnel is authenticated and logged with caller identity, operation performed, and timestamp.
 


### PR DESCRIPTION
Style/terminology polish on already-shipped security content. No behavioral or factual change.

## Changes

**1. `Zero-trust` → `Zero Trust` (NIST SP 800-207 spelling)** — 7 occurrences / 3 files.
Capitalize the proper-noun part of the security-model name; keep `security` lowercase per the sentence-case house style; drop the hyphen. Sits consistently in the top nav beside `Platform deployment` (both sentence case, proper noun capitalized). Applies to the frontmatter title, H1, body mentions, and the `Zero Trust, in one line:` callout (all-7-or-none for consistency).

**2. `Direct-to-DataPlane` → `Direct-to-Data-Plane`** — 31 occurrences / 13 files.
Consistent hyphenation of the coined tunnel name.

## Provenance
Manual-init `/docsy` run (Peeter, 2026-06-10). Related to DOC-1206 (Zero Trust Security docs coverage, merged #1094) but distinct: this is a docs-wide terminology standardization, not new coverage.

## ⚠️ Reviewer note
`Direct-to-Data-Plane` is a **coined product/architecture name**. If the product UI, SDK, or marketing renders it `Direct-to-DataPlane`, this docs rename introduces a docs-vs-product divergence — reconcile the canonical spelling with eng/marketing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)