### PR TITLE
docs: sentence-case fixes — lowercase generic "control plane"/"data plane" + Terraform page headings

### DIFF
--- a/content/community/contributing-code.md
+++ b/content/community/contributing-code.md
@@ -127,7 +127,7 @@ To understand how the below components interact with each other, refer to [Compo
 
 | **Repo** | [flyteadmin](https://github.com/flyteorg/flyteadmin) \| [Code Reference](https://pkg.go.dev/mod/github.com/flyteorg/flyteadmin) |
 |----------|------------------------------------------------------------------------------------------------|
-| **Purpose** | Control Plane |
+| **Purpose** | Control plane |
 | **Language** | Go |
 | **Guidelines** |                                                                                          |
 |              | - Check for Makefile in the root repo                                                      |

--- a/content/deployment/byoc/data-plane-setup-on-gcp.md
+++ b/content/deployment/byoc/data-plane-setup-on-gcp.md
@@ -195,7 +195,7 @@ gcloud services enable storage-api.googleapis.com
 If you decide to manage your own VPC instead of leaving it to {{< key product_name >}}, then you will need to set it up yourself.
 The VPC should be configured with the following characteristics:
 
-* We recommend using a VPC that resides in the same project as the {{< key product_name >}} Data Plane Kubernetes cluster. If you want to use a [shared VPC](https://cloud.google.com/vpc/docs/shared-vpc), contact {{< key product_name >}} support.
+* We recommend using a VPC that resides in the same project as the {{< key product_name >}} data plane Kubernetes cluster. If you want to use a [shared VPC](https://cloud.google.com/vpc/docs/shared-vpc), contact {{< key product_name >}} support.
 * Create a single VPC subnet with:
   * A primary IPv4 range with /18 CIDR mask. This is used for cluster node IP addresses.
   * A secondary range with /15 CIDR mask. This is used for Kubernetes Pod IP addresses. We recommend associating the name with pods, e.g. `gke-pods`.

--- a/content/deployment/byoc/enabling-azure-resources/enabling-azure-container-registry.md
+++ b/content/deployment/byoc/enabling-azure-resources/enabling-azure-container-registry.md
@@ -6,7 +6,7 @@ variants: -flyte +union
 
 # Enabling Azure Container Registry (ACR)
 
-ACR can be used to store container images within Azure and accessed within your Azure-based Data Plane.
+ACR can be used to store container images within Azure and accessed within your Azure-based data plane.
 
 {{< key product_name >}} leverages Azure Kubernetes Service (AKS) managed identities to authenticate with ACR.
 

--- a/content/deployment/flyte-deployment/multicluster.md
+++ b/content/deployment/flyte-deployment/multicluster.md
@@ -15,7 +15,7 @@ This is needed because in a multi-cluster setup, the execution engine (`flytepro
 
 ## Scaling Beyond Kubernetes
 
-As described in the [Architecture Overview](https://docs.flyte.org/en/latest/concepts/architecture.html), the Flyte control plane (`flyteadmin`) sends workflows off to the Data Plane (`flytepropeller`) for execution.
+As described in the [Architecture Overview](https://docs.flyte.org/en/latest/concepts/architecture.html), the Flyte control plane (`flyteadmin`) sends workflows off to the data plane (`flytepropeller`) for execution.
 The data plane fulfills these workflows by launching pods in Kubernetes.
 
 The case for multiple Kubernetes clusters may arise due to security constraints, cost-effectiveness or a need to scale out computing resources.
@@ -51,7 +51,7 @@ To make sure that your multi-cluster deployment is able to scale and process req
     By default, every Pod created for a Task execution, uses the `default` Service Account in their respective namespace.
     In your cluster, you'll have as many namespaces as `project` and `domain` combinations you may have.
 
-### Data Plane Deployment
+### Data plane deployment
 
 This guide assumes that you have two Kubernetes clusters and that you can access them all with `kubectl`.
 
@@ -113,7 +113,7 @@ Let's call these clusters `dataplane1` and `dataplane2`. In this section, you'll
           --create-namespace flyte
    ```
 
-## Control Plane configuration
+## Control plane configuration
 
 For `flyteadmin` to access and create Kubernetes resources in one or more Flyte data plane clusters, it needs credentials to each cluster.
 Flyte makes use of Kubernetes Service Accounts to enable every control plane cluster to perform authenticated requests to the Kubernetes API Server in the data plane cluster.

--- a/content/deployment/selfmanaged/configuration/monitoring.md
+++ b/content/deployment/selfmanaged/configuration/monitoring.md
@@ -31,7 +31,7 @@ The chart offers two Prometheus deployment options for Union features:
 
 ```
                     ┌─────────────────────────────────────┐
-                    │          Data Plane Cluster         │
+                    │          Data plane cluster         │
                     │                                     │
                     │  ┌──────────────────────┐           │
                     │  │  Prometheus          │           │

--- a/content/deployment/terraform/management.md
+++ b/content/deployment/terraform/management.md
@@ -1,16 +1,16 @@
 ---
-title: Resource Management
+title: Resource management
 weight: 2
 variants: -flyte +union
 ---
 
-# Managing Union Resources with Terraform
+# Managing Union resources with Terraform
 
 The Union Terraform provider enables you to manage Union resources using infrastructure-as-code principles. This page provides an overview of the provider's capabilities, including authentication, available resources, and data sources.
 
-## Provider Configuration
+## Provider configuration
 
-### Basic Configuration
+### Basic configuration
 
 Configure the Union provider in your Terraform configuration:
 
@@ -30,7 +30,7 @@ provider "unionai" {
 }
 ```
 
-### Configuration Parameters
+### Configuration parameters
 
 - **`api_key`** (Required): Your Union API key for authentication
 - **`allowed_orgs`** (Optional): List of organization names to restrict operations to, preventing unintended operations across multiple organizations
@@ -39,7 +39,7 @@ provider "unionai" {
 
 The Union Terraform provider uses API key authentication. You can provide your API key in two ways:
 
-### 1. Provider Configuration
+### 1. Provider configuration
 
 Specify the API key directly in the provider block (use variables to avoid hardcoding):
 
@@ -49,7 +49,7 @@ provider "unionai" {
 }
 ```
 
-### 2. Environment Variable
+### 2. Environment variable
 
 Set the `UNIONAI_API_KEY` environment variable:
 
@@ -57,7 +57,7 @@ Set the `UNIONAI_API_KEY` environment variable:
 export UNIONAI_API_KEY="your-api-key"
 ```
 
-### Generating an API Key
+### Generating an API key
 
 Create an API key using the Flyte CLI:
 
@@ -69,7 +69,7 @@ For more information on creating API keys, see the [Flyte CLI documentation](../
 
 Save the generated key securely, as it will be used to authenticate all Terraform operations against your Union deployment.
 
-## Available Resources
+## Available resources
 
 The Union Terraform provider supports the following resources for managing your Union deployment:
 
@@ -121,7 +121,7 @@ resource "unionai_policy" "example" {
 }
 ```
 
-### API Keys
+### API keys
 
 Generate and manage API keys programmatically:
 
@@ -132,7 +132,7 @@ resource "unionai_api_key" "example" {
 }
 ```
 
-### OAuth Applications
+### OAuth applications
 
 Configure OAuth applications for external integrations:
 
@@ -143,7 +143,7 @@ resource "unionai_oauth_application" "example" {
 }
 ```
 
-### Access Assignments
+### Access assignments
 
 Assign users and applications to resources with specific roles:
 
@@ -161,7 +161,7 @@ resource "unionai_application_access" "example" {
 }
 ```
 
-## Available Data Sources
+## Available data sources
 
 Data sources allow you to query existing Union resources for use in your Terraform configuration.
 
@@ -205,7 +205,7 @@ data "unionai_policy" "existing" {
 }
 ```
 
-### API Keys
+### API keys
 
 Reference existing API keys:
 
@@ -255,9 +255,9 @@ data "unionai_dataplanes" "all" {
 }
 ```
 
-## Best Practices
+## Best practices
 
-### Use Variables for Sensitive Data
+### Use variables for sensitive data
 
 Never hardcode sensitive information like API keys in your Terraform files:
 
@@ -273,7 +273,7 @@ provider "unionai" {
 }
 ```
 
-### Organize Resources with Modules
+### Organize resources with modules
 
 Structure your Terraform code using modules for reusability:
 
@@ -291,7 +291,7 @@ terraform/
 └── main.tf
 ```
 
-### Use Organization Restrictions
+### Use organization restrictions
 
 Prevent accidental operations across multiple organizations:
 
@@ -302,7 +302,7 @@ provider "unionai" {
 }
 ```
 
-### Version Control Your Configuration
+### Version control your configuration
 
 Store your Terraform configuration in version control to track changes over time, but ensure sensitive files are excluded:
 
@@ -314,7 +314,7 @@ Store your Terraform configuration in version control to track changes over time
 .terraform/
 ```
 
-### Use Remote State
+### Use remote state
 
 For team environments, use remote state storage:
 
@@ -328,7 +328,7 @@ terraform {
 }
 ```
 
-## Example: Complete Setup
+## Example: complete setup
 
 Here's a complete example that creates a project with access control:
 
@@ -380,7 +380,7 @@ resource "unionai_api_key" "ci_cd" {
 }
 ```
 
-## Additional Resources
+## Additional resources
 
 - [Union Terraform Provider Documentation](https://registry.terraform.io/providers/unionai/unionai/latest/docs)
 - [Terraform Documentation](https://www.terraform.io/docs)
@@ -392,6 +392,6 @@ resource "unionai_api_key" "ci_cd" {
 - **Union API Key**: Generated via Flyte CLI
 - **Go**: >= 1.24 (for development only)
 
-## Support and Contributions
+## Support and contributions
 
 The Union Terraform provider is open source and licensed under the Mozilla Public License 2.0. For the complete provider documentation, visit the [Terraform Registry](https://registry.terraform.io/providers/unionai/unionai/latest/docs).

--- a/content/deployment/terraform/management.md
+++ b/content/deployment/terraform/management.md
@@ -225,7 +225,7 @@ data "unionai_application" "existing" {
 }
 ```
 
-### Data Plane Information
+### Data plane information
 
 Query information about the data plane:
 
@@ -235,7 +235,7 @@ data "unionai_dataplane" "current" {
 }
 ```
 
-### Control Plane Information
+### Control plane information
 
 Access control plane details:
 
@@ -245,7 +245,7 @@ data "unionai_controlplane" "current" {
 }
 ```
 
-### Data Plane Listings
+### Data plane listings
 
 List all available data planes:
 

--- a/content/security/architecture/network.md
+++ b/content/security/architecture/network.md
@@ -44,10 +44,10 @@ All communication paths in the system use encryption. No unencrypted communicati
 
 | Path | Protocol | Encryption |
 |---|---|---|
-| Client to Control Plane (orchestration API) | HTTPS | TLS 1.2+ |
-| Client to Data Plane (customer-data requests, default tier) | Direct-to-Data-Plane tunnel | TLS 1.3 + mTLS |
-| Client to Data Plane (customer-data requests, Sovereign Data Plane tier) | Customer-managed internal LB (corporate VPN) | TLS (customer-managed) |
-| Data Plane → Control Plane (orchestration metadata, outbound-initiated) | gRPC over TLS | TLS 1.2+ |
+| Client to control plane (orchestration API) | HTTPS | TLS 1.2+ |
+| Client to data plane (customer-data requests, default tier) | Direct-to-Data-Plane tunnel | TLS 1.3 + mTLS |
+| Client to data plane (customer-data requests, Sovereign Data Plane tier) | Customer-managed internal LB (corporate VPN) | TLS (customer-managed) |
+| Data plane → control plane (orchestration metadata, outbound-initiated) | gRPC over TLS | TLS 1.2+ |
 | Client to Object Store | HTTPS (presigned URL) | TLS 1.2+ (cloud provider enforced) |
 | Fluent Bit to Log Aggregator | Cloud provider SDK | TLS (cloud-native) |
 | Task Pods to Object Store | Cloud provider SDK | TLS (cloud-native) |

--- a/content/security/data-protection/secrets.md
+++ b/content/security/data-protection/secrets.md
@@ -26,10 +26,10 @@ All four backends are available regardless of deployment model. The choice of ba
 | Phase | Encrypted? | Details |
 |-------|------------|---------|
 | Client → Cloudflare edge | **Yes** | TLS 1.3 (default tier only) |
-| Cloudflare edge → Data Plane (tunnel) | **Yes** | mTLS + Cloudflare Tunnel |
+| Cloudflare edge → data plane (tunnel) | **Yes** | mTLS + Cloudflare Tunnel |
 | Client → Internal load balancer | **Yes** | TLS, customer-managed certificate ([Sovereign Data Plane](../architecture/sovereign-data-plane) tier only) |
 | At Envoy router (data plane) | **Plaintext in memory** | AuthN + RBAC check; not persisted, cached, or logged |
-| In Data Plane (operator) | **Plaintext in memory** | Briefly held before writing to secret backend |
+| In data plane (operator) | **Plaintext in memory** | Briefly held before writing to secret backend |
 | At rest (secret backend) | **Yes** | AWS Secrets Manager (AES-256/KMS), GCP Secret Manager (Google-managed or CMEK), Azure Key Vault (HSM-backed), or K8s etcd encryption |
 
 **Consumption:** When a task pod is created, the system configures it to mount the requested secrets from the backend as environment variables or files. The value is read by the data plane's secrets backend and injected into the pod. It never leaves the customer's infrastructure during this process. The control plane is not involved in secret consumption at runtime.

--- a/content/user-guide/run-scaling/life-of-a-run.md
+++ b/content/user-guide/run-scaling/life-of-a-run.md
@@ -71,16 +71,16 @@ For more details on code packaging, see [Packaging](../task-deployment/packaging
 
 Once the code bundle is created:
 
-1. **Request signed URL**: The SDK sends the bundle checksum and target path to the Control Plane.
-2. **Control Plane obtains URL**: The Control Plane calls the Data Plane to obtain a signed URL for that checksum and path.
+1. **Request signed URL**: The SDK sends the bundle checksum and target path to the control plane.
+2. **Control plane obtains URL**: The control plane calls the data plane to obtain a signed URL for that checksum and path.
 3. **Direct upload**: The signed URL is returned to the SDK, which uploads the code bundle directly to the object store.
 
 ## Phase 5: Run creation and queuing
 
 1. **Upload inputs**: The SDK uploads the run's inputs to the data-plane `dataproxy` service, which writes them to the object store. The input values never pass through the control plane.
 2. **Invoke `CreateRun`**: The SDK calls the `CreateRun` API with a reference (URI) to the uploaded inputs, not the input values themselves.
-3. **En-queue a run**: The run is queued into the Union Control Plane.
-4. **Hand off to executor**: The Union Control Plane hands the task to the Executor Service in your data plane.
+3. **En-queue a run**: The run is queued into the Union control plane.
+4. **Hand off to executor**: The Union control plane hands the task to the Executor Service in your data plane.
 5. **Create action**: The parent task action (called `a0`) is created.
 
 ## Phase 6: Task execution in data plane
@@ -99,7 +99,7 @@ If the task invokes other tasks:
 
 1. **Controller thread**: A controller thread starts to communicate with the backend Queue Service.
 2. **Monitor status**: The controller monitors the status of downstream actions.
-3. **Crash recovery**: If the task crashes, the action identifier is deterministic, allowing the task to resurrect its state from Union Control Plane.
+3. **Crash recovery**: If the task crashes, the action identifier is deterministic, allowing the task to resurrect its state from Union control plane.
 4. **Replay**: The controller efficiently replays state (even at large scale) to find missing completions and resume monitoring.
 
 ### Execution flow diagram
@@ -107,8 +107,8 @@ If the task invokes other tasks:
 ```mermaid
 sequenceDiagram
     participant Client as SDK/Client
-    participant Control as Control Plane<br/>(Queue Service)
-    participant Data as Data Plane<br/>(Executor)
+    participant Control as Control plane<br/>(Queue Service)
+    participant Data as Data plane<br/>(Executor)
     participant ObjStore as Object Store
     participant Container as Task Container
 
@@ -157,7 +157,7 @@ Flyte uses deterministic action identifiers to enable robust crash recovery:
 - **Consistent identifiers**: Action identifiers are consistently computed based on task and invocation context.
 - **Re-run identical**: In any re-run, the action identifier is identical for the same invocation.
 - **Multiple invocations**: Multiple invocations of the same task receive unique identifiers.
-- **Efficient resurrection**: On crash, the `a0` action resurrects its state from Union Control Plane efficiently, even at large scale.
+- **Efficient resurrection**: On crash, the `a0` action resurrects its state from Union control plane efficiently, even at large scale.
 - **Replay and resume**: The controller replays execution until it finds missing completions and starts watching them.
 
 ## Downstream task execution


### PR DESCRIPTION
Follow-up to #1097, applied on top of it. The capitalization audit that produced #1097 surfaced the *real* latent inconsistency: standalone `Control Plane`/`Data Plane` was Title-Cased ~26 times but lowercase 212/368 times sitewide.

## Principle
`control plane` / `data plane` are **generic industry common nouns** (the Kubernetes-origin architectural roles), not Union-coined names — so under the sentence-case house style they take lowercase in running text. Same rule that *promotes* "Zero Trust" (a name) *demotes* "data plane" (a description): **name → capitalize, description → lowercase.**

## Changes — 26 occurrences / 9 files
Lowercased generic uses in prose, tables, diagram captions, and authored headings. Includes an intra-sentence inconsistency in `multicluster.md:18` ("Flyte control plane … to the Data Plane") and three Terraform-doc H3 headings (the prose under each already says "data plane" lowercase; the HCL data sources are `unionai_dataplane`/`unionai_controlplane`, so the headings were authored, not literal labels).

## Preserved (deliberately)
- **Coined names:** `Sovereign Data Plane` (29×), `Direct-to-Data-Plane` (31×) — untouched.
- **Unit-initial capitals:** first word of a heading / bold lead-in / table cell / diagram caption keeps its capital ("Control plane configuration", "Data plane information").
- **SVG figure text** (`_static/images/deployment/architecture.svg`, 3 labels) — **out of scope**; figure-label casing is a separate diagram concern, not prose. Flagged for a possible later diagram pass.

## Scope note
Cross-variant by nature (the strays span `+flyte` and `+union` content, not just union-only), so this touches Flyte OSS deployment pages too — intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)