### PR TITLE
docs: un-redact --cluster-pool on queue creation

### DIFF
--- a/content/api-reference/flyte-cli.md
+++ b/content/api-reference/flyte-cli.md
@@ -469,6 +469,9 @@ Create a scheduling queue.
         $ flyte create queue gpu-queue --run-concurrency 50 --action-concurrency 500 \
             --priority min --cluster gpu-cluster-1
 
+        $ flyte create queue pool-queue --run-concurrency 50 --action-concurrency 500 \
+            --cluster-pool gpu-pool
+
         $ flyte create queue backfill --run-concurrency 10 --action-concurrency 100 \
             --depth 5000 --priority max
 
@@ -483,6 +486,7 @@ Create a scheduling queue.
 | `--priority` | `choice` | `medium` | Queue priority |
 | `--fairness` | `choice` | `round_robin` | Fairness algorithm |
 | `--cluster` | `text` | `Sentinel.UNSET` | Target cluster(s). Repeat for multiple. |
+| `--cluster-pool` | `text` | `None` | Cluster pool to bind the queue to (defaults to the org's default pool). Cannot be changed later. |
 | `--project` | `text` | `` | Scope queue to a project |
 | `--domain` | `text` | `` | Scope queue to a domain |
 | `--help` | `boolean` | `False` | Show this message and exit. |

--- a/content/api-reference/flyte-cli.md
+++ b/content/api-reference/flyte-cli.md
@@ -486,7 +486,7 @@ Create a scheduling queue.
 | `--priority` | `choice` | `medium` | Queue priority |
 | `--fairness` | `choice` | `round_robin` | Fairness algorithm |
 | `--cluster` | `text` | `Sentinel.UNSET` | Target cluster(s). Repeat for multiple. |
-| `--cluster-pool` | `text` | `None` | Cluster pool to bind the queue to (defaults to the org's default pool). Cannot be changed later. |
+| `--cluster-pool` | `text` | `default` | Cluster pool to bind the queue to. Defaults to `default` when omitted. Changing pools requires draining and updating the queue configuration. |
 | `--project` | `text` | `` | Scope queue to a project |
 | `--domain` | `text` | `` | Scope queue to a domain |
 | `--help` | `boolean` | `False` | Show this message and exit. |

--- a/content/user-guide/cluster-workload-management/queues.md
+++ b/content/user-guide/cluster-workload-management/queues.md
@@ -80,15 +80,16 @@ sensible default. With no `--cluster` a queue spreads work across **all** health
 clusters in its pool.
 
 > [!NOTE] Queues are bound to a cluster pool
-> Every queue is bound to a cluster pool. The `--cluster-pool` flag for selecting
-> which pool a queue lives in will be added soon. Until then, in the absence of
-> `--cluster-pool`, all queues are bound to the `default` cluster pool only.
+> Every queue is bound to a cluster pool, chosen at creation time with
+> `--cluster-pool`. In the absence of `--cluster-pool`, the queue is bound to the
+> `default` cluster pool.
 
 Pin a queue to specific clusters within its pool, scope it to a project/domain, and
 tune its limits:
 
 ```bash
 flyte create queue gpu-queue \
+  --cluster-pool prod \
   --cluster prod-us-east-1 \
   --run-concurrency 50 \
   --action-concurrency 500 \
@@ -102,8 +103,9 @@ flyte create queue gpu-queue \
 ### What each setting controls
 
 - **`--cluster-pool`** — the pool this queue lives in. A queue can only route to
-  clusters in its own pool. This flag will be added soon; until then every queue is
-  bound to the `default` pool.
+  clusters in its own pool. Omit to bind the queue to the `default` pool. The pool
+  is fixed at creation time; moving a queue to another pool later
+  [requires a drain](#change-a-queues-pool--drain-first).
 - **`--cluster`** — pin the queue to one or more clusters in the pool (repeat the
   flag for several). Omit to use all clusters in the pool.
 - **`--run-concurrency`** — maximum number of *runs* active on the queue at once.


### PR DESCRIPTION
## Summary
`flyteplugins-union` v0.4.1 shipped the `--cluster-pool` flag on `flyte create queue`, so the "will be added soon" redactions can come out.

- **Queues page** (`cluster-workload-management/queues.md`):
  - The "Queues are bound to a cluster pool" note now documents the flag as available: the pool is chosen at creation time and defaults to the `default` pool.
  - The `--cluster-pool` entry in "What each setting controls" now describes real behavior and links to the existing drain-first procedure for moving a queue to another pool (matching the page's `gpu-queue`-in-`prod`-pool diagram).
  - Added `--cluster-pool prod` to the `gpu-queue` create example, consistent with the diagram above it.
- **Flyte CLI reference** (`api-reference/flyte-cli.md`): added the `--cluster-pool` option row and example to `flyte create queue`, mirroring the actual `--help` output from v0.4.1 (hand-edited; will be confirmed by the next reference regeneration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)