### PR TITLE
wip

### DIFF
--- a/content/deployment/byoc/configuring-your-data-plane.md
+++ b/content/deployment/byoc/configuring-your-data-plane.md
@@ -64,8 +64,8 @@ If you are provisioning your own VPC, provide the VPC ID.
 
 Each cluster has its own internal object store that is used to store data used in the execution of workflows.
 This includes task input-output metadata, task input-output raw data, Flyte Decks data, and fast registration data.
-For each cluster, you can choose to enable a data retention policy that defines a maximum time for this data to be stored, after which it will be automatically deleted.
-Alternatively, you can set this to `unlimited` to disable automatic data deletion.
+The data retention policy defines the maximum time this data is stored, after which it is automatically deleted.
+The retention period is set by your {{< key product_name >}} plan.
 See [Data retention policy](./data-retention-policy) for more details.
 
 ## Worker node groups
@@ -142,7 +142,6 @@ Values provided by you are in single quotes (').
         - Account ID: 'account-id-1'
         - Region: 'us-west'
         - VPC: 'vpc-id-1'
-        - Data retention policy: '30 days'
         - Node groups:
             - 'node-group-1'
                 - Node type: 'p3d.4xlarge'
@@ -162,7 +161,6 @@ Values provided by you are in single quotes (').
         - Account ID: 'account-id-2'
         - Region: 'us-west'
         - VPC: 'vpc-id-2'
-        - Data retention policy: '30 days'
         - Node groups:
             - 'node-group-1'
                 - Node type: 'p3d.4xlarge'
@@ -182,7 +180,6 @@ Values provided by you are in single quotes (').
         - Account ID: 'account-id-3'
         - Region: 'us-west'
         - VPC: 'vpc-id-3'
-        - Data retention policy: 'unlimited'
         - Node groups:
             - 'node-group-1'
                 - Node type: 'p3d.4xlarge'

--- a/content/deployment/byoc/data-retention-policy.md
+++ b/content/deployment/byoc/data-retention-policy.md
@@ -21,17 +21,17 @@ Retention periods are not adjustable through the UI or CLI.
 
 ## Data categories
 
-The retention policy applies to the following categories of data:
+The retention policy applies to the following data:
 
-1. **Workflow execution data** — the per-run artifacts written during task execution:
+1. **Workflow execution data**: the per-run artifacts written during task execution:
    - Task inputs and outputs (the `inputs.pb` / `outputs.pb` protobuf payloads written by the platform during run setup and task execution).
    - Offloaded large values: `flyte.io.File`, `flyte.io.Dir`, `flyte.io.DataFrame`, and other reference-type payloads — both in their default location and in any custom location specified per run via `flyte.with_runcontext(raw_data_path=...)`.
    - `Deck` and report artifacts.
    - Trace checkpoints.
 
-2. **Fast-registered code** — the local code artifacts that are uploaded by `flyte deploy` or `flyte run --copy-style all` so the cluster can run your local Python without rebuilding the container image.
+2. **Workflow code**: The code that is uploaded by `flyte deploy` or `flyte run --copy-style all` and that make up the logic of your tasks and apps and other Flyte entities.
 
-When data reaches the plan's retention period, it expires and is deleted.
+When the age of the data reaches the plan's retention period, it is deleted.
 
 ## Attempting to access deleted data
 
@@ -43,9 +43,9 @@ If you attempt to access deleted data, you will receive an error:
 
 To remedy these types of errors, you have to re-run the workflow that generated the data in question.
 
-- When fast-registered code data is deleted, executions that depend on it will fail.
+- When workflow code is deleted, executions that depend on it will fail.
 
-To remedy this, you have to both re-register and re-run the workflow.
+To remedy this, you have to both re-deploy and re-run the workflow.
 
 ## Data retention and task caching
 

--- a/content/deployment/byoc/data-retention-policy.md
+++ b/content/deployment/byoc/data-retention-policy.md
@@ -6,15 +6,22 @@ variants: -flyte +union
 
 # Data retention policy
 
-Data retention policies let you control how long workflow data is kept in the data plane object store. They are a cost-management tool: you trade the ability to inspect or re-run aged-out executions against storage cost.
+Data retention policies determine how long workflow data is kept in the data plane object store. After the retention period expires, the data is automatically deleted.
 
-For the conceptual map of what's in the data plane bucket versus the control plane database, see [Where your data lives](../../user-guide/core-concepts/where-data-lives). This page describes the **policy interface** — what categories you can configure, what the policy values mean, and what happens when data is deleted.
+For the conceptual map of what's in the data plane bucket versus the control plane database, see [Where your data lives](../../user-guide/core-concepts/where-data-lives). This page describes which data is covered by the retention policy and what happens when data is deleted.
 
-As a {{< key product_name >}} administrator, retention policies are specified in discussion with the {{< key product_name >}} team when you set up your {{< key product_name >}} instance. They are not adjustable through the UI or CLI.
+Retention periods are set by your {{< key product_name >}} plan:
+
+| Plan | Retention period |
+| ---- | ---------------- |
+| Teams | 30 days |
+| Enterprise | 1 year |
+
+Retention periods are not adjustable through the UI or CLI.
 
 ## Data categories
 
-The retention policy system distinguishes the following categories of data:
+The retention policy applies to the following categories of data:
 
 1. **Workflow execution data** — the per-run artifacts written during task execution:
    - Task inputs and outputs (the `inputs.pb` / `outputs.pb` protobuf payloads written by the platform during run setup and task execution).
@@ -24,37 +31,7 @@ The retention policy system distinguishes the following categories of data:
 
 2. **Fast-registered code** — the local code artifacts that are uploaded by `flyte deploy` or `flyte run --copy-style all` so the cluster can run your local Python without rebuilding the container image.
 
-Each category is stored with object versioning enabled, which means two retention values can be specified for each category — one for current versions and one for non-current versions.
-
-> [!NOTE] Object versions are not the same as {{< key product_name >}} entity versions
-> The versions discussed here are at the object level and are not related to the versions of workflows, tasks, and other {{< key product_name >}} entities that you see in the {{< key product_name >}} UI.
-
-## How policies are specified
-
-A policy determines how long data in a given category and version-state (current vs. non-current) is retained in the object store before being automatically deleted.
-
-A policy is specified as a time period in days, or `unlimited` (in which case automatic data deletion is disabled for that category and version-state).
-
-## Deletion of current versions
-
-For current versions, deletion due to a retention period running out means moving the object to a non-current version — *soft-deletion*.
-
-## Deletion of non-current versions
-
-For non-current versions, deletion due to a retention period running out means permanent deletion.
-
-## Defaults
-
-|                     | Workflow execution data | Fast-registered code |
-| ------------------- | ----------------------- | -------------------- |
-| Current version     | unlimited               | unlimited            |
-| Non-current version | 7 days                  | 7 days               |
-
-By default:
-
-- The retention policy for **current versions in all categories** is `unlimited`, meaning that auto-deletion is disabled.
-  - If you change this to a specified number of days, then auto-deletion will occur after that time period, but because it applies to current versions the data object will be soft-deleted (that is, moved to a non-current version), not permanently deleted.
-- The retention policy for **non-current versions in all categories** is `7 days`, meaning that auto-deletion will occur after 7 days and that the data will be permanently deleted.
+When data reaches the plan's retention period, it expires and is deleted.
 
 ## Attempting to access deleted data
 
@@ -70,10 +47,6 @@ To remedy these types of errors, you have to re-run the workflow that generated 
 
 To remedy this, you have to both re-register and re-run the workflow.
 
-## Separate sets of policies per cluster
-
-If you have a multi-cluster setup, you can specify a different set of retention policies (one per category) for each cluster.
-
 ## Data retention and task caching
 
-When data retention is enabled, task caching is adjusted accordingly. To avoid attempts to retrieve cache data that has already been deleted, the cache `age` is configured to be less than the sum of both retention periods.
+Task caching is adjusted to match the retention period. To avoid attempts to retrieve cache data that has already been deleted, the cache `age` is configured to be less than the retention period.


### PR DESCRIPTION
 ## Summary

  Updates BYOC data retention docs to describe retention as plan-based rather than customer-configurable.

  ## Changes

  - States Teams plan retention is 30 days and Enterprise retention is 1 year.
  - Removes current/non-current object version details.
  - Removes configurable defaults, `unlimited`, and per-cluster retention policy language.
  - Updates the BYOC data plane configuration page to avoid contradictory retention guidance.