### PR TITLE
Add missing kubectl requirement to run the devbox

### DIFF
--- a/content/user-guide/run-modes/running-devbox.md
+++ b/content/user-guide/run-modes/running-devbox.md
@@ -32,6 +32,7 @@ The Flyte devbox is a lightweight local cluster that runs on your machine with D
 
 - Python 3.10+ in a virtual environment
 - [Docker](https://docs.docker.com/get-docker/) installed and running
+- [kubectl](https://kubernetes.io/docs/tasks/tools/)
 
 ## Install the SDK
 


### PR DESCRIPTION
Re-push of #1055 from an in-repo branch so the **Build and deploy docs** check can run with repository secrets (the original is from a fork, so the Cloudflare deploy step fails on a missing `CLOUDFLARE_API_TOKEN` — unrelated to the change itself).

Identical one-line change, with @paulmaschhoff's original commit cherry-picked to preserve authorship.

---

The flyte CLI requires `kubectl` to run the devbox, but that's missing from the [current docs](https://www.union.ai/docs/v2/flyte/user-guide/run-modes/running-devbox/). The CLI throws a [user-friendly error](https://github.com/flyteorg/flyte-sdk/commit/d27d7b074fa250e8ab3984015be40c238c2ab88d) if it's missing, with a link to install it. This PR adds the same link to the "Run on the devbox" page.

Supersedes #1055 (approved by @kumare3). Credit: @paulmaschhoff.