### PR TITLE
ci: fix fork-PR preview deploys via build + workflow_run deploy split

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -5,13 +5,16 @@ name: Build and deploy docs
 # Replaces CF Pages' native build runner — CF Pages stays only as the
 # static host.
 #
+# Production-only path. PR previews are handled by the two-stage pair
+# `build-pr.yml` (untrusted build, no secrets) + `deploy-pr-preview.yml`
+# (trusted workflow_run deploy, has secrets), because GitHub does NOT expose
+# repo secrets to pull_request workflows triggered from forks (so the deploy
+# here fails on fork PRs). See DOC-1228.
+#
 # Triggers:
 #   - push to main — production deploy (project=docs, --branch=main).
 #     This is the prod path; CF auto-deploys on the `docs` project are
 #     disabled, so GHA owns prod end-to-end.
-#   - pull_request — branch deploy to the `docs` project. Each PR gets
-#     a preview at <sanitized-branch>.docs-dog.pages.dev, identical to
-#     what CF Pages' bot used to produce. Sticky comment posts the URL.
 #   - workflow_dispatch — manual run; redeploys whatever commit the branch
 #     is at to the docs project (useful for re-runs after a flake).
 
@@ -19,8 +22,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, synchronize, reopened]
   workflow_dispatch:
 
 permissions:
@@ -37,16 +38,14 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 # Concurrency policy:
-#   - PRs: cancel any in-flight run when a new commit is pushed to the
-#     same PR (only the latest commit's preview matters).
 #   - push to main: queue in order, don't cancel, so we never leave
 #     production in an inconsistent state mid-deploy.
 #   - workflow_dispatch: own group, distinct from push, so manual
 #     re-runs never block or get blocked by an in-progress production
 #     deploy.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref_name }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name }}
+  cancel-in-progress: false
 
 jobs:
   build-and-deploy:
@@ -105,8 +104,8 @@ jobs:
             "workflow_file": ".github/workflows/build-and-deploy.yml",
             "run_id": "${{ github.run_id }}",
             "run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-            "commit": "${{ github.event.pull_request.head.sha || github.sha }}",
-            "ref": "${{ github.head_ref || github.ref_name }}",
+            "commit": "${{ github.sha }}",
+            "ref": "${{ github.ref_name }}",
             "event": "${{ github.event_name }}",
             "built_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           }
@@ -141,27 +140,9 @@ jobs:
         id: branch
         run: |
           # CF Pages branch names: lowercase alphanumeric + hyphens, max 28 chars.
-          #
-          # On pull_request events we prefix the deploy branch with `pr-<num>`.
-          # This both (a) makes each PR's preview alias unique even when two
-          # PRs share a long common branch-name prefix, and (b) guarantees a
-          # PR-event deploy can never sanitize to a production branch name
-          # like `main` or `v1` (e.g. a branch named `main_` would otherwise
-          # sanitize to `main` and overwrite production now that PRs deploy
-          # into the same `docs` Pages project).
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            pr_num="${{ github.event.pull_request.number }}"
-            raw_branch="${{ github.head_ref }}"
-            # Compose `pr-<num>-<branch>` then truncate to 28 chars (CF Pages
-            # limit). Branch portion auto-shrinks as PR numbers grow digits.
-            full=$(printf 'pr-%s-%s' "$pr_num" "$raw_branch" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^a-z0-9]+#-#g' | sed -E 's#^-+|-+$##g')
-            sanitized=$(printf '%s' "$full" | cut -c1-28 | sed -E 's#-+$##g')
-            echo "Source PR #$pr_num branch '$raw_branch' → CF Pages branch: $sanitized"
-          else
-            raw="${{ github.ref_name }}"
-            sanitized=$(echo "$raw" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^a-z0-9]+#-#g' | sed -E 's#^-+|-+$##g' | cut -c1-28)
-            echo "Source branch: $raw → CF Pages branch: $sanitized"
-          fi
+          raw="${{ github.ref_name }}"
+          sanitized=$(echo "$raw" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^a-z0-9]+#-#g' | sed -E 's#^-+|-+$##g' | cut -c1-28)
+          echo "Source branch: $raw → CF Pages branch: $sanitized"
           echo "name=$sanitized" >> "$GITHUB_OUTPUT"
 
       - name: Deploy to Cloudflare Pages
@@ -188,25 +169,7 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "- Project: \`docs\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Branch (CF Pages): \`${{ steps.branch.outputs.name }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Commit: \`${{ github.event.pull_request.head.sha || github.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Commit: \`${{ github.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
           if [ -n "${{ steps.deploy.outputs.deployment-url }}" ]; then
             echo "- Deployment URL: ${{ steps.deploy.outputs.deployment-url }}" >> "$GITHUB_STEP_SUMMARY"
           fi
-
-      - name: Post / update preview comment on PR
-        if: success() && github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: gha-build-and-deploy-preview
-          message: |
-            ### GHA build & deploy preview
-
-            Built by `.github/workflows/build-and-deploy.yml` and deployed to the **`docs`** CF Pages project.
-
-            | | |
-            |---|---|
-            | Branch alias | <https://${{ steps.branch.outputs.name }}.docs-dog.pages.dev> |
-            | This commit | ${{ steps.deploy.outputs.deployment-url }} |
-            | Commit SHA | `${{ github.event.pull_request.head.sha }}` |
-
-            Updated automatically on every push.

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,0 +1,129 @@
+name: Build PR
+
+# PR-build half of the two-stage preview pipeline (DOC-1228).
+#
+# Runs on `pull_request` and builds the docs via `make dist`, but holds NO
+# secrets and performs NO deploy. GitHub does not expose repo secrets to
+# pull_request runs from forks, so anything secret-bearing here would fail on
+# fork PRs (it failed external PR #1055). Instead this job just builds and
+# uploads the dist + PR metadata as an artifact; the trusted companion
+# workflow `deploy-pr-preview.yml` picks it up via `workflow_run` (where
+# secrets ARE available) and deploys it.
+#
+# The job name is intentionally "Build and deploy docs" — the same name the
+# old single-stage workflow used — so the branch-protection required status
+# check keeps matching by check-run name without any reconfiguration.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+# Opt in early to the Node.js 24 runtime for JavaScript actions (see
+# build-and-deploy.yml for the full rationale).
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+# Cancel any in-flight build when a new commit lands on the same PR — only
+# the latest commit's preview matters.
+concurrency:
+  group: build-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    # Name preserved from the original single-stage workflow so the existing
+    # branch-protection required status check (matched by check-run name)
+    # keeps passing — no admin reconfiguration needed.
+    name: "Build and deploy docs"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 1
+
+      - name: Set up Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: '0.161.1'
+          extended: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Print environment
+        run: |
+          echo "::group::versions"
+          hugo version
+          python --version
+          uv --version
+          echo "::endgroup::"
+
+      - name: Build dist
+        run: |
+          start=$(date +%s)
+          make dist
+          echo "BUILD_SECONDS=$(( $(date +%s) - start ))" >> "$GITHUB_ENV"
+
+      - name: Emit build provenance
+        if: success()
+        run: |
+          # Write build-info.json at dist/docs/ (served at /docs/build-info.json
+          # once deployed). Lets incident response probe "what version is this?".
+          mkdir -p dist/docs
+          cat > dist/docs/build-info.json <<EOF
+          {
+            "builder": "github-actions",
+            "repository": "${{ github.repository }}",
+            "workflow_file": ".github/workflows/build-pr.yml",
+            "run_id": "${{ github.run_id }}",
+            "run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            "commit": "${{ github.event.pull_request.head.sha }}",
+            "ref": "${{ github.head_ref }}",
+            "event": "${{ github.event_name }}",
+            "built_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          }
+          EOF
+          cat dist/docs/build-info.json
+
+      - name: Build summary
+        if: always()
+        run: |
+          echo "::group::dist tree (top 2 levels)"
+          find dist -maxdepth 2 -mindepth 1 -print 2>/dev/null | sort || true
+          echo "::endgroup::"
+          echo "::group::dist size"
+          du -sh dist 2>/dev/null || true
+          du -sh dist/docs/v2 dist/docs/v1 2>/dev/null || true
+          echo "::endgroup::"
+          if [ -n "${BUILD_SECONDS:-}" ]; then
+            echo "Build wall time: ${BUILD_SECONDS}s"
+          fi
+
+      - name: Write PR metadata
+        run: |
+          cat > pr-meta.json <<EOF
+          {"pr_number": "${{ github.event.pull_request.number }}", "head_sha": "${{ github.event.pull_request.head.sha }}", "head_ref": "${{ github.head_ref }}"}
+          EOF
+
+      - name: Upload PR dist artifact
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-dist
+          path: |
+            dist
+            pr-meta.json
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -1,0 +1,114 @@
+name: Deploy PR preview
+
+# Deploy half of the two-stage preview pipeline (DOC-1228).
+#
+# Triggered by `workflow_run` after "Build PR" completes. A workflow_run
+# always executes in the TRUSTED base-repo context (using the base ref's
+# workflow definition and with repo secrets available), even when the
+# triggering PR came from a fork. That is what makes fork-PR previews work:
+# the untrusted build happens secret-less in build-pr.yml, and this job only
+# ever DOWNLOADS that prebuilt artifact and deploys it — it never checks out
+# or executes untrusted PR code/build scripts with secrets in scope.
+
+on:
+  workflow_run:
+    workflows: ["Build PR"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: read
+
+# Opt in early to the Node.js 24 runtime for JavaScript actions (see
+# build-and-deploy.yml for the full rationale).
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  deploy:
+    # Only deploy for successful PR builds. workflow_run fires for every
+    # completion; gate on the originating event + a green build.
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Download PR dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-dist
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: .
+
+      - name: Parse PR metadata
+        id: meta
+        run: |
+          pr_number=$(jq -r '.pr_number' pr-meta.json)
+          head_sha=$(jq -r '.head_sha' pr-meta.json)
+          head_ref=$(jq -r '.head_ref' pr-meta.json)
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "head_ref=$head_ref" >> "$GITHUB_OUTPUT"
+          echo "Parsed PR #$pr_number, head_ref '$head_ref', head_sha $head_sha"
+
+      - name: Sanitize branch name for CF Pages
+        id: branch
+        run: |
+          # CF Pages branch names: lowercase alphanumeric + hyphens, max 28 chars.
+          #
+          # Compose `pr-<num>-<branch>` then sanitize. The `pr-<num>` prefix
+          # (a) makes each PR's preview alias unique even when two PRs share a
+          # long common branch-name prefix, and (b) guarantees a PR deploy can
+          # never sanitize to a production branch name like `main` or `v1`.
+          pr_num="${{ steps.meta.outputs.pr_number }}"
+          raw_branch="${{ steps.meta.outputs.head_ref }}"
+          full=$(printf 'pr-%s-%s' "$pr_num" "$raw_branch" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^a-z0-9]+#-#g' | sed -E 's#^-+|-+$##g')
+          sanitized=$(printf '%s' "$full" | cut -c1-28 | sed -E 's#-+$##g')
+          echo "Source PR #$pr_num branch '$raw_branch' → CF Pages branch: $sanitized"
+          echo "name=$sanitized" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy to Cloudflare Pages
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_PAGES_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # --commit-dirty: the prebuilt dist contains regenerated tracked
+          # files, so wrangler would otherwise warn about a dirty tree. The
+          # warning is noise here.
+          command: pages deploy ./dist --project-name=docs --branch=${{ steps.branch.outputs.name }} --commit-dirty=true
+
+      - name: Deploy summary
+        if: success()
+        run: |
+          echo "## Deployment" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Project: \`docs\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Branch (CF Pages): \`${{ steps.branch.outputs.name }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Commit: \`${{ steps.meta.outputs.head_sha }}\`" >> "$GITHUB_STEP_SUMMARY"
+          if [ -n "${{ steps.deploy.outputs.deployment-url }}" ]; then
+            echo "- Deployment URL: ${{ steps.deploy.outputs.deployment-url }}" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Post / update preview comment on PR
+        if: success()
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: gha-build-and-deploy-preview
+          # workflow_run runs detached from any PR, so the comment target must
+          # be named explicitly via `number`.
+          number: ${{ steps.meta.outputs.pr_number }}
+          message: |
+            ### GHA build & deploy preview
+
+            Built by `.github/workflows/build-pr.yml` and deployed to the **`docs`** CF Pages project by `.github/workflows/deploy-pr-preview.yml`.
+
+            | | |
+            |---|---|
+            | Branch alias | <https://${{ steps.branch.outputs.name }}.docs-dog.pages.dev> |
+            | This commit | ${{ steps.deploy.outputs.deployment-url }} |
+            | Commit SHA | `${{ steps.meta.outputs.head_sha }}` |
+
+            Updated automatically on every push.


### PR DESCRIPTION
> docsy-authored draft PR. Closes DOC-1228.

## Problem

`pull_request` workflows triggered **from forks** do not receive repo secrets — GitHub deliberately withholds them from the untrusted fork context. The single-stage `build-and-deploy.yml` ran on `pull_request` and deployed to Cloudflare Pages using `CLOUDFLARE_PAGES_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID`, so the deploy step **failed on every fork PR** (external PR #1055 failed for exactly this reason; we worked around it by re-pushing as in-repo PR #1110). The production path (`push: main`) was never affected because it runs in the trusted base context where secrets are available.

## Fix — two-stage build + `workflow_run` deploy

Split the PR preview path into two workflows:

1. **`build-pr.yml`** — runs on `pull_request`, builds `dist` via `make dist`, and uploads `dist` + a `pr-meta.json` (PR number, head SHA, head ref) as the `pr-dist` artifact. It holds **no secrets** and performs **no deploy**, so it runs identically on fork and in-repo PRs.
2. **`deploy-pr-preview.yml`** — triggered by `workflow_run` after **Build PR** completes. `workflow_run` always runs in the **trusted base-repo context** (base ref's workflow definition, secrets available) even when the PR is from a fork. It downloads the prebuilt artifact, deploys it to CF Pages, and posts the sticky preview comment (targeting the PR explicitly via the `number:` input, since `workflow_run` is detached from any PR).

`build-and-deploy.yml` is now **production-only** (`push: main` + `workflow_dispatch`); the PR-only steps (preview comment, the `pull_request` branch of the sanitize step) were removed.

## Production is untouched

The `push: main` path keeps the same job, steps, Hugo/Python/uv versions, build, provenance, artifact upload, branch sanitize, wrangler deploy, and summary. PR fields in the production workflow (`github.event.pull_request.*`, `github.head_ref`) were always empty on `push`/`workflow_dispatch`, so dropping the `|| <prod>` fallbacks is behaviorally identical for production.

## No branch-protection change needed

The required status check is matched by **check-run name = job name**. The PR-build job in `build-pr.yml` keeps the **exact** job name `Build and deploy docs`, so the existing branch-protection rule keeps matching with **no admin reconfiguration**.

## Security note

`deploy-pr-preview.yml` runs in the trusted context with secrets, but it **only ever downloads a prebuilt artifact and deploys it** — it does not check out or execute untrusted PR code/build scripts with secrets in scope. The untrusted build (which runs PR-controlled `make dist`) happens secret-less in `build-pr.yml`. This is the standard safe pattern for fork-PR preview deploys.

## References
- Closes DOC-1228
- Prior failure: #1055 (fork PR, deploy failed) → re-pushed as #1110 (in-repo)