### PR TITLE
ci: step-level timeout on Cloudflare Pages deploy (DOC-1229)

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -148,6 +148,11 @@ jobs:
       - name: Deploy to Cloudflare Pages
         if: success()
         id: deploy
+        # Step-level cap: a normal CF Pages deploy is ~1-3 min. Without this a
+        # hung wrangler upload eats the whole job's timeout-minutes budget
+        # (incl. the build) before failing — observed once at ~26 min on a large
+        # API-docs regen. Fail fast so the deploy can be re-run. See DOC-1229.
+        timeout-minutes: 10
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_PAGES_API_TOKEN }}

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -71,6 +71,10 @@ jobs:
 
       - name: Deploy to Cloudflare Pages
         id: deploy
+        # Step-level cap: fail a hung wrangler upload fast (normal deploy ~1-3
+        # min) instead of consuming the whole job budget. Parity with
+        # build-and-deploy.yml. See DOC-1229.
+        timeout-minutes: 10
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_PAGES_API_TOKEN }}


### PR DESCRIPTION
## What

Adds `timeout-minutes: 10` to the **`Deploy to Cloudflare Pages`** step in `build-and-deploy.yml` and `deploy-pr-preview.yml`.

## Why

The flyte 2.5.1 API-docs regen deploy ([PR #1113](https://github.com/unionai/unionai-docs/pull/1113), merge `5500d3422`) **hung ~26 min** on the CF deploy step ([run #27706390876](https://github.com/unionai/unionai-docs/actions/runs/27706390876)); cancel + re-run deployed cleanly in 45s — a transient `wrangler`/Cloudflare stall.

The deploy **jobs already have timeouts** (`build-and-deploy` 30 min, `deploy` 15 min), so the hang would have eventually failed — but only after burning the entire job budget (which also covers the build). A **step-level** cap fails the *deploy specifically* fast (normal deploy is ~1–3 min) so it can be re-run promptly instead of hanging near the job limit.

## Scope

Two-line change, one per workflow. Production deploy behavior is otherwise unchanged. No content changes.

Closes DOC-1229 (the deploy-hardening follow-up from the 2.5.1 regen incident).

🤖 Generated with [Claude Code](https://claude.com/claude-code)