### PR TITLE
Document content-based caching for DataFrame/File/Dir inputs (DOC-1232)

### DIFF
--- a/content/user-guide/run-scaling/data-flow.md
+++ b/content/user-guide/run-scaling/data-flow.md
@@ -105,10 +105,7 @@ All inline data is cached using a consistent hashing system. The cache key is de
 
 ### Reference data hashing
 
-Reference data (files, directories) is hashed shallowly by default using the hash of the storage location. You can customize hashing:
-
-- Use `flyte.io.File.new_remote()` or `flyte.io.File.from_existing_remote()` with custom hash functions or values.
-- Provide explicit hash values for deep content hashing if needed.
+Reference data (DataFrames, files, directories) is hashed shallowly by default using the hash of the storage location, so a downstream task does not cache-hit on identical content stored at a new path. To cache on content instead, attach a content hash at production time with `flyte.io.HashFunction`. See [Content-based caching for DataFrames, files, and directories](../task-configuration/caching#content-based-caching-for-dataframes-files-and-directories).
 
 ### Cache control
 

--- a/content/user-guide/task-configuration/caching.md
+++ b/content/user-guide/task-configuration/caching.md
@@ -117,6 +117,41 @@ Use `salt` to vary cache keys without changing function logic:
 - Temporary cache namespaces for experiments.
 - Environment-specific cache isolation.
 
+## Content-based caching for DataFrames, files, and directories
+
+When a task input is a DataFrame (`pandas`, `polars`, or `flyte.io.DataFrame`), a `flyte.io.File`, or a `flyte.io.Dir`, the value is passed *by reference* - the cache key is derived from the data's storage location, not its contents. As a result, a downstream task keyed on such an input does **not** get a cache hit when the underlying data is identical but lives at a new path (the common case, since each run writes to a fresh location).
+
+To cache on **content** instead, attach a hash of the data at the point where it is produced. Flyte then uses that content hash when computing the cache key of any downstream consuming task, so identical content produces a cache hit regardless of where it is stored.
+
+> [!NOTE]
+> Caching applies only on a remote cluster - local execution does not produce cache hits across runs.
+
+### DataFrames
+
+For a raw `pandas` or `polars` DataFrame, supply a content hash with `flyte.io.HashFunction.from_fn` in a `typing.Annotated` return type. Define the hash function once and reuse the annotated alias:
+
+{{< code file="/unionai-examples/v2/user-guide/task-configuration/caching/content_caching.py" fragment="pandas" lang="python" >}}
+
+The producer's return annotation tells Flyte to compute the content hash; the consumer is cached on it. The same pattern works for `polars`:
+
+{{< code file="/unionai-examples/v2/user-guide/task-configuration/caching/content_caching.py" fragment="polars" lang="python" >}}
+
+For `flyte.io.DataFrame`, pass the `HashFunction` to `DataFrame.from_local` via the `hash_method` parameter instead of annotating the return type:
+
+{{< code file="/unionai-examples/v2/user-guide/task-configuration/caching/content_caching.py" fragment="flyte-dataframe" lang="python" >}}
+
+### Files
+
+A `flyte.io.File` accepts a `hash_method` on `File.from_local` (and on `File.new_remote`). Pass a `HashFunction` that hashes the file's bytes, and the file is cached on its content rather than its remote path:
+
+{{< code file="/unionai-examples/v2/user-guide/task-configuration/caching/content_caching.py" fragment="file" lang="python" >}}
+
+### Directories
+
+`flyte.io.Dir.from_local` does **not** take a `HashFunction` callable. Instead, compute a content key yourself and pass it as the precomputed `dir_cache_key`:
+
+{{< code file="/unionai-examples/v2/user-guide/task-configuration/caching/content_caching.py" fragment="dir" lang="python" >}}
+
 ## Cache policies
 
 For details on implementing custom cache policies, see the [`CachePolicy` protocol](../../api-reference/flyte-sdk/packages/flyte/cachepolicy) and [`Cache` class](../../api-reference/flyte-sdk/packages/flyte/cache) API references.

--- a/content/user-guide/task-programming/dataframes.md
+++ b/content/user-guide/task-programming/dataframes.md
@@ -14,6 +14,9 @@ The `flyte.io.DataFrame` type provides serialization support for common engines 
 
 DataFrame contents are written to the data plane object store and passed between tasks by reference. For the full map of what goes in the bucket versus what stays in the control plane database, see [Where your data lives](../core-concepts/where-data-lives).
 
+> [!NOTE]
+> Because a DataFrame is passed by reference, a downstream cached task does not get a cache hit on identical content stored at a new path. To cache on content, attach a hash with `flyte.io.HashFunction` - see [Content-based caching for DataFrames, files, and directories](../task-configuration/caching#content-based-caching-for-dataframes-files-and-directories).
+
 ## Setting up the environment and sample data
 
 For our example we will start by setting up our task environment with the required dependencies and create some sample data.

--- a/content/user-guide/task-programming/files-and-directories.md
+++ b/content/user-guide/task-programming/files-and-directories.md
@@ -23,6 +23,9 @@ For the full picture of what gets stored in the bucket versus what stays in the 
 
 The `File` and `Dir` classes provide both `sync` and `async` methods to interact with the data.
 
+> [!NOTE]
+> Because `File` and `Dir` are passed by reference, a downstream cached task does not get a cache hit on identical content stored at a new path. To cache on content, attach a hash at production time - see [Content-based caching for DataFrames, files, and directories](../task-configuration/caching#content-based-caching-for-dataframes-files-and-directories).
+
 ## Example usage
 
 The examples below show the basic use-cases of uploading files and directories created locally, and using them as inputs to a task.


### PR DESCRIPTION
## What

Documents how to cache on **content** when a DataFrame, `flyte.io.File`, or `flyte.io.Dir` is a task input — previously undocumented (confirmed by Niels Bantilan; the SDK ships it).

Adds a new section **"Content-based caching for DataFrames, files, and directories"** to the [Caching](content/user-guide/task-configuration/caching.md) page:
- The cache-key-is-the-path gotcha (reference data → no content cache hits by default).
- pandas / polars: `Annotated[df, HashFunction.from_fn(...)]` return type.
- `flyte.io.DataFrame` / `flyte.io.File`: the `hash_method` parameter on `from_local`.
- `flyte.io.Dir`: the precomputed `dir_cache_key` (Dir takes **no** `HashFunction` callable — a real API asymmetry).

Cross-links added from **Data flow** (Reference data hashing), **DataFrames**, and **Files and directories**.

## Grounding (code is authoritative)

- `flyte.io.HashFunction` verified exported from `flyte.io` in flyte-sdk `main`.
- Code fragments grounded on the shipped flyte-sdk examples `examples/advanced/hash_{pandas,polars,flyte}_dataframe.py` @ `344207419`, plus `File.from_local` / `Dir.from_local` signatures read from SDK source.
- Local Hugo build passes; all five fragments render; section anchor + cross-links verified.

## Surface footprint

Paired with **unionai/unionai-examples#260** which adds the referenced tested example `content_caching.py`. **Merge the examples PR first**, then bump the submodule pointer here.

Variants: `+flyte +union` (SDK-level, variant-agnostic — matches the existing page frontmatter).

Linear: DOC-1232.

🤖 Generated with [Claude Code](https://claude.com/claude-code)