### PR TITLE
docs(api-ref): populate integration landing-page directories (regen)

### DIFF
--- a/content/api-reference/integrations/anthropic/_index.md
+++ b/content/api-reference/integrations/anthropic/_index.md
@@ -9,3 +9,17 @@ layout: py_api
 
 
 
+## Directory
+
+### Classes
+
+| Class | Description |
+|-|-|
+| [`flyteplugins.anthropic.Agent`](packages/flyteplugins.anthropic/agent) | A Claude agent configuration. |
+
+### Packages
+
+| Package | Description |
+|-|-|
+| [`flyteplugins.anthropic`](packages/flyteplugins.anthropic/_index) | Anthropic Claude plugin for Flyte. |
+

--- a/content/api-reference/integrations/anthropic/packages/_index.md
+++ b/content/api-reference/integrations/anthropic/packages/_index.md
@@ -9,4 +9,4 @@ layout: py_api
 
 | Package | Description |
 |-|-|
-| [`flyteplugins.anthropic`](flyteplugins.anthropic) | Anthropic Claude plugin for Flyte. |
+| [`flyteplugins.anthropic`](flyteplugins.anthropic/_index) | Anthropic Claude plugin for Flyte. |

--- a/content/api-reference/integrations/bigquery/_index.md
+++ b/content/api-reference/integrations/bigquery/_index.md
@@ -9,3 +9,19 @@ layout: py_api
 
 
 
+## Directory
+
+### Classes
+
+| Class | Description |
+|-|-|
+| [`flyteplugins.bigquery.BigQueryConfig`](packages/flyteplugins.bigquery/bigqueryconfig) | Configuration for a BigQuery task. |
+| [`flyteplugins.bigquery.BigQueryConnector`](packages/flyteplugins.bigquery/bigqueryconnector) |  |
+| [`flyteplugins.bigquery.BigQueryTask`](packages/flyteplugins.bigquery/bigquerytask) |  |
+
+### Packages
+
+| Package | Description |
+|-|-|
+| [`flyteplugins.bigquery`](packages/flyteplugins.bigquery/_index) | BigQuery connector plugin for Flyte. |
+

--- a/content/api-reference/integrations/bigquery/packages/_index.md
+++ b/content/api-reference/integrations/bigquery/packages/_index.md
@@ -9,4 +9,4 @@ layout: py_api
 
 | Package | Description |
 |-|-|
-| [`flyteplugins.bigquery`](flyteplugins.bigquery) | BigQuery connector plugin for Flyte. |
+| [`flyteplugins.bigquery`](flyteplugins.bigquery/_index) | BigQuery connector plugin for Flyte. |

--- a/content/api-reference/integrations/codegen/_index.md
+++ b/content/api-reference/integrations/codegen/_index.md
@@ -9,3 +9,22 @@ layout: py_api
 
 
 
+## Directory
+
+### Classes
+
+| Class | Description |
+|-|-|
+| [`flyteplugins.codegen.AutoCoderAgent`](packages/flyteplugins.codegen/autocoderagent) | Agent for single-file Python code generation with automatic testing and iteration. |
+| [`flyteplugins.codegen.CodeGenEvalResult`](packages/flyteplugins.codegen/codegenevalresult) | Result from code generation and evaluation. |
+| [`flyteplugins.codegen.CodePlan`](packages/flyteplugins.codegen/codeplan) | Structured plan for the code solution. |
+| [`flyteplugins.codegen.CodeSolution`](packages/flyteplugins.codegen/codesolution) | Structured code solution. |
+| [`flyteplugins.codegen.ErrorDiagnosis`](packages/flyteplugins.codegen/errordiagnosis) | Structured diagnosis of execution errors. |
+| [`flyteplugins.codegen.ImageConfig`](packages/flyteplugins.codegen/imageconfig) | Configuration for Docker image building at runtime. |
+
+### Packages
+
+| Package | Description |
+|-|-|
+| [`flyteplugins.codegen`](packages/flyteplugins.codegen/_index) |  |
+

--- a/content/api-reference/integrations/codegen/packages/_index.md
+++ b/content/api-reference/integrations/codegen/packages/_index.md
@@ -9,4 +9,4 @@ layout: py_api
 
 | Package | Description |
 |-|-|
-| [`flyteplugins.codegen`](flyteplugins.codegen) |  |
+| [`flyteplugins.codegen`](flyteplugins.codegen/_index) |  |

--- a/content/api-reference/integrations/dask/_index.md
+++ b/content/api-reference/integrations/dask/_index.md
@@ -9,3 +9,19 @@ layout: py_api
 
 
 
+## Directory
+
+### Classes
+
+| Class | Description |
+|-|-|
+| [`flyteplugins.dask.Dask`](packages/flyteplugins.dask/dask) | Configuration for the dask task. |
+| [`flyteplugins.dask.Scheduler`](packages/flyteplugins.dask/scheduler) | Configuration for the scheduler pod. |
+| [`flyteplugins.dask.WorkerGroup`](packages/flyteplugins.dask/workergroup) | Configuration for a group of dask worker pods. |
+
+### Packages
+
+| Package | Description |
+|-|-|
+| [`flyteplugins.dask`](packages/flyteplugins.dask/_index) |  |
+

--- a/content/api-reference/integrations/dask/packages/_index.md
+++ b/content/api-reference/integrations/dask/packages/_index.md
@@ -9,4 +9,4 @@ layout: py_api
 
 | Package | Description |
 |-|-|
-| [`flyteplugins.dask`](flyteplugins.dask) |  |
+| [`flyteplugins.dask`](flyteplugins.dask/_index) |  |

--- a/content/api-reference/integrations/databricks/_index.md
+++ b/content/api-reference/integrations/databricks/_index.md
@@ -9,3 +9,18 @@ layout: py_api
 
 
 
+## Directory
+
+### Classes
+
+| Class | Description |
+|-|-|
+| [`flyteplugins.databricks.Databricks`](packages/flyteplugins.databricks/databricks) | Configuration for a Databricks task. |
+| [`flyteplugins.databricks.DatabricksConnector`](packages/flyteplugins.databricks/databricksconnector) |  |
+
+### Packages
+
+| Package | Description |
+|-|-|
+| [`flyteplugins.databricks`](packages/flyteplugins.databricks/_index) | Databricks connector plugin for Flyte. |
+

--- a/content/api-reference/integrations/databricks/packages/_index.md
+++ b/content/api-reference/integrations/databricks/packages/_index.md
@@ -9,4 +9,4 @@ layout: py_api
 
 | Package | Description |
 |-|-|
-| [`flyteplugins.databricks`](flyteplugins.databricks) | Databricks connector plugin for Flyte. |
+| [`flyteplugins.databricks`](flyteplugins.databricks/_index) | Databricks connector plugin for Flyte. |

--- a/content/api-reference/integrations/gemini/_index.md
+++ b/content/api-reference/integrations/gemini/_index.md
@@ -9,3 +9,17 @@ layout: py_api
 
 
 
+## Directory
+
+### Classes
+
+| Class | Description |
+|-|-|
+| [`flyteplugins.gemini.Agent`](packages/flyteplugins.gemini/agent) | A Gemini agent configuration. |
+
+### Packages
+
+| Package | Description |
+|-|-|
+| [`flyteplugins.gemini`](packages/flyteplugins.gemini/_index) | Google Gemini plugin for Flyte. |
+

--- a/content/api-reference/integrations/gemini/packages/_index.md
+++ b/content/api-reference/integrations/gemini/packages/_index.md
@@ -9,4 +9,4 @@ layout: py_api
 
 | Package | Description |
 |-|-|
-| [`flyteplugins.gemini`](flyteplugins.gemini) | Google Gemini plugin for Flyte. |
+| [`flyteplugins.gemini`](flyteplugins.gemini/_index) | Google Gemini plugin for Flyte. |

--- a/content/api-reference/integrations/hitl/_index.md
+++ b/content/api-reference/integrations/hitl/_index.md
@@ -9,3 +9,17 @@ layout: py_api
 
 
 
+## Directory
+
+### Classes
+
+| Class | Description |
+|-|-|
+| [`flyteplugins.hitl.Event`](packages/flyteplugins.hitl/event) | An event that waits for human input via an embedded FastAPI app. |
+
+### Packages
+
+| Package | Description |
+|-|-|
+| [`flyteplugins.hitl`](packages/flyteplugins.hitl/_index) | Human-in-the-Loop (HITL) plugin for Flyte. |
+

--- a/content/api-reference/integrations/hitl/packages/_index.md
+++ b/content/api-reference/integrations/hitl/packages/_index.md
@@ -9,4 +9,4 @@ layout: py_api
 
 | Package | Description |
 |-|-|
-| [`flyteplugins.hitl`](flyteplugins.hitl) | Human-in-the-Loop (HITL) plugin for Flyte. |
+| [`flyteplugins.hitl`](flyteplugins.hitl/_index) | Human-in-the-Loop (HITL) plugin for Flyte. |

--- a/content/api-reference/integrations/hydra/_index.md
+++ b/content/api-reference/integrations/hydra/_index.md
@@ -9,3 +9,11 @@ layout: py_api
 
 
 
+## Directory
+
+### Packages
+
+| Package | Description |
+|-|-|
+| [`flyteplugins.hydra`](packages/flyteplugins.hydra/_index) | flyteplugins-hydra — Hydra launcher plugin for Flyte. |
+

--- a/content/api-reference/integrations/jsonl/_index.md
+++ b/content/api-reference/integrations/jsonl/_index.md
@@ -9,3 +9,18 @@ layout: py_api
 
 
 
+## Directory
+
+### Classes
+
+| Class | Description |
+|-|-|
+| [`flyteplugins.jsonl.JsonlDir`](packages/flyteplugins.jsonl/jsonldir) | A directory of sharded JSONL files. |
+| [`flyteplugins.jsonl.JsonlFile`](packages/flyteplugins.jsonl/jsonlfile) | A file type for JSONL (JSON Lines) files, backed by `orjson` for fast. |
+
+### Packages
+
+| Package | Description |
+|-|-|
+| [`flyteplugins.jsonl`](packages/flyteplugins.jsonl/_index) |  |
+

--- a/content/api-reference/integrations/jsonl/packages/_index.md
+++ b/content/api-reference/integrations/jsonl/packages/_index.md
@@ -9,4 +9,4 @@ layout: py_api
 
 | Package | Description |
 |-|-|
-| [`flyteplugins.jsonl`](flyteplugins.jsonl) |  |
+| [`flyteplugins.jsonl`](flyteplugins.jsonl/_index) |  |

--- a/content/api-reference/integrations/mlflow/_index.md
+++ b/content/api-reference/integrations/mlflow/_index.md
@@ -9,3 +9,17 @@ layout: py_api
 
 
 
+## Directory
+
+### Classes
+
+| Class | Description |
+|-|-|
+| [`flyteplugins.mlflow.Mlflow`](packages/flyteplugins.mlflow/mlflow) | MLflow UI link for Flyte tasks. |
+
+### Packages
+
+| Package | Description |
+|-|-|
+| [`flyteplugins.mlflow`](packages/flyteplugins.mlflow/_index) | ## Key features:. |
+

--- a/content/api-reference/integrations/mlflow/packages/_index.md
+++ b/content/api-reference/integrations/mlflow/packages/_index.md
@@ -9,4 +9,4 @@ layout: py_api
 
 | Package | Description |
 |-|-|
-| [`flyteplugins.mlflow`](flyteplugins.mlflow) | ## Key features:. |
+| [`flyteplugins.mlflow`](flyteplugins.mlflow/_index) | ## Key features:. |

--- a/content/api-reference/integrations/omegaconf/_index.md
+++ b/content/api-reference/integrations/omegaconf/_index.md
@@ -9,3 +9,11 @@ layout: py_api
 
 
 
+## Directory
+
+### Packages
+
+| Package | Description |
+|-|-|
+| [`flyteplugins.omegaconf`](packages/flyteplugins.omegaconf/_index) | OmegaConf DictConfig/ListConfig support for Flyte. |
+

--- a/content/api-reference/integrations/openai/_index.md
+++ b/content/api-reference/integrations/openai/_index.md
@@ -9,3 +9,11 @@ layout: py_api
 
 
 
+## Directory
+
+### Packages
+
+| Package | Description |
+|-|-|
+| [`flyteplugins.openai.agents`](packages/flyteplugins.openai.agents/_index) |  |
+

--- a/content/api-reference/integrations/papermill/_index.md
+++ b/content/api-reference/integrations/papermill/_index.md
@@ -9,3 +9,17 @@ layout: py_api
 
 
 
+## Directory
+
+### Classes
+
+| Class | Description |
+|-|-|
+| [`flyteplugins.papermill.NotebookTask`](packages/flyteplugins.papermill/notebooktask) | A Flyte task that executes a Jupyter notebook via Papermill. |
+
+### Packages
+
+| Package | Description |
+|-|-|
+| [`flyteplugins.papermill`](packages/flyteplugins.papermill/_index) |  |
+

--- a/content/api-reference/integrations/papermill/packages/_index.md
+++ b/content/api-reference/integrations/papermill/packages/_index.md
@@ -9,4 +9,4 @@ layout: py_api
 
 | Package | Description |
 |-|-|
-| [`flyteplugins.papermill`](flyteplugins.papermill) |  |
+| [`flyteplugins.papermill`](flyteplugins.papermill/_index) |  |

--- a/content/api-reference/integrations/polars/_index.md
+++ b/content/api-reference/integrations/polars/_index.md
@@ -9,3 +9,20 @@ layout: py_api
 
 
 
+## Directory
+
+### Classes
+
+| Class | Description |
+|-|-|
+| [`flyteplugins.polars.df_transformer.ParquetToPolarsDecodingHandler`](packages/flyteplugins.polars.df_transformer/parquettopolarsdecodinghandler) |  |
+| [`flyteplugins.polars.df_transformer.ParquetToPolarsLazyFrameDecodingHandler`](packages/flyteplugins.polars.df_transformer/parquettopolarslazyframedecodinghandler) |  |
+| [`flyteplugins.polars.df_transformer.PolarsLazyFrameToParquetEncodingHandler`](packages/flyteplugins.polars.df_transformer/polarslazyframetoparquetencodinghandler) |  |
+| [`flyteplugins.polars.df_transformer.PolarsToParquetEncodingHandler`](packages/flyteplugins.polars.df_transformer/polarstoparquetencodinghandler) |  |
+
+### Packages
+
+| Package | Description |
+|-|-|
+| [`flyteplugins.polars.df_transformer`](packages/flyteplugins.polars.df_transformer/_index) |  |
+

--- a/content/api-reference/integrations/polars/packages/_index.md
+++ b/content/api-reference/integrations/polars/packages/_index.md
@@ -9,4 +9,4 @@ layout: py_api
 
 | Package | Description |
 |-|-|
-| [`flyteplugins.polars.df_transformer`](flyteplugins.polars.df_transformer) |  |
+| [`flyteplugins.polars.df_transformer`](flyteplugins.polars.df_transformer/_index) |  |

--- a/content/api-reference/integrations/pytorch/_index.md
+++ b/content/api-reference/integrations/pytorch/_index.md
@@ -9,3 +9,17 @@ layout: py_api
 
 
 
+## Directory
+
+### Classes
+
+| Class | Description |
+|-|-|
+| [`flyteplugins.pytorch.Elastic`](packages/flyteplugins.pytorch/elastic) | Elastic defines the configuration for running a PyTorch elastic job using torch. |
+
+### Packages
+
+| Package | Description |
+|-|-|
+| [`flyteplugins.pytorch`](packages/flyteplugins.pytorch/_index) |  |
+

--- a/content/api-reference/integrations/pytorch/packages/_index.md
+++ b/content/api-reference/integrations/pytorch/packages/_index.md
@@ -9,4 +9,4 @@ layout: py_api
 
 | Package | Description |
 |-|-|
-| [`flyteplugins.pytorch`](flyteplugins.pytorch) |  |
+| [`flyteplugins.pytorch`](flyteplugins.pytorch/_index) |  |

--- a/content/api-reference/integrations/ray/_index.md
+++ b/content/api-reference/integrations/ray/_index.md
@@ -9,3 +9,19 @@ layout: py_api
 
 
 
+## Directory
+
+### Classes
+
+| Class | Description |
+|-|-|
+| [`flyteplugins.ray.HeadNodeConfig`](packages/flyteplugins.ray/headnodeconfig) |  |
+| [`flyteplugins.ray.RayJobConfig`](packages/flyteplugins.ray/rayjobconfig) |  |
+| [`flyteplugins.ray.WorkerNodeConfig`](packages/flyteplugins.ray/workernodeconfig) |  |
+
+### Packages
+
+| Package | Description |
+|-|-|
+| [`flyteplugins.ray`](packages/flyteplugins.ray/_index) |  |
+

--- a/content/api-reference/integrations/ray/packages/_index.md
+++ b/content/api-reference/integrations/ray/packages/_index.md
@@ -9,4 +9,4 @@ layout: py_api
 
 | Package | Description |
 |-|-|
-| [`flyteplugins.ray`](flyteplugins.ray) |  |
+| [`flyteplugins.ray`](flyteplugins.ray/_index) |  |

--- a/content/api-reference/integrations/sglang/_index.md
+++ b/content/api-reference/integrations/sglang/_index.md
@@ -9,3 +9,17 @@ layout: py_api
 
 
 
+## Directory
+
+### Classes
+
+| Class | Description |
+|-|-|
+| [`flyteplugins.sglang.SGLangAppEnvironment`](packages/flyteplugins.sglang/sglangappenvironment) | App environment backed by SGLang for serving large language models. |
+
+### Packages
+
+| Package | Description |
+|-|-|
+| [`flyteplugins.sglang`](packages/flyteplugins.sglang/_index) |  |
+

--- a/content/api-reference/integrations/sglang/packages/_index.md
+++ b/content/api-reference/integrations/sglang/packages/_index.md
@@ -9,4 +9,4 @@ layout: py_api
 
 | Package | Description |
 |-|-|
-| [`flyteplugins.sglang`](flyteplugins.sglang) |  |
+| [`flyteplugins.sglang`](flyteplugins.sglang/_index) |  |

--- a/content/api-reference/integrations/snowflake/_index.md
+++ b/content/api-reference/integrations/snowflake/_index.md
@@ -9,3 +9,19 @@ layout: py_api
 
 
 
+## Directory
+
+### Classes
+
+| Class | Description |
+|-|-|
+| [`flyteplugins.snowflake.Snowflake`](packages/flyteplugins.snowflake/snowflake) |  |
+| [`flyteplugins.snowflake.SnowflakeConfig`](packages/flyteplugins.snowflake/snowflakeconfig) | Configure a Snowflake Task using a `SnowflakeConfig` object. |
+| [`flyteplugins.snowflake.SnowflakeConnector`](packages/flyteplugins.snowflake/snowflakeconnector) |  |
+
+### Packages
+
+| Package | Description |
+|-|-|
+| [`flyteplugins.snowflake`](packages/flyteplugins.snowflake/_index) | Key features:. |
+

--- a/content/api-reference/integrations/snowflake/packages/_index.md
+++ b/content/api-reference/integrations/snowflake/packages/_index.md
@@ -9,4 +9,4 @@ layout: py_api
 
 | Package | Description |
 |-|-|
-| [`flyteplugins.snowflake`](flyteplugins.snowflake) | Key features:. |
+| [`flyteplugins.snowflake`](flyteplugins.snowflake/_index) | Key features:. |

--- a/content/api-reference/integrations/spark/_index.md
+++ b/content/api-reference/integrations/spark/_index.md
@@ -9,3 +9,19 @@ layout: py_api
 
 
 
+## Directory
+
+### Classes
+
+| Class | Description |
+|-|-|
+| [`flyteplugins.spark.ParquetToSparkDecoder`](packages/flyteplugins.spark/parquettosparkdecoder) |  |
+| [`flyteplugins.spark.Spark`](packages/flyteplugins.spark/spark) | Use this to configure a SparkContext for a your task. |
+| [`flyteplugins.spark.SparkToParquetEncoder`](packages/flyteplugins.spark/sparktoparquetencoder) |  |
+
+### Packages
+
+| Package | Description |
+|-|-|
+| [`flyteplugins.spark`](packages/flyteplugins.spark/_index) |  |
+

--- a/content/api-reference/integrations/spark/packages/_index.md
+++ b/content/api-reference/integrations/spark/packages/_index.md
@@ -9,4 +9,4 @@ layout: py_api
 
 | Package | Description |
 |-|-|
-| [`flyteplugins.spark`](flyteplugins.spark) |  |
+| [`flyteplugins.spark`](flyteplugins.spark/_index) |  |

--- a/content/api-reference/integrations/vllm/_index.md
+++ b/content/api-reference/integrations/vllm/_index.md
@@ -9,3 +9,17 @@ layout: py_api
 
 
 
+## Directory
+
+### Classes
+
+| Class | Description |
+|-|-|
+| [`flyteplugins.vllm.VLLMAppEnvironment`](packages/flyteplugins.vllm/vllmappenvironment) | App environment backed by vLLM for serving large language models. |
+
+### Packages
+
+| Package | Description |
+|-|-|
+| [`flyteplugins.vllm`](packages/flyteplugins.vllm/_index) |  |
+

--- a/content/api-reference/integrations/vllm/packages/_index.md
+++ b/content/api-reference/integrations/vllm/packages/_index.md
@@ -9,4 +9,4 @@ layout: py_api
 
 | Package | Description |
 |-|-|
-| [`flyteplugins.vllm`](flyteplugins.vllm) |  |
+| [`flyteplugins.vllm`](flyteplugins.vllm/_index) |  |

--- a/content/api-reference/integrations/wandb/_index.md
+++ b/content/api-reference/integrations/wandb/_index.md
@@ -9,3 +9,18 @@ layout: py_api
 
 
 
+## Directory
+
+### Classes
+
+| Class | Description |
+|-|-|
+| [`flyteplugins.wandb.Wandb`](packages/flyteplugins.wandb/wandb) | Generates a Weights & Biases run link. |
+| [`flyteplugins.wandb.WandbSweep`](packages/flyteplugins.wandb/wandbsweep) | Generates a Weights & Biases Sweep link. |
+
+### Packages
+
+| Package | Description |
+|-|-|
+| [`flyteplugins.wandb`](packages/flyteplugins.wandb/_index) | ## Key features:. |
+

--- a/content/api-reference/integrations/wandb/packages/_index.md
+++ b/content/api-reference/integrations/wandb/packages/_index.md
@@ -9,4 +9,4 @@ layout: py_api
 
 | Package | Description |
 |-|-|
-| [`flyteplugins.wandb`](flyteplugins.wandb) | ## Key features:. |
+| [`flyteplugins.wandb`](flyteplugins.wandb/_index) | ## Key features:. |


### PR DESCRIPTION
## What
Regenerates all **21 integration plugin** API-ref sections so their landing pages show a populated **Classes/Packages Directory**, picking up the `generate_home_directory()` fix (infra [#128](https://github.com/unionai/unionai-docs-infra/pull/128)/[#129](https://github.com/unionai/unionai-docs-infra/pull/129)) + the package-index `/_index` link form ([#130](https://github.com/unionai/unionai-docs-infra/pull/130)).

## Why
Every integration landing page (vllm, spark, anthropic, dask, …) rendered **blank** — they predate the generator fix and hadn't been regenerated. Only `union-plugin` had been regenerated (during its move, DOC-1231), which is why it was the only populated one. This is the generic counterpart: same fix, now applied to all integrations.

## Scope
- **39 files**, all under `content/api-reference/integrations/`:
  - 21 landing `_index.md` → now carry a Directory (Classes + Packages tables with correct per-page / `/_index` links).
  - 18 `packages/_index.md` → explicit `/_index` section-link form.
- **No version drift** (all 2.5.1) → no docstring/detail-page churn; purely the generator-fix-driven changes.
- Regenerated per-plugin via `Makefile.api.plugins` (each in an isolated venv).

Maintenance regen (no Linear ticket; run-type `regen`). Follow-on to DOC-1231.

🤖 Generated with [Claude Code](https://claude.com/claude-code)