### PR TITLE
Add tutorial docs for workshop examples

### DIFF
--- a/content/tutorials/agents/_index.md
+++ b/content/tutorials/agents/_index.md
@@ -31,6 +31,10 @@ Monitor trusted regulatory sources with the You.com Research API and route citat
 Build an agentic workflow for deep research with multi-step reasoning and evaluation.
 {{< /link-card >}}
 
+{{< link-card target="langgraph-agent-research" title="LangGraph research agent" >}}
+Combine LangGraph control flow with Flyte tasks for multi-topic web research with quality-check loops.
+{{< /link-card >}}
+
 {{< link-card target="field-data-enrichment-agent" title="Field data enrichment agent" >}}
 Enrich geo-tagged operational events with real-world public context using the You.com Search API with country and freshness targeting.
 {{< /link-card >}}

--- a/content/tutorials/agents/langgraph-agent-research/_index.md
+++ b/content/tutorials/agents/langgraph-agent-research/_index.md
@@ -44,11 +44,11 @@ Inside each research task, a ReAct subgraph (`graph.py`) uses `@flyte.trace` on 
 
 ## Run the agent
 
-Create secrets for OpenAI and Tavily:
+Create secrets for Anthropic and Tavily:
 
 ```
-flyte create secret openai-api-key <YOUR_OPENAI_API_KEY>
-flyte create secret tavily-api-key <YOUR_TAVILY_API_KEY>
+flyte create secret internal-anthropic-api-key <YOUR_ANTHROPIC_API_KEY>
+flyte create secret tavily_api_key <YOUR_TAVILY_API_KEY>
 ```
 
 From the [example directory](https://github.com/unionai/unionai-examples/tree/main/v2/tutorials/langgraph_agent_research):

--- a/content/tutorials/agents/langgraph-agent-research/_index.md
+++ b/content/tutorials/agents/langgraph-agent-research/_index.md
@@ -1,0 +1,67 @@
+---
+title: LangGraph research agent
+weight: 3
+variants: +flyte +union
+---
+
+# LangGraph research agent
+
+> [!NOTE]
+> Code available [here](https://github.com/unionai/unionai-examples/tree/main/v2/tutorials/langgraph_agent_research).
+
+This tutorial combines [LangGraph](https://langchain-ai.github.io/langgraph/) for agentic control flow with Flyte for durable compute. A research pipeline plans sub-topics, fans out ReAct agents that search the web with [Tavily](https://tavily.com/), synthesizes findings, and loops on quality gaps until the report is good enough. Each LangGraph step dispatches to a separate Flyte task so planning, research, synthesis, and quality checks appear independently in the run UI.
+
+Flyte provides:
+
+- **Per-step tasks** visible in the Flyte UI while LangGraph orchestrates the graph.
+- **Secrets** for OpenAI and Tavily API keys.
+- **Live HTML reports** with Mermaid graph visualizations and the final synthesized report.
+
+## Define the task environment
+
+{{< code file="/unionai-examples/v2/tutorials/langgraph_agent_research/langgraph_agent_research.py" fragment=env lang=python >}}
+
+```
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#    "flyte>=2.4.0",
+#    "langgraph>=1.0.7",
+#    "langchain-openai",
+#    "tavily-python",
+#    ...
+# ]
+# ///
+```
+
+## Orchestrate the pipeline
+
+The `research_pipeline` task builds the LangGraph workflow, renders graph diagrams in a report tab, and runs the full plan → research → synthesize → quality-check loop.
+
+{{< code file="/unionai-examples/v2/tutorials/langgraph_agent_research/langgraph_agent_research.py" fragment=pipeline lang=python >}}
+
+Inside each research task, a ReAct subgraph (`graph.py`) uses `@flyte.trace` on Tavily search calls for observability.
+
+## Run the agent
+
+Create secrets for OpenAI and Tavily:
+
+```
+flyte create secret openai-api-key <YOUR_OPENAI_API_KEY>
+flyte create secret tavily-api-key <YOUR_TAVILY_API_KEY>
+```
+
+From the [example directory](https://github.com/unionai/unionai-examples/tree/main/v2/tutorials/langgraph_agent_research):
+
+```
+cd v2/tutorials/langgraph_agent_research
+uv run --script langgraph_agent_research.py
+```
+
+Or pass a custom query:
+
+```
+flyte run langgraph_agent_research.py research_pipeline --query "Compare quantum computing approaches"
+```
+
+Check the **Agent Graphs** report tab for the LangGraph diagram and the main report for the synthesized research output.

--- a/content/tutorials/biotech-healthcare/_index.md
+++ b/content/tutorials/biotech-healthcare/_index.md
@@ -15,6 +15,14 @@ Tutorials for bioinformatics, medical imaging, and other life-sciences workloads
 Align sequencing reads to a reference genome with a cached, parallel Bowtie 2 pipeline.
 {{< /link-card >}}
 
+{{< link-card target="genomic-gene-comparison" title="Cross-species gene comparison" >}}
+Compare homologous genes across species with Carbon scoring, sequence alignment, and ESMFold 3D structures.
+{{< /link-card >}}
+
+{{< link-card target="genomic-variant-effect" title="Genomic variant effect prediction" >}}
+Zero-shot pathogenicity scoring with HuggingFace Carbon and interactive VEP reports.
+{{< /link-card >}}
+
 {{< link-card target="tumor-detection" title="Brain tumor MRI classification" >}}
 Classify brain MRI scans with a two-phase EfficientNet-B4 pipeline featuring resumable GPU checkpointing and in-UI reports.
 {{< /link-card >}}

--- a/content/tutorials/biotech-healthcare/genomic-gene-comparison/_index.md
+++ b/content/tutorials/biotech-healthcare/genomic-gene-comparison/_index.md
@@ -1,0 +1,62 @@
+---
+title: Cross-species gene comparison
+weight: 2
+variants: +flyte +union
+---
+
+# Cross-species gene comparison
+
+> [!NOTE]
+> Code available [here](https://github.com/unionai/unionai-examples/tree/main/v2/tutorials/genomic_gene_comparison).
+
+This tutorial builds a bioinformatics pipeline that compares homologous genes across species. The workflow loads curated gene sequences (insulin, hemoglobin, or p53 by default), scores each sequence with the [Carbon](https://huggingface.co/HuggingFaceBio/Carbon-3B) genomic language model, aligns DNA and translated protein sequences, folds proteins with [ESMFold](https://github.com/facebookresearch/esm), and renders interactive HTML reports with identity heatmaps, phylogenetic trees, and 3D structure viewers.
+
+Flyte makes the multi-stage GPU/CPU pipeline reliable:
+
+- **Separate CPU and GPU `TaskEnvironment`s** so alignment runs on modest CPU boxes while Carbon scoring and ESMFold run on GPUs.
+- **`report=True`** on every stage for live HTML progress and final summaries in the Flyte UI.
+- **Cached data loading** and orchestrated fan-out across pipeline stages.
+
+## Define the task environments
+
+GPU tasks handle Carbon log-likelihood scoring and ESMFold structure prediction; CPU tasks load gene sets, run Needleman-Wunsch alignments, and generate the final summary.
+
+{{< code file="/unionai-examples/v2/tutorials/genomic_gene_comparison/genomic_gene_comparison.py" fragment=env lang=python >}}
+
+Dependencies are declared at the top of the file using the `uv` script style:
+
+```
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#    "flyte>=2.4.0",
+#    "torch>=2.9.0",
+#    "transformers>=4.49.0",
+#    "accelerate>=0.34.0",
+#    "numpy",
+# ]
+# ///
+```
+
+## Orchestrate the pipeline
+
+The top-level `pipeline` task chains four stages: load genes, Carbon scoring, sequence alignment, ESMFold folding, and a cross-species summary report.
+
+{{< code file="/unionai-examples/v2/tutorials/genomic_gene_comparison/genomic_gene_comparison.py" fragment=pipeline lang=python >}}
+
+## Run the workflow
+
+From the [example directory](https://github.com/unionai/unionai-examples/tree/main/v2/tutorials/genomic_gene_comparison):
+
+```
+cd v2/tutorials/genomic_gene_comparison
+uv run --script genomic_gene_comparison.py
+```
+
+Or submit a specific gene set with the Flyte CLI:
+
+```
+flyte run genomic_gene_comparison.py pipeline --gene_set hemoglobin
+```
+
+This example needs a GPU for Carbon and ESMFold. Open the run URL and check each task's report tab for heatmaps, dendrograms, and interactive 3D viewers.

--- a/content/tutorials/biotech-healthcare/genomic-variant-effect/_index.md
+++ b/content/tutorials/biotech-healthcare/genomic-variant-effect/_index.md
@@ -1,0 +1,58 @@
+---
+title: Genomic variant effect prediction
+weight: 3
+variants: +flyte +union
+---
+
+# Genomic variant effect prediction
+
+> [!NOTE]
+> Code available [here](https://github.com/unionai/unionai-examples/tree/main/v2/tutorials/genomic_variant_effect).
+
+This tutorial demonstrates zero-shot variant effect prediction (VEP) with HuggingFace [Carbon](https://huggingface.co/HuggingFaceBio/Carbon-3B). The pipeline loads clinically relevant variants across genes such as BRCA2, TP53, CFTR, KRAS, and HBB, scores each mutation with a log-likelihood ratio, and produces rich HTML reports with DNA tracks, lollipop plots, confusion matrices, and ranked pathogenicity tables.
+
+Flyte provides:
+
+- **GPU-backed inference** for Carbon scoring with live progress reports.
+- **CPU analysis tasks** for visualization and accuracy metrics without holding a GPU.
+- **End-to-end orchestration** from variant loading through summary reporting.
+
+## Define the task environments
+
+{{< code file="/unionai-examples/v2/tutorials/genomic_variant_effect/genomic_variant_effect.py" fragment=env lang=python >}}
+
+```
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#    "flyte>=2.4.0",
+#    "torch>=2.9.0",
+#    "transformers>=4.49.0",
+#    "accelerate>=0.34.0",
+#    "numpy",
+# ]
+# ///
+```
+
+## Orchestrate the pipeline
+
+The `pipeline` task loads variants, scores them with Carbon, analyzes classification accuracy against known labels, and generates a summary report.
+
+{{< code file="/unionai-examples/v2/tutorials/genomic_variant_effect/genomic_variant_effect.py" fragment=pipeline lang=python >}}
+
+## Run the workflow
+
+From the [example directory](https://github.com/unionai/unionai-examples/tree/main/v2/tutorials/genomic_variant_effect):
+
+```
+cd v2/tutorials/genomic_variant_effect
+uv run --script genomic_variant_effect.py
+```
+
+Use a smaller Carbon model for faster iteration:
+
+```
+flyte run genomic_variant_effect.py pipeline --model_name HuggingFaceBio/Carbon-500M
+```
+
+Negative VEP scores indicate the model prefers the reference allele over the alternate — a signal correlated with pathogenicity in this zero-shot setup.

--- a/content/tutorials/computer-vision/_index.md
+++ b/content/tutorials/computer-vision/_index.md
@@ -15,6 +15,10 @@ Tutorials for image and vision-language model workloads.
 Adapt Qwen2.5-VL to occluded image classification by training a 10K-parameter adapter with multi-node DeepSpeed, automatic recovery, and live training dashboards.
 {{< /link-card >}}
 
+{{< link-card target="detr-object-detection" title="RT-DETR object detection" >}}
+Fine-tune RT-DETRv2 on a COCO dataset with live training charts, mAP evaluation, and bounding-box demos.
+{{< /link-card >}}
+
 {{< link-card target="multimodal-retrieval-evaluation" title="Multimodal retrieval evaluation" >}}
 Benchmark ColPali, SigLIP, and OCR+BM25 visual document retrieval on ViDoRe with warm GPU containers, dynamic batching, and an interactive report.
 {{< /link-card >}}

--- a/content/tutorials/computer-vision/detr-object-detection/_index.md
+++ b/content/tutorials/computer-vision/detr-object-detection/_index.md
@@ -1,0 +1,59 @@
+---
+title: RT-DETR object detection
+weight: 3
+variants: +flyte +union
+---
+
+# RT-DETR object detection
+
+> [!NOTE]
+> Code available [here](https://github.com/unionai/unionai-examples/tree/main/v2/tutorials/detr_object_detection).
+
+This tutorial fine-tunes [RT-DETRv2](https://huggingface.co/PekingU/rtdetr_v2_r18vd) on a custom COCO-format dataset from HuggingFace. The pipeline downloads and splits the data, fine-tunes the detector with live training charts in Flyte reports, evaluates COCO mAP on a validation split, and renders a side-by-side inference demo with ground-truth and predicted bounding boxes.
+
+Flyte highlights:
+
+- **Cached dataset preparation** so re-runs skip the HuggingFace download.
+- **Live training reports** with loss curves and optional periodic mAP checkpoints.
+- **GPU evaluation and demo tasks** that stream annotated images into the UI.
+
+## Define the task environments
+
+{{< code file="/unionai-examples/v2/tutorials/detr_object_detection/detr_object_detection.py" fragment=env lang=python >}}
+
+```
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#    "flyte>=2.4.0",
+#    "torch>=2.9.0",
+#    "transformers>=4.49.0",
+#    "albumentations>=1.4.0",
+#    "torchmetrics>=1.4.0",
+#    ...
+# ]
+# ///
+```
+
+## Orchestrate the pipeline
+
+The `pipeline` task prepares data, fine-tunes RT-DETR, evaluates mAP, and renders an inference demo.
+
+{{< code file="/unionai-examples/v2/tutorials/detr_object_detection/detr_object_detection.py" fragment=pipeline lang=python >}}
+
+## Run the workflow
+
+From the [example directory](https://github.com/unionai/unionai-examples/tree/main/v2/tutorials/detr_object_detection):
+
+```
+cd v2/tutorials/detr_object_detection
+uv run --script detr_object_detection.py
+```
+
+Quick local smoke test with one epoch:
+
+```
+flyte run detr_object_detection.py pipeline --epochs 1 --batch_size 2
+```
+
+This workflow needs a GPU. Check the **train**, **evaluate**, and **inference_demo** task reports for charts and annotated images.

--- a/content/tutorials/financial-services/_index.md
+++ b/content/tutorials/financial-services/_index.md
@@ -15,6 +15,10 @@ Tutorials for financial research, trading, and other fintech workloads.
 Prep equity briefings for the earnings cycle with grounded You.com Research synthesis and fresh news from the Search API.
 {{< /link-card >}}
 
+{{< link-card target="fraud-detection-feast" title="Fraud detection with Feast" >}}
+Train an XGBoost fraud classifier and materialize transaction features in Feast for online scoring.
+{{< /link-card >}}
+
 {{< link-card target="trading-agents" title="Multi-agent trading simulation" >}}
 A multi-agent trading simulation, modeling how agents within a firm might interact, strategize, and make trades collaboratively.
 {{< /link-card >}}

--- a/content/tutorials/financial-services/fraud-detection-feast/_index.md
+++ b/content/tutorials/financial-services/fraud-detection-feast/_index.md
@@ -1,0 +1,53 @@
+---
+title: Fraud detection with Feast
+weight: 3
+variants: +flyte +union
+---
+
+# Fraud detection with Feast
+
+> [!NOTE]
+> Code available [here](https://github.com/unionai/unionai-examples/tree/main/v2/tutorials/fraud_detection_feast).
+
+This tutorial builds a credit-card fraud detection pipeline that combines [Feast](https://feast.dev/) feature store materialization with an XGBoost classifier on the Sparkov simulated transactions dataset. The workflow engineers transaction and user-level features, trains a model, registers features in Feast, and materializes online feature values for low-latency scoring.
+
+Flyte provides:
+
+- **Cached data preparation** for the Kaggle dataset download and feature engineering.
+- **Report-backed training** with confusion matrix and ROC-style metrics in the UI.
+- **Durable artifacts** — the trained model and Feast repo are returned as `flyte.io.File` and `flyte.io.Dir`.
+
+## Define the task environment
+
+{{< code file="/unionai-examples/v2/tutorials/fraud_detection_feast/fraud_detection_feast.py" fragment=env lang=python >}}
+
+```
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#    "flyte>=2.4.0",
+#    "feast==0.63.0",
+#    "xgboost==3.2.0",
+#    "scikit-learn==1.8.0",
+#    "kagglehub==0.3.12",
+#    ...
+# ]
+# ///
+```
+
+## Orchestrate the pipeline
+
+The `fraud_detection_pipeline` task downloads data, trains XGBoost, applies Feast feature definitions, and materializes features.
+
+{{< code file="/unionai-examples/v2/tutorials/fraud_detection_feast/fraud_detection_feast.py" fragment=pipeline lang=python >}}
+
+## Run the workflow
+
+From the [example directory](https://github.com/unionai/unionai-examples/tree/main/v2/tutorials/fraud_detection_feast):
+
+```
+cd v2/tutorials/fraud_detection_feast
+uv run --script fraud_detection_feast.py
+```
+
+The first run downloads the dataset via `kagglehub` (public dataset, no API key required). Open the run report to review the confusion matrix and feature-importance summary when training completes.

--- a/content/tutorials/model-training/_index.md
+++ b/content/tutorials/model-training/_index.md
@@ -15,4 +15,12 @@ Tutorials for training, fine-tuning, and hyperparameter optimization of models a
 Run large-scale HPO experiments with zero manual tracking, deterministic results, and automatic recovery.
 {{< /link-card >}}
 
+{{< link-card target="llm-fine-tuning-lora-qlora" title="LLM fine-tuning with LoRA and QLoRA" >}}
+Fine-tune a language model for SQL generation using full, LoRA, or QLoRA methods in one Flyte pipeline.
+{{< /link-card >}}
+
+{{< link-card target="bert-fine-tuning-emotion" title="BERT emotion classification" >}}
+Fine-tune ModernBERT on Twitter emotion labels with confusion-matrix evaluation and attention visualizations.
+{{< /link-card >}}
+
 {{< /grid >}}

--- a/content/tutorials/model-training/bert-fine-tuning-emotion/_index.md
+++ b/content/tutorials/model-training/bert-fine-tuning-emotion/_index.md
@@ -1,0 +1,57 @@
+---
+title: BERT emotion classification
+weight: 3
+variants: +flyte +union
+---
+
+# BERT emotion classification
+
+> [!NOTE]
+> Code available [here](https://github.com/unionai/unionai-examples/tree/main/v2/tutorials/bert_fine_tuning_emotion).
+
+This tutorial fine-tunes a BERT-style model (ModernBERT by default) on the [dair-ai/emotion](https://huggingface.co/datasets/dair-ai/emotion) Twitter dataset for six-way emotion classification: sadness, joy, love, anger, fear, and surprise. The pipeline trains the classifier, evaluates with a confusion matrix and per-class F1, and explores inference with attention and token-importance visualizations in Flyte reports.
+
+Flyte provides:
+
+- **GPU fine-tuning** with live training loss charts.
+- **Rich evaluation reports** including confusion matrices and confidence bars.
+- **Cached dataset loading** for repeatable experiments.
+
+## Define the task environments
+
+{{< code file="/unionai-examples/v2/tutorials/bert_fine_tuning_emotion/bert_fine_tuning_emotion.py" fragment=env lang=python >}}
+
+```
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#    "flyte>=2.4.0",
+#    "torch>=2.1.0",
+#    "transformers>=4.45.0",
+#    "datasets>=3.0.0",
+#    "scikit-learn",
+#    ...
+# ]
+# ///
+```
+
+## Orchestrate the pipeline
+
+{{< code file="/unionai-examples/v2/tutorials/bert_fine_tuning_emotion/bert_fine_tuning_emotion.py" fragment=pipeline lang=python >}}
+
+## Run the workflow
+
+From the [example directory](https://github.com/unionai/unionai-examples/tree/main/v2/tutorials/bert_fine_tuning_emotion):
+
+```
+cd v2/tutorials/bert_fine_tuning_emotion
+uv run --script bert_fine_tuning_emotion.py
+```
+
+Quick smoke test with a small sample:
+
+```
+flyte run bert_fine_tuning_emotion.py pipeline --max_train_samples 200 --max_eval_samples 50 --epochs 1
+```
+
+Open the **evaluate** and **explore_inference** task reports for confusion matrices and attention visualizations.

--- a/content/tutorials/model-training/llm-fine-tuning-lora-qlora/_index.md
+++ b/content/tutorials/model-training/llm-fine-tuning-lora-qlora/_index.md
@@ -1,0 +1,66 @@
+---
+title: LLM fine-tuning with LoRA and QLoRA
+weight: 2
+variants: +flyte +union
+---
+
+# LLM fine-tuning with LoRA and QLoRA
+
+> [!NOTE]
+> Code available [here](https://github.com/unionai/unionai-examples/tree/main/v2/tutorials/llm_fine_tuning_lora_qlora).
+
+This tutorial fine-tunes a language model for SQL generation using three methods in one workflow: **full** fine-tuning, **LoRA** adapters, and **QLoRA** (4-bit quantized base + LoRA). The pipeline prepares an instruction dataset from HuggingFace, trains with [TRL](https://huggingface.co/docs/trl) `SFTTrainer`, evaluates against a base-model baseline, and streams training charts into Flyte reports.
+
+Flyte provides:
+
+- **GPU training** with live loss and learning-rate charts via `report=True`.
+- **Method switching** through a single `method` parameter (`full`, `lora`, or `qlora`).
+- **Cached dataset preparation** for fast iteration on hyperparameters.
+
+## Define the task environments
+
+The GPU environment declares a HuggingFace token secret for gated models.
+
+{{< code file="/unionai-examples/v2/tutorials/llm_fine_tuning_lora_qlora/llm_fine_tuning_lora_qlora.py" fragment=env lang=python >}}
+
+```
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#    "flyte>=2.4.0",
+#    "torch>=2.1.0",
+#    "transformers>=4.45.0",
+#    "peft>=0.13.0",
+#    "trl>=0.12.0",
+#    "bitsandbytes>=0.44.0",
+#    ...
+# ]
+# ///
+```
+
+## Orchestrate the pipeline
+
+{{< code file="/unionai-examples/v2/tutorials/llm_fine_tuning_lora_qlora/llm_fine_tuning_lora_qlora.py" fragment=pipeline lang=python >}}
+
+## Run the workflow
+
+Create a HuggingFace token secret if you use a gated base model:
+
+```
+flyte create secret huggingface-token <YOUR_HF_TOKEN>
+```
+
+From the [example directory](https://github.com/unionai/unionai-examples/tree/main/v2/tutorials/llm_fine_tuning_lora_qlora):
+
+```
+cd v2/tutorials/llm_fine_tuning_lora_qlora
+uv run --script llm_fine_tuning_lora_qlora.py
+```
+
+Try QLoRA on a GPU:
+
+```
+flyte run llm_fine_tuning_lora_qlora.py pipeline --method qlora --epochs 3
+```
+
+QLoRA requires CUDA; LoRA and full fine-tuning follow the same entry point with different memory requirements.


### PR DESCRIPTION
## Summary
- Add tutorial pages for seven workshop-derived examples (genomic gene comparison, variant effect prediction, RT-DETR, fraud detection with Feast, LLM LoRA/QLoRA, BERT emotion, LangGraph research agent).
- Update section index pages with link cards in the appropriate vertical/topic categories.
- Point `unionai-examples` submodule at [unionai/unionai-examples#261](https://github.com/unionai/unionai-examples/pull/261).

## Test plan
- [ ] `make dev` and verify new tutorial pages render with code fragments
- [ ] Confirm link cards appear on Biotech, Computer Vision, Financial Services, Model Training, and Agents section pages
- [ ] Merge after unionai-examples PR #261 lands, then update submodule to main


Made with [Cursor](https://cursor.com)