### PR TITLE
Add tutorial docs for AutoSec, parallelized autoresearch, and drug screening

### DIFF
--- a/content/tutorials/agents/_index.md
+++ b/content/tutorials/agents/_index.md
@@ -15,6 +15,14 @@ Tutorials for building agentic workflows and autonomous LLM-powered systems.
 Run an autonomous research loop that drives Claude Code in a GPU container to run experiments, then commits results and opens a pull request.
 {{< /link-card >}}
 
+{{< link-card target="parallelized-autoresearch-agent" title="Parallelized autoresearch agent" >}}
+Scale autoresearch with a code-mode MLE agent that batches train.py edits and runs sandbox experiments in parallel via flyte.map.
+{{< /link-card >}}
+
+{{< link-card target="autosec-research-agent" title="AutoSec researcher agent" >}}
+Fan out vulnerability analysis across C targets, hypothesize exploits with an LLM agent, and validate PoCs in an isolated sandbox.
+{{< /link-card >}}
+
 {{< link-card target="code-agent" title="Coding agent" >}}
 Securely execute and iterate on LLM-generated code using a code agent with error reflection and retry logic.
 {{< /link-card >}}

--- a/content/tutorials/agents/autoresearch/_index.md
+++ b/content/tutorials/agents/autoresearch/_index.md
@@ -34,6 +34,7 @@ The task needs a GPU, a generous disk for the cloned repo and model weights, and
 
 The agent targets a specific repository, identity, and branch via module-level constants. Update these to point at your own fork before running:
 
+```
 GITHUB_USERNAME = "<YOUR_GITHUB_USERNAME>"
 GITHUB_EMAIL = "you@example.com"
 AUTORESEARCH_REPO_URL = "https://github.com/<YOUR_ORG>/<YOUR_REPO>.git"

--- a/content/tutorials/agents/autosec-research-agent/_index.md
+++ b/content/tutorials/agents/autosec-research-agent/_index.md
@@ -1,0 +1,71 @@
+---
+title: AutoSec researcher agent
+weight: 3
+variants: +flyte +union
+---
+
+# AutoSec researcher agent
+
+> [!NOTE]
+> Code available [here](https://github.com/unionai/unionai-examples/tree/main/v2/tutorials/autosec_research_agent).
+
+This tutorial demonstrates an autonomous security-research agent on Flyte. The pipeline fans out across bundled C source files (each with a planted memory-corruption bug), runs static analysis, uses a `flyte.ai.agents.Agent` to hypothesize vulnerabilities, builds proof-of-concept payloads, and validates exploits inside an on-device [unionai-sandbox](https://www.union.ai/docs/v2/union/user-guide/sandboxing/interactive-sandboxes/) user-namespace session.
+
+Flyte provides:
+
+- **Parallel fan-out** across every target file with `asyncio.gather`
+- **Self-healing tasks** — LLM timeouts, malformed JSON, and OOM during static analysis retry with bounded resources
+- **Sandbox isolation** — PoC compilation and execution never runs on the orchestration node
+- **Live HTML reports** with per-target detail tabs in the Flyte UI
+
+> [!WARNING]
+> This example analyzes deliberately vulnerable C code and runs generated exploit payloads in a sandbox. Use it only in controlled environments.
+
+## Define the task environment
+
+The agent needs an Anthropic API key and a container image with `gcc` for sandbox compilation.
+
+{{< code file="/unionai-examples/v2/tutorials/autosec_research_agent/main.py" fragment=env lang=python >}}
+
+The Python packages are declared at the top of the file using the `uv` script style:
+
+```
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#    "flyte>=2.4.0",
+#    "unionai-sandbox",
+# ]
+# ///
+```
+
+## Run the security pipeline
+
+Each target flows through four stages: static scan, LLM hypothesis, PoC construction, and sandbox validation. The driver task analyzes all bundled targets in parallel and streams a findings report.
+
+{{< code file="/unionai-examples/v2/tutorials/autosec_research_agent/main.py" fragment=pipeline lang=python >}}
+
+## Run the agent
+
+### Create secrets
+
+Get an Anthropic API key from the [Anthropic console](https://console.anthropic.com/) and register it as a Flyte secret:
+
+```
+flyte create secret internal-anthropic-api-key <YOUR_ANTHROPIC_API_KEY>
+```
+
+See [Secrets](../../../user-guide/task-configuration/secrets) for scoping and file-based secrets.
+
+### Run remotely
+
+From the [example directory](https://github.com/unionai/unionai-examples/tree/main/v2/tutorials/autosec_research_agent):
+
+```
+cd v2/tutorials/autosec_research_agent
+uv run --script main.py
+```
+
+Follow the printed run URL to watch each target progress through the pipeline and open the report panel for the findings table and per-target detail tabs.
+
+Optional environment variables demonstrate self-healing behavior (`AUTOSEC_FORCE_LLM_TIMEOUT`, `AUTOSEC_FORCE_BAD_TOOL_CALL`, `AUTOSEC_FORCE_OOM`, or `AUTOSEC_FORCE_ALL=1`).

--- a/content/tutorials/agents/autosec-research-agent/_index.md
+++ b/content/tutorials/agents/autosec-research-agent/_index.md
@@ -9,7 +9,7 @@ variants: +flyte +union
 > [!NOTE]
 > Code available [here](https://github.com/unionai/unionai-examples/tree/main/v2/tutorials/autosec_research_agent).
 
-This tutorial demonstrates an autonomous security-research agent on Flyte. The pipeline fans out across bundled C source files (each with a planted memory-corruption bug), runs static analysis, uses a `flyte.ai.agents.Agent` to hypothesize vulnerabilities, builds proof-of-concept payloads, and validates exploits inside an on-device [unionai-sandbox](https://www.union.ai/docs/v2/union/user-guide/sandboxing/interactive-sandboxes/) user-namespace session.
+This tutorial demonstrates an autonomous security-research agent on Flyte. The pipeline fans out across bundled C source files (each with a planted memory-corruption bug), runs static analysis, uses a `flyte.ai.agents.Agent` to hypothesize vulnerabilities, builds proof-of-concept payloads, and validates exploits inside an on-device [unionai-sandbox](../../../user-guide/sandboxing/_index) user-namespace session.
 
 Flyte provides:
 

--- a/content/tutorials/agents/autosec-research-agent/_index.md
+++ b/content/tutorials/agents/autosec-research-agent/_index.md
@@ -35,6 +35,7 @@ The Python packages are declared at the top of the file using the `uv` script st
 # dependencies = [
 #    "flyte>=2.4.0",
 #    "unionai-sandbox",
+#    "litellm",
 # ]
 # ///
 ```

--- a/content/tutorials/agents/autosec-research-agent/_index.md
+++ b/content/tutorials/agents/autosec-research-agent/_index.md
@@ -42,7 +42,7 @@ The Python packages are declared at the top of the file using the `uv` script st
 
 ## Run the security pipeline
 
-Each target flows through four stages: static scan, LLM hypothesis, PoC construction, and sandbox validation. The driver task analyzes all bundled targets in parallel and streams a findings report.
+Each target flows through four stages: static scan, LLM hypothesis, PoC construction, and sandbox validation. The `run_autosec_agent` driver task analyzes all bundled targets in parallel and streams a findings report.
 
 {{< code file="/unionai-examples/v2/tutorials/autosec_research_agent/main.py" fragment=pipeline lang=python >}}
 

--- a/content/tutorials/agents/code-agent/_index.md
+++ b/content/tutorials/agents/code-agent/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Coding agent
-weight: 1
+weight: 3
 variants: +flyte +union
 sidebar_expanded: true
 ---

--- a/content/tutorials/agents/deep-research/_index.md
+++ b/content/tutorials/agents/deep-research/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Deep research
-weight: 2
+weight: 3
 variants: +flyte +union
 ---
 

--- a/content/tutorials/agents/mle-bot/_index.md
+++ b/content/tutorials/agents/mle-bot/_index.md
@@ -1,6 +1,6 @@
 ---
 title: MLE bot
-weight: 1
+weight: 3
 variants: +flyte +union
 ---
 

--- a/content/tutorials/agents/parallelized-autoresearch-agent/_index.md
+++ b/content/tutorials/agents/parallelized-autoresearch-agent/_index.md
@@ -9,7 +9,7 @@ variants: +flyte +union
 > [!NOTE]
 > Code available [here](https://github.com/unionai/unionai-examples/tree/main/v2/tutorials/parallelized_autoresearch).
 
-This tutorial extends the [Autoresearch agent](../autoresearch/_index) pattern with a code-mode MLE agent that plans **batches** of training experiments, saves distinct `train.py` edits, and runs them **in parallel** via `flyte.map`. It follows the [karpathy/autoresearch](https://github.com/karpathy/autoresearch) loop — minimize validation bits-per-byte on a TinyGPT variant — but orchestrates fan-out batches with durable Flyte tasks and [unionai-sandbox](https://www.union.ai/docs/v2/union/user-guide/sandboxing/interactive-sandboxes/) execution.
+This tutorial extends the [Autoresearch agent](../autoresearch/_index) pattern with a code-mode MLE agent that plans **batches** of training experiments, saves distinct `train.py` edits, and runs them **in parallel** via `flyte.map`. It follows the [karpathy/autoresearch](https://github.com/karpathy/autoresearch) loop — minimize validation bits-per-byte on a TinyGPT variant — but orchestrates fan-out batches with durable Flyte tasks and [unionai-sandbox](../../../user-guide/sandboxing/_index) execution.
 
 Compared to the single-threaded Claude Code autoresearch tutorial, this agent:
 

--- a/content/tutorials/agents/parallelized-autoresearch-agent/_index.md
+++ b/content/tutorials/agents/parallelized-autoresearch-agent/_index.md
@@ -48,7 +48,7 @@ From the [example directory](https://github.com/unionai/unionai-examples/tree/ma
 
 ```
 cd v2/tutorials/mle_autoresearch_fanout
-uv run --script mle_autoresearch_fanout.py --n-experiments 6 --batch-size 3 --num-shards 1
+uv run --script mle_autoresearch_fanout.py -- --n_experiments 6 --batch_size 3 --num_shards 1
 ```
 
 Use `--memory-key` to resume a prior research session. Code mode needs more turns than JSON tool mode — increase `--max-turns` for larger sweeps.

--- a/content/tutorials/agents/parallelized-autoresearch-agent/_index.md
+++ b/content/tutorials/agents/parallelized-autoresearch-agent/_index.md
@@ -24,7 +24,7 @@ The example uses three environments — bundle preparation, sandbox experiments,
 
 {{< code file="/unionai-examples/v2/tutorials/parallelized_autoresearch/bundle.py" fragment=env lang=python >}}
 
-Supporting modules (`train.py`, `prepare.py`, `sandbox_runner.py`, `code_edit_tools.py`, `fanout_tools.py`, and others) live alongside the entry point in the example directory.
+Supporting modules (`train.py`, `prepare.py`, `tools.py`, and `ui.py`) live alongside the entry point in the example directory.
 
 ## The fan-out agent task
 

--- a/content/tutorials/agents/parallelized-autoresearch-agent/_index.md
+++ b/content/tutorials/agents/parallelized-autoresearch-agent/_index.md
@@ -1,0 +1,59 @@
+---
+title: Parallelized autoresearch agent
+weight: 2
+variants: +flyte +union
+---
+
+# Parallelized autoresearch agent
+
+> [!NOTE]
+> Code available [here](https://github.com/unionai/unionai-examples/tree/main/v2/tutorials/mle_autoresearch_fanout).
+
+This tutorial extends the [Autoresearch agent](./autoresearch/) pattern with a code-mode MLE agent that plans **batches** of training experiments, saves distinct `train.py` edits, and runs them **in parallel** via `flyte.map`. It follows the [karpathy/autoresearch](https://github.com/karpathy/autoresearch) loop — minimize validation bits-per-byte on a TinyGPT variant — but orchestrates fan-out batches with durable Flyte tasks and [unionai-sandbox](https://www.union.ai/docs/v2/union/user-guide/sandboxing/interactive-sandboxes/) execution.
+
+Compared to the single-threaded Claude Code autoresearch tutorial, this agent:
+
+- Edits full `train.py` source (upstream karpathy style) instead of calling a remote coding CLI
+- Uses **`code_mode=True`** so the LLM writes Python plans that call `run_experiment_batch` or `flyte_map`
+- Persists a **leaderboard**, code-edit history, and batch plans in `MemoryStore`
+- Self-heals **OOM** during sandbox training runs by bumping memory and retrying
+
+## Define the task environments
+
+The example uses three environments — bundle preparation, sandbox experiments, and the agent driver — sharing a Debian-based image with PyTorch and sandbox tooling.
+
+{{< code file="/unionai-examples/v2/tutorials/mle_autoresearch_fanout/bundle.py" fragment=env lang=python >}}
+
+Supporting modules (`train.py`, `prepare.py`, `sandbox_runner.py`, `code_edit_tools.py`, `fanout_tools.py`, and others) live alongside the entry point in the example directory.
+
+## The fan-out agent task
+
+The driver task restores prior memory, streams Activity / Leaderboard / Code edits / Memory report tabs, and runs the code-mode agent loop.
+
+{{< code file="/unionai-examples/v2/tutorials/mle_autoresearch_fanout/mle_autoresearch_fanout.py" fragment=agent lang=python >}}
+
+## Run the agent
+
+### Create secrets
+
+Register an Anthropic API key for the agent LLM calls:
+
+```
+flyte create secret internal-anthropic-api-key <YOUR_ANTHROPIC_API_KEY>
+```
+
+### Run remotely
+
+From the [example directory](https://github.com/unionai/unionai-examples/tree/main/v2/tutorials/mle_autoresearch_fanout):
+
+```
+cd v2/tutorials/mle_autoresearch_fanout
+uv run --script mle_autoresearch_fanout.py --n-experiments 6 --batch-size 3 --num-shards 1
+```
+
+Use `--memory-key` to resume a prior research session. Code mode needs more turns than JSON tool mode — increase `--max-turns` for larger sweeps.
+
+> [!NOTE]
+> The first run downloads climbmix data shards and trains a BPE tokenizer. Subsequent runs reuse cached bundle tasks.
+
+See also the single-task [Autoresearch agent](./autoresearch/) tutorial for the Claude Code + pull-request workflow.

--- a/content/tutorials/agents/parallelized-autoresearch-agent/_index.md
+++ b/content/tutorials/agents/parallelized-autoresearch-agent/_index.md
@@ -56,7 +56,7 @@ Use `--memory-key` to resume a prior research session. Code mode needs more turn
 Or invoke the agent task directly with `flyte run` (snake_case task inputs):
 
 ```
-flyte run parallelized_autoresearch.py mle_autoresearch_code_fanout_agent \
+flyte run parallelized_autoresearch.py parallelized_autoresearch \
   --n_experiments 6 --batch_size 3 --num_shards 1 --max_turns 12
 ```
 

--- a/content/tutorials/agents/parallelized-autoresearch-agent/_index.md
+++ b/content/tutorials/agents/parallelized-autoresearch-agent/_index.md
@@ -7,7 +7,7 @@ variants: +flyte +union
 # Parallelized autoresearch agent
 
 > [!NOTE]
-> Code available [here](https://github.com/unionai/unionai-examples/tree/main/v2/tutorials/mle_autoresearch_fanout).
+> Code available [here](https://github.com/unionai/unionai-examples/tree/main/v2/tutorials/parallelized_autoresearch).
 
 This tutorial extends the [Autoresearch agent](./autoresearch/) pattern with a code-mode MLE agent that plans **batches** of training experiments, saves distinct `train.py` edits, and runs them **in parallel** via `flyte.map`. It follows the [karpathy/autoresearch](https://github.com/karpathy/autoresearch) loop — minimize validation bits-per-byte on a TinyGPT variant — but orchestrates fan-out batches with durable Flyte tasks and [unionai-sandbox](https://www.union.ai/docs/v2/union/user-guide/sandboxing/interactive-sandboxes/) execution.
 
@@ -22,7 +22,7 @@ Compared to the single-threaded Claude Code autoresearch tutorial, this agent:
 
 The example uses three environments — bundle preparation, sandbox experiments, and the agent driver — sharing a Debian-based image with PyTorch and sandbox tooling.
 
-{{< code file="/unionai-examples/v2/tutorials/mle_autoresearch_fanout/bundle.py" fragment=env lang=python >}}
+{{< code file="/unionai-examples/v2/tutorials/parallelized_autoresearch/bundle.py" fragment=env lang=python >}}
 
 Supporting modules (`train.py`, `prepare.py`, `sandbox_runner.py`, `code_edit_tools.py`, `fanout_tools.py`, and others) live alongside the entry point in the example directory.
 
@@ -30,7 +30,7 @@ Supporting modules (`train.py`, `prepare.py`, `sandbox_runner.py`, `code_edit_to
 
 The driver task restores prior memory, streams Activity / Leaderboard / Code edits / Memory report tabs, and runs the code-mode agent loop.
 
-{{< code file="/unionai-examples/v2/tutorials/mle_autoresearch_fanout/mle_autoresearch_fanout.py" fragment=agent lang=python >}}
+{{< code file="/unionai-examples/v2/tutorials/parallelized_autoresearch/parallelized_autoresearch.py" fragment=agent lang=python >}}
 
 ## Run the agent
 
@@ -44,11 +44,11 @@ flyte create secret internal-anthropic-api-key <YOUR_ANTHROPIC_API_KEY>
 
 ### Run remotely
 
-From the [example directory](https://github.com/unionai/unionai-examples/tree/main/v2/tutorials/mle_autoresearch_fanout):
+From the [example directory](https://github.com/unionai/unionai-examples/tree/main/v2/tutorials/parallelized_autoresearch):
 
 ```
-cd v2/tutorials/mle_autoresearch_fanout
-uv run --script mle_autoresearch_fanout.py -- --n-experiments 6 --batch-size 3 --num-shards 1
+cd v2/tutorials/parallelized_autoresearch
+uv run --script parallelized_autoresearch.py -- --n-experiments 6 --batch-size 3 --num-shards 1
 ```
 
 Use `--memory-key` to resume a prior research session. Code mode needs more turns than JSON tool mode — increase `--max-turns` for larger sweeps.
@@ -56,7 +56,7 @@ Use `--memory-key` to resume a prior research session. Code mode needs more turn
 Or invoke the agent task directly with `flyte run` (snake_case task inputs):
 
 ```
-flyte run mle_autoresearch_fanout.py mle_autoresearch_code_fanout_agent \
+flyte run parallelized_autoresearch.py mle_autoresearch_code_fanout_agent \
   --n_experiments 6 --batch_size 3 --num_shards 1 --max_turns 12
 ```
 

--- a/content/tutorials/agents/parallelized-autoresearch-agent/_index.md
+++ b/content/tutorials/agents/parallelized-autoresearch-agent/_index.md
@@ -51,7 +51,7 @@ cd v2/tutorials/mle_autoresearch_fanout
 uv run --script mle_autoresearch_fanout.py -- --n_experiments 6 --batch_size 3 --num_shards 1
 ```
 
-Use `--memory-key` to resume a prior research session. Code mode needs more turns than JSON tool mode — increase `--max-turns` for larger sweeps.
+Use `--memory_key` to resume a prior research session. Code mode needs more turns than JSON tool mode — increase `--max_turns` for larger sweeps.
 
 > [!NOTE]
 > The first run downloads climbmix data shards and trains a BPE tokenizer. Subsequent runs reuse cached bundle tasks.

--- a/content/tutorials/agents/parallelized-autoresearch-agent/_index.md
+++ b/content/tutorials/agents/parallelized-autoresearch-agent/_index.md
@@ -28,7 +28,7 @@ Supporting modules (`train.py`, `prepare.py`, `tools.py`, and `ui.py`) live alon
 
 ## The fan-out agent task
 
-The driver task restores prior memory, streams Activity / Leaderboard / Code edits / Memory report tabs, and runs the code-mode agent loop.
+The driver task `parallelized_autoresearch` restores prior memory (default key `parallelized-autoresearch`), streams Activity / Leaderboard / Code edits / Memory report tabs, and runs the code-mode agent loop.
 
 {{< code file="/unionai-examples/v2/tutorials/parallelized_autoresearch/parallelized_autoresearch.py" fragment=agent lang=python >}}
 
@@ -51,13 +51,14 @@ cd v2/tutorials/parallelized_autoresearch
 uv run --script parallelized_autoresearch.py -- --n-experiments 6 --batch-size 3 --num-shards 1
 ```
 
-Use `--memory-key` to resume a prior research session. Code mode needs more turns than JSON tool mode — increase `--max-turns` for larger sweeps.
+Use `--memory-key` to resume a prior research session (default: `parallelized-autoresearch`). Pass a unique key — for example `parallelized-autoresearch-20260622-215057` — to start with empty memory. Code mode needs more turns than JSON tool mode — increase `--max-turns` for larger sweeps.
 
 Or invoke the agent task directly with `flyte run` (snake_case task inputs):
 
 ```
 flyte run parallelized_autoresearch.py parallelized_autoresearch \
-  --n_experiments 6 --batch_size 3 --num_shards 1 --max_turns 12
+  --n_experiments 6 --batch_size 3 --num_shards 1 --max_turns 12 \
+  --memory_key parallelized-autoresearch
 ```
 
 > [!NOTE]

--- a/content/tutorials/agents/parallelized-autoresearch-agent/_index.md
+++ b/content/tutorials/agents/parallelized-autoresearch-agent/_index.md
@@ -9,7 +9,7 @@ variants: +flyte +union
 > [!NOTE]
 > Code available [here](https://github.com/unionai/unionai-examples/tree/main/v2/tutorials/parallelized_autoresearch).
 
-This tutorial extends the [Autoresearch agent](./autoresearch/) pattern with a code-mode MLE agent that plans **batches** of training experiments, saves distinct `train.py` edits, and runs them **in parallel** via `flyte.map`. It follows the [karpathy/autoresearch](https://github.com/karpathy/autoresearch) loop — minimize validation bits-per-byte on a TinyGPT variant — but orchestrates fan-out batches with durable Flyte tasks and [unionai-sandbox](https://www.union.ai/docs/v2/union/user-guide/sandboxing/interactive-sandboxes/) execution.
+This tutorial extends the [Autoresearch agent](../autoresearch/_index) pattern with a code-mode MLE agent that plans **batches** of training experiments, saves distinct `train.py` edits, and runs them **in parallel** via `flyte.map`. It follows the [karpathy/autoresearch](https://github.com/karpathy/autoresearch) loop — minimize validation bits-per-byte on a TinyGPT variant — but orchestrates fan-out batches with durable Flyte tasks and [unionai-sandbox](https://www.union.ai/docs/v2/union/user-guide/sandboxing/interactive-sandboxes/) execution.
 
 Compared to the single-threaded Claude Code autoresearch tutorial, this agent:
 
@@ -64,4 +64,4 @@ flyte run parallelized_autoresearch.py parallelized_autoresearch \
 > [!NOTE]
 > The first run downloads climbmix data shards and trains a BPE tokenizer. Subsequent runs reuse cached bundle tasks.
 
-See also the single-task [Autoresearch agent](./autoresearch/) tutorial for the Claude Code + pull-request workflow.
+See also the single-task [Autoresearch agent](../autoresearch/_index) tutorial for the Claude Code + pull-request workflow.

--- a/content/tutorials/agents/parallelized-autoresearch-agent/_index.md
+++ b/content/tutorials/agents/parallelized-autoresearch-agent/_index.md
@@ -48,10 +48,17 @@ From the [example directory](https://github.com/unionai/unionai-examples/tree/ma
 
 ```
 cd v2/tutorials/mle_autoresearch_fanout
-uv run --script mle_autoresearch_fanout.py -- --n_experiments 6 --batch_size 3 --num_shards 1
+uv run --script mle_autoresearch_fanout.py -- --n-experiments 6 --batch-size 3 --num-shards 1
 ```
 
-Use `--memory_key` to resume a prior research session. Code mode needs more turns than JSON tool mode — increase `--max_turns` for larger sweeps.
+Use `--memory-key` to resume a prior research session. Code mode needs more turns than JSON tool mode — increase `--max-turns` for larger sweeps.
+
+Or invoke the agent task directly with `flyte run` (snake_case task inputs):
+
+```
+flyte run mle_autoresearch_fanout.py mle_autoresearch_code_fanout_agent \
+  --n_experiments 6 --batch_size 3 --num_shards 1 --max_turns 12
+```
 
 > [!NOTE]
 > The first run downloads climbmix data shards and trains a BPE tokenizer. Subsequent runs reuse cached bundle tasks.

--- a/content/tutorials/biotech-healthcare/_index.md
+++ b/content/tutorials/biotech-healthcare/_index.md
@@ -19,4 +19,8 @@ Align sequencing reads to a reference genome with a cached, parallel Bowtie 2 pi
 Classify brain MRI scans with a two-phase EfficientNet-B4 pipeline featuring resumable GPU checkpointing and in-UI reports.
 {{< /link-card >}}
 
+{{< link-card target="drug-molecule-screening" title="Drug molecule screening" >}}
+Screen drug candidates with RDKit physicochemical properties, Lipinski filters, and ranked drug-likeness reports.
+{{< /link-card >}}
+
 {{< /grid >}}

--- a/content/tutorials/biotech-healthcare/drug-molecule-screening/_index.md
+++ b/content/tutorials/biotech-healthcare/drug-molecule-screening/_index.md
@@ -53,10 +53,10 @@ cd v2/tutorials/drug_molecule_screening
 uv run --script drug_molecule_screening.py
 ```
 
-The default run screens a curated library of ~15 well-known drugs. Pass custom inputs to narrow the target profile:
+Pass a custom target profile:
 
 ```
-uv run --script drug_molecule_screening.py pipeline \
+flyte run drug_molecule_screening.py pipeline \
   --target_profile '{"mw": [100, 400], "logp": [-0.5, 4.0]}'
 ```
 

--- a/content/tutorials/biotech-healthcare/drug-molecule-screening/_index.md
+++ b/content/tutorials/biotech-healthcare/drug-molecule-screening/_index.md
@@ -28,7 +28,7 @@ The pipeline runs on CPU with RDKit and system libraries for 2D structure render
 # requires-python = ">=3.12"
 # dependencies = [
 #    "flyte>=2.4.0",
-#    "rdkit-pypi",
+#    "rdkit",
 #    "numpy",
 #    "scikit-learn",
 #    "pillow",

--- a/content/tutorials/biotech-healthcare/drug-molecule-screening/_index.md
+++ b/content/tutorials/biotech-healthcare/drug-molecule-screening/_index.md
@@ -14,8 +14,8 @@ This tutorial builds a virtual drug-screening pipeline on Flyte. The workflow lo
 Flyte provides:
 
 - **Cached molecule loading** so repeated runs skip re-parsing SMILES
-- **Report tasks** that stream property charts, similarity matrices, and candidate spotlights as each stage completes
-- **End-to-end orchestration** from library loading through final ranked recommendations
+- **Report-enabled stage tasks** that stream property charts, similarity matrices, and candidate spotlights as each step completes
+- **Lightweight orchestration** — the top-level `pipeline` task chains stages without its own report surface
 
 ## Define the task environment
 
@@ -38,11 +38,11 @@ The pipeline runs on CPU with RDKit and system libraries for 2D structure render
 
 ## Orchestrate the pipeline
 
-The `pipeline` task loads molecules, computes properties, screens against a target profile, and generates a final report.
+The `pipeline` task is a lightweight orchestrator: it calls four stage tasks in sequence and returns a JSON summary.
 
 {{< code file="/unionai-examples/v2/tutorials/drug_molecule_screening/drug_molecule_screening.py" fragment=pipeline lang=python >}}
 
-Intermediate tasks (`load_molecules`, `compute_properties`, `screen_candidates`, `generate_report`) each update the Flyte report as they run.
+Each stage task (`load_molecules`, `compute_properties`, `screen_candidates`, `generate_report`) owns its own `report=True` surface and updates the Flyte UI as it runs.
 
 ## Run the workflow
 

--- a/content/tutorials/biotech-healthcare/drug-molecule-screening/_index.md
+++ b/content/tutorials/biotech-healthcare/drug-molecule-screening/_index.md
@@ -1,0 +1,63 @@
+---
+title: Drug molecule screening
+weight: 5
+variants: +flyte +union
+---
+
+# Drug molecule screening
+
+> [!NOTE]
+> Code available [here](https://github.com/unionai/unionai-examples/tree/main/v2/tutorials/drug_molecule_screening).
+
+This tutorial builds a virtual drug-screening pipeline on Flyte. The workflow loads a library of drug SMILES strings, computes physicochemical properties with [RDKit](https://www.rdkit.org/), applies Lipinski's Rule of Five and custom target-profile filters, and ranks candidates by drug-likeness score — with rich HTML reports streamed into the Flyte UI.
+
+Flyte provides:
+
+- **Cached molecule loading** so repeated runs skip re-parsing SMILES
+- **Report tasks** that stream property charts, similarity matrices, and candidate spotlights as each stage completes
+- **End-to-end orchestration** from library loading through final ranked recommendations
+
+## Define the task environment
+
+The pipeline runs on CPU with RDKit and system libraries for 2D structure rendering.
+
+{{< code file="/unionai-examples/v2/tutorials/drug_molecule_screening/drug_molecule_screening.py" fragment=env lang=python >}}
+
+```
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#    "flyte>=2.4.0",
+#    "rdkit-pypi",
+#    "numpy",
+#    "scikit-learn",
+#    "pillow",
+# ]
+# ///
+```
+
+## Orchestrate the pipeline
+
+The `pipeline` task loads molecules, computes properties, screens against a target profile, and generates a final report.
+
+{{< code file="/unionai-examples/v2/tutorials/drug_molecule_screening/drug_molecule_screening.py" fragment=pipeline lang=python >}}
+
+Intermediate tasks (`load_molecules`, `compute_properties`, `screen_candidates`, `generate_report`) each update the Flyte report as they run.
+
+## Run the workflow
+
+From the [example directory](https://github.com/unionai/unionai-examples/tree/main/v2/tutorials/drug_molecule_screening):
+
+```
+cd v2/tutorials/drug_molecule_screening
+uv run --script drug_molecule_screening.py
+```
+
+The default run screens a curated library of ~15 well-known drugs. Pass custom inputs to narrow the target profile:
+
+```
+uv run --script drug_molecule_screening.py pipeline \
+  --target_profile '{"mw": [100, 400], "logp": [-0.5, 4.0]}'
+```
+
+Open the run URL and follow the report panel for funnel charts, property distributions, and top-candidate spotlights.


### PR DESCRIPTION
## Summary
- Add Agents tutorial pages for **AutoSec researcher agent** and **Parallelized autoresearch agent**
- Add Biotech & healthcare tutorial page for **Drug molecule screening**
- Update Agents and Biotech section indices with link cards
- Fix broken markdown in the existing **Autoresearch agent** tutorial (missing opening code fence on constants block)

Companion examples PR: [unionai/unionai-examples#262](https://github.com/unionai/unionai-examples/pull/262) (submodule at `2833ee5`).

## Test plan
- [ ] `make dev` and verify new tutorial pages render under Agents and Biotech sections
- [ ] Confirm autoresearch constants block renders as a code fence
- [ ] Verify `{{< code fragment=... >}}` shortcodes resolve for all three new examples