### PR TITLE
Regenerate v2 API reference docs (flyte 2.5.1 → 2.5.2)

### DIFF
--- a/content/api-reference/flyte-cli.md
+++ b/content/api-reference/flyte-cli.md
@@ -1,6 +1,6 @@
 ---
 title: "Flyte CLI"
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 weight: 3
@@ -1493,6 +1493,13 @@ $ flyte get run --task-name my_task
 $ flyte get run --task-name my_task --task-version v1.0
 ```
 
+You can filter runs by their user-defined labels:
+
+```bash
+$ flyte get run --with-label team=ml --with-label env=prod
+$ flyte get run --with-label-key team
+```
+
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `--limit` | `integer` | `100` | Limit the number of runs to fetch when listing. |
@@ -1504,6 +1511,8 @@ $ flyte get run --task-name my_task --task-version v1.0
 | `--created-before` | `datetime` |  | Show runs created before this datetime (UTC). |
 | `--updated-after` | `datetime` |  | Show runs updated at or after this datetime (UTC). Accepts ISO dates, 'now', 'today', or 'now - 1 day'. |
 | `--updated-before` | `datetime` |  | Show runs updated before this datetime (UTC). |
+| `--with-label` | `text` | `()` | Filter runs that have this label key=value. Can be specified multiple times (AND semantics). |
+| `--with-label-key` | `text` | `()` | Filter runs that have this label key present (existence check). Can be specified multiple times. |
 | {{< multiline >}}`-p`
 `--project`{{< /multiline >}} | `text` |  | Project to which this command applies. |
 | {{< multiline >}}`-d`
@@ -1827,6 +1836,7 @@ flyte run hello.py my_task --help
 | {{< multiline >}}`--env`
 `-e`{{< /multiline >}} | `text` | `Sentinel.UNSET` | Environment variable to set on the run context. Format: KEY=VALUE. Can be specified multiple times, e.g. `-e LOG_LEVEL=debug -e FOO=bar`. |
 | `--max-action-concurrency` | `integer range` |  | Maximum number of actions that can run concurrently within the run. If not provided, the platform default (run.max_action_concurrency setting) applies. |
+| `--label` | `text` | `Sentinel.UNSET` | User-defined label to attach to the run. Format: KEY=VALUE. Can be specified multiple times, e.g. `--label team=ml --label env=prod`. |
 | `--help` | `boolean` | `False` | Show this message and exit. |
 
 #### flyte run deployed-task

--- a/content/api-reference/flyte-sdk/_index.md
+++ b/content/api-reference/flyte-sdk/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Flyte SDK
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 weight: 4
@@ -13,4 +13,237 @@ These are the docs for Flyte SDK version 2.0
 Flyte is the core Python SDK for the Union and Flyte platforms.
 
 
+
+## Directory
+
+### Classes
+
+| Class | Description |
+|-|-|
+| [`flyte.AppHandle`](packages/flyte/apphandle) | Protocol defining the common interface between local and remote app handles. |
+| [`flyte.Backoff`](packages/flyte/backoff) | Exponential backoff policy applied between user retries. |
+| [`flyte.BaseCheckpoint`](packages/flyte/basecheckpoint) | Base type for task checkpoint helpers. |
+| [`flyte.Cache`](packages/flyte/cache) | Cache configuration for a task. |
+| [`flyte.CachePolicy`](packages/flyte/cachepolicy) | Protocol for custom cache version strategies. |
+| [`flyte.Checkpoint`](packages/flyte/checkpoint) | Checkpoint helper using `flyte. |
+| [`flyte.ConditionWebhook`](packages/flyte/conditionwebhook) | Webhook configuration for a condition notification. |
+| [`flyte.Cron`](packages/flyte/cron) | Cron-based automation schedule for use with `Trigger`. |
+| [`flyte.Device`](packages/flyte/device) | Represents a device type, its quantity and partition if applicable. |
+| [`flyte.Environment`](packages/flyte/environment) | Base class for execution environments, shared by `TaskEnvironment` and. |
+| [`flyte.FixedRate`](packages/flyte/fixedrate) | Fixed-rate (interval-based) automation schedule for use with `Trigger`. |
+| [`flyte.Image`](packages/flyte/image) | Container image specification built using a fluent, two-step pattern:. |
+| [`flyte.ImageBuild`](packages/flyte/imagebuild) | Result of an image build operation. |
+| [`flyte.Link`](packages/flyte/link) |  |
+| [`flyte.PodTemplate`](packages/flyte/podtemplate) | Custom PodTemplate specification for a Task. |
+| [`flyte.Resources`](packages/flyte/resources) | Resources such as CPU, Memory, and GPU that can be allocated to a task. |
+| [`flyte.RetryStrategy`](packages/flyte/retrystrategy) | Retry strategy for a task. |
+| [`flyte.ReusePolicy`](packages/flyte/reusepolicy) | Configure a task environment for container reuse across multiple task invocations. |
+| [`flyte.Secret`](packages/flyte/secret) | Secrets are used to inject sensitive information into tasks or image build context. |
+| [`flyte.TaskEnvironment`](packages/flyte/taskenvironment) | Define an execution environment for a set of tasks. |
+| [`flyte.Timeout`](packages/flyte/timeout) | Timeout bounds for a task. |
+| [`flyte.Trigger`](packages/flyte/trigger) | Specification for a scheduled trigger that can be associated with any Flyte task. |
+| [`flyte.ai.agents.AccessDenied`](packages/flyte.ai.agents/accessdenied) | Raised when a write targets a read-only or reserved prefix. |
+| [`flyte.ai.agents.Agent`](packages/flyte.ai.agents/agent) | A flyte-native tool-use agent harness. |
+| [`flyte.ai.agents.AgentEvent`](packages/flyte.ai.agents/agentevent) | Lightweight event emitted by the agent loop. |
+| [`flyte.ai.agents.AgentProtocol`](packages/flyte.ai.agents/agentprotocol) | Minimal protocol that any agent must satisfy to work with. |
+| [`flyte.ai.agents.AgentResult`](packages/flyte.ai.agents/agentresult) | Outcome of a single agent invocation. |
+| [`flyte.ai.agents.AgentTool`](packages/flyte.ai.agents/agenttool) | A normalized tool descriptor used by :class:`Agent`. |
+| [`flyte.ai.agents.ConcurrencyError`](packages/flyte.ai.agents/concurrencyerror) | Raised when an ``expected_sha`` precondition does not match the current state. |
+| [`flyte.ai.agents.LLMMessage`](packages/flyte.ai.agents/llmmessage) | Provider-agnostic shape returned by :data:`LLMCallable`. |
+| [`flyte.ai.agents.MCPServerSpec`](packages/flyte.ai.agents/mcpserverspec) | Declarative spec for a remote MCP server that exposes tools. |
+| [`flyte.ai.agents.MemoryMeta`](packages/flyte.ai.agents/memorymeta) | Per-file metadata sidecar (sha256, actor, timestamp, …) for a memory entry. |
+| [`flyte.ai.agents.MemoryStore`](packages/flyte.ai.agents/memorystore) | Conversation transcript + path-addressed artifact memory backed by :class:`flyte. |
+| [`flyte.ai.agents.MemoryStoreError`](packages/flyte.ai.agents/memorystoreerror) | Base class for :class:`MemoryStore` errors. |
+| [`flyte.ai.agents.ToolFn`](packages/flyte.ai.agents/toolfn) | The tool under invocation, handed to a :data:`ToolCallHandler`. |
+| [`flyte.ai.agents.agent.Agent`](packages/flyte.ai.agents.agent/agent) | A flyte-native tool-use agent harness. |
+| [`flyte.ai.agents.agent.AgentEvent`](packages/flyte.ai.agents.agent/agentevent) | Lightweight event emitted by the agent loop. |
+| [`flyte.ai.agents.memory.AccessDenied`](packages/flyte.ai.agents.memory/accessdenied) | Raised when a write targets a read-only or reserved prefix. |
+| [`flyte.ai.agents.memory.ConcurrencyError`](packages/flyte.ai.agents.memory/concurrencyerror) | Raised when an ``expected_sha`` precondition does not match the current state. |
+| [`flyte.ai.agents.memory.MemoryMeta`](packages/flyte.ai.agents.memory/memorymeta) | Per-file metadata sidecar (sha256, actor, timestamp, …) for a memory entry. |
+| [`flyte.ai.agents.memory.MemoryStore`](packages/flyte.ai.agents.memory/memorystore) | Conversation transcript + path-addressed artifact memory backed by :class:`flyte. |
+| [`flyte.ai.agents.memory.MemoryStoreError`](packages/flyte.ai.agents.memory/memorystoreerror) | Base class for :class:`MemoryStore` errors. |
+| [`flyte.ai.agents.protocol.AgentProtocol`](packages/flyte.ai.agents.protocol/agentprotocol) | Minimal protocol that any agent must satisfy to work with. |
+| [`flyte.ai.agents.protocol.AgentResult`](packages/flyte.ai.agents.protocol/agentresult) | Outcome of a single agent invocation. |
+| [`flyte.ai.chat.AgentChatAppEnvironment`](packages/flyte.ai.chat/agentchatappenvironment) | An :class:`~flyte. |
+| [`flyte.ai.chat.CustomTheme`](packages/flyte.ai.chat/customtheme) | Declarative color theme for the Agent Chat UI. |
+| [`flyte.ai.chat.app.AgentChatAppEnvironment`](packages/flyte.ai.chat.app/agentchatappenvironment) | An :class:`~flyte. |
+| [`flyte.ai.chat.app.CustomTheme`](packages/flyte.ai.chat.app/customtheme) | Declarative color theme for the Agent Chat UI. |
+| [`flyte.ai.mcp.FlyteMCPAppEnvironment`](packages/flyte.ai.mcp/flytemcpappenvironment) | Serve a Flyte-facing MCP server over HTTP (FastMCP + Starlette + Uvicorn). |
+| [`flyte.ai.mcp.MCPAppEnvironment`](packages/flyte.ai.mcp/mcpappenvironment) | Serve a FastMCP server over HTTP (Starlette + Uvicorn). |
+| [`flyte.app.AppEndpoint`](packages/flyte.app/appendpoint) | Embed an upstream app's endpoint as an app parameter. |
+| [`flyte.app.AppEnvironment`](packages/flyte.app/appenvironment) | Configure a long-running app environment for APIs, dashboards, or model servers. |
+| [`flyte.app.ConnectorEnvironment`](packages/flyte.app/connectorenvironment) | Configure a connector environment for custom Flyte connectors. |
+| [`flyte.app.Domain`](packages/flyte.app/domain) | Subdomain to use for the domain. |
+| [`flyte.app.Link`](packages/flyte.app/link) | Custom links to add to the app. |
+| [`flyte.app.Parameter`](packages/flyte.app/parameter) | Parameter for application. |
+| [`flyte.app.Port`](packages/flyte.app/port) |  |
+| [`flyte.app.RunOutput`](packages/flyte.app/runoutput) | Use a run's output for app parameters. |
+| [`flyte.app.Scaling`](packages/flyte.app/scaling) | Controls replica count and autoscaling behavior for app environments. |
+| [`flyte.app.Timeouts`](packages/flyte.app/timeouts) | Timeout configuration for the application. |
+| [`flyte.app.extras.FastAPIAppEnvironment`](packages/flyte.app.extras/fastapiappenvironment) |  |
+| [`flyte.app.extras.FastAPIPassthroughAuthMiddleware`](packages/flyte.app.extras/fastapipassthroughauthmiddleware) | FastAPI middleware that automatically sets Flyte auth metadata from request headers. |
+| [`flyte.app.extras.FlyteWebhookAppEnvironment`](packages/flyte.app.extras/flytewebhookappenvironment) | A pre-built FastAPI app environment for common Flyte webhook operations. |
+| [`flyte.clustered.ClusterFailurePolicy`](packages/flyte.clustered/clusterfailurepolicy) | Failure and restart policy for the JobSet as a whole. |
+| [`flyte.clustered.ClusteredTaskEnvironment`](packages/flyte.clustered/clusteredtaskenvironment) | A TaskEnvironment that emits a Kubernetes JobSet for distributed multi-node training. |
+| [`flyte.clustered.ClusteredTaskTemplate`](packages/flyte.clustered/clusteredtasktemplate) | Task template for ``ClusteredTaskEnvironment``. |
+| [`flyte.clustered.TorchRun`](packages/flyte.clustered/torchrun) | TorchRun launcher configuration for a ClusteredTaskEnvironment. |
+| [`flyte.config.Config`](packages/flyte.config/config) | This the parent configuration object and holds all the underlying configuration object types. |
+| [`flyte.connectors.AsyncConnector`](packages/flyte.connectors/asyncconnector) | This is the base class for all async connectors, and it defines the interface that all connectors must implement. |
+| [`flyte.connectors.AsyncConnectorExecutorMixin`](packages/flyte.connectors/asyncconnectorexecutormixin) | This mixin class is used to run the connector task locally, and it's only used for local execution. |
+| [`flyte.connectors.ConnectorRegistry`](packages/flyte.connectors/connectorregistry) | This is the registry for all connectors. |
+| [`flyte.connectors.ConnectorService`](packages/flyte.connectors/connectorservice) |  |
+| [`flyte.connectors.Resource`](packages/flyte.connectors/resource) | This is the output resource of the job. |
+| [`flyte.connectors.ResourceMeta`](packages/flyte.connectors/resourcemeta) | This is the metadata for the job. |
+| [`flyte.errors.ActionAbortedError`](packages/flyte.errors/actionabortederror) | This error is raised when an action was aborted, externally. |
+| [`flyte.errors.ActionNotFoundError`](packages/flyte.errors/actionnotfounderror) | This error is raised when the user tries to access an action that does not exist. |
+| [`flyte.errors.BaseRuntimeError`](packages/flyte.errors/baseruntimeerror) | Base class for all Union runtime errors. |
+| [`flyte.errors.CodeBundleError`](packages/flyte.errors/codebundleerror) | This error is raised when the code bundle cannot be created, for example when no files are found to bundle. |
+| [`flyte.errors.ConditionAlreadyExistsError`](packages/flyte.errors/conditionalreadyexistserror) | This error is raised when the user tries to create a condition that already exists within the action. |
+| [`flyte.errors.ConditionFailedError`](packages/flyte.errors/conditionfailederror) | This error is raised when a condition fails during execution. |
+| [`flyte.errors.ConditionNotFoundError`](packages/flyte.errors/conditionnotfounderror) | This error is raised when the user tries to access a condition that does not exist. |
+| [`flyte.errors.ConditionTimedoutError`](packages/flyte.errors/conditiontimedouterror) | This error is raised when a condition is not signaled within its specified timeout. |
+| [`flyte.errors.CustomError`](packages/flyte.errors/customerror) | This error is raised when the user raises a custom error. |
+| [`flyte.errors.DeploymentError`](packages/flyte.errors/deploymenterror) | This error is raised when the deployment of a task fails, or some preconditions for deployment are not met. |
+| [`flyte.errors.ImageBuildError`](packages/flyte.errors/imagebuilderror) | This error is raised when the image build fails. |
+| [`flyte.errors.ImagePullBackOffError`](packages/flyte.errors/imagepullbackofferror) | This error is raised when the image cannot be pulled. |
+| [`flyte.errors.InitializationError`](packages/flyte.errors/initializationerror) | This error is raised when the Union system is tried to access without being initialized. |
+| [`flyte.errors.InlineIOMaxBytesBreached`](packages/flyte.errors/inlineiomaxbytesbreached) | This error is raised when the inline IO max bytes limit is breached. |
+| [`flyte.errors.InvalidImageNameError`](packages/flyte.errors/invalidimagenameerror) | This error is raised when the image name is invalid. |
+| [`flyte.errors.InvalidPackageError`](packages/flyte.errors/invalidpackageerror) | Raised when an invalid system package is detected during image build. |
+| [`flyte.errors.LogsNotYetAvailableError`](packages/flyte.errors/logsnotyetavailableerror) | This error is raised when the logs are not yet available for a task. |
+| [`flyte.errors.ModuleLoadError`](packages/flyte.errors/moduleloaderror) | This error is raised when the module cannot be loaded, either because it does not exist or because of a. |
+| [`flyte.errors.NonRecoverableError`](packages/flyte.errors/nonrecoverableerror) | Raised when an error is encountered that is not recoverable. |
+| [`flyte.errors.NotInTaskContextError`](packages/flyte.errors/notintaskcontexterror) | This error is raised when the user tries to access the task context outside of a task. |
+| [`flyte.errors.OOMError`](packages/flyte.errors/oomerror) | This error is raised when the underlying task execution fails because of an out-of-memory error. |
+| [`flyte.errors.OnlyAsyncIOSupportedError`](packages/flyte.errors/onlyasynciosupportederror) | This error is raised when the user tries to use sync IO in an async task. |
+| [`flyte.errors.ParameterMaterializationError`](packages/flyte.errors/parametermaterializationerror) | This error is raised when the user tries to use a Parameter in an App, that has delayed Materialization,. |
+| [`flyte.errors.PrimaryContainerNotFoundError`](packages/flyte.errors/primarycontainernotfounderror) | This error is raised when the primary container is not found. |
+| [`flyte.errors.RemoteTaskNotFoundError`](packages/flyte.errors/remotetasknotfounderror) | This error is raised when the user tries to access a task that does not exist. |
+| [`flyte.errors.RemoteTaskUsageError`](packages/flyte.errors/remotetaskusageerror) | This error is raised when the user tries to access a task that does not exist. |
+| [`flyte.errors.RestrictedTypeError`](packages/flyte.errors/restrictedtypeerror) | This error is raised when the user uses a restricted type, for example current a Tuple is not supported for one. |
+| [`flyte.errors.RetriesExhaustedError`](packages/flyte.errors/retriesexhaustederror) | This error is raised when the underlying task execution fails after all retries have been exhausted. |
+| [`flyte.errors.RuntimeDataValidationError`](packages/flyte.errors/runtimedatavalidationerror) | This error is raised when the user tries to access a resource that does not exist or is invalid. |
+| [`flyte.errors.RuntimeSystemError`](packages/flyte.errors/runtimesystemerror) | This error is raised when the underlying task execution fails because of a system error. |
+| [`flyte.errors.RuntimeUnknownError`](packages/flyte.errors/runtimeunknownerror) | This error is raised when the underlying task execution fails because of an unknown error. |
+| [`flyte.errors.RuntimeUserError`](packages/flyte.errors/runtimeusererror) | This error is raised when the underlying task execution fails because of an error in the user's code. |
+| [`flyte.errors.SlowDownError`](packages/flyte.errors/slowdownerror) | This error is raised when the user tries to access a resource that does not exist or is invalid. |
+| [`flyte.errors.TaskInterruptedError`](packages/flyte.errors/taskinterruptederror) | This error is raised when the underlying task execution is interrupted. |
+| [`flyte.errors.TaskTimeoutError`](packages/flyte.errors/tasktimeouterror) | This error is raised when the underlying task execution runs for longer than the specified timeout. |
+| [`flyte.errors.TraceDoesNotAllowNestedTasksError`](packages/flyte.errors/tracedoesnotallownestedtaskserror) | This error is raised when the user tries to use a task from within a trace. |
+| [`flyte.errors.UnionRpcError`](packages/flyte.errors/unionrpcerror) | This error is raised when communication with the Union server fails. |
+| [`flyte.extend.AsyncFunctionTaskTemplate`](packages/flyte.extend/asyncfunctiontasktemplate) | A task template that wraps an asynchronous functions. |
+| [`flyte.extend.ImageBuildEngine`](packages/flyte.extend/imagebuildengine) | ImageBuildEngine contains a list of builders that can be used to build an ImageSpec. |
+| [`flyte.extend.ImageBuilder`](packages/flyte.extend/imagebuilder) |  |
+| [`flyte.extend.ImageChecker`](packages/flyte.extend/imagechecker) |  |
+| [`flyte.extend.TaskTemplate`](packages/flyte.extend/tasktemplate) | Task template is a template for a task that can be executed. |
+| [`flyte.extras.BatchStats`](packages/flyte.extras/batchstats) | Monitoring statistics exposed by `DynamicBatcher. |
+| [`flyte.extras.ContainerTask`](packages/flyte.extras/containertask) | This is an intermediate class that represents Flyte Tasks that run a container at execution time. |
+| [`flyte.extras.CostEstimator`](packages/flyte.extras/costestimator) | Protocol for records that can estimate their own processing cost. |
+| [`flyte.extras.DynamicBatcher`](packages/flyte.extras/dynamicbatcher) | Batches records from many concurrent producers and runs them through. |
+| [`flyte.extras.Prompt`](packages/flyte.extras/prompt) | Simple prompt record with built-in token estimation. |
+| [`flyte.extras.Sleep`](packages/flyte.extras/sleep) | Route a task to the backend `core-sleep` plugin. |
+| [`flyte.extras.SleepTask`](packages/flyte.extras/sleeptask) |  |
+| [`flyte.extras.TokenBatcher`](packages/flyte.extras/tokenbatcher) | Token-aware batcher for LLM inference workloads. |
+| [`flyte.extras.TokenEstimator`](packages/flyte.extras/tokenestimator) | Protocol for records that can estimate their own token count. |
+| [`flyte.extras.shell.FlagSpec`](packages/flyte.extras.shell/flagspec) | How to render a typed input as a CLI flag in ``{flags. |
+| [`flyte.extras.shell.Glob`](packages/flyte.extras.shell/glob) | A multi-file output bundle. |
+| [`flyte.extras.shell.Stderr`](packages/flyte.extras.shell/stderr) | Capture the task's stderr as a typed output. |
+| [`flyte.extras.shell.Stdout`](packages/flyte.extras.shell/stdout) | Capture the task's stdout as a typed output. |
+| [`flyte.git.GitStatus`](packages/flyte.git/gitstatus) | A class representing the status of a git repository. |
+| [`flyte.io.DataFrame`](packages/flyte.io/dataframe) | A Flyte meta DataFrame object, that wraps all other dataframe types (usually available as plugins, pandas. |
+| [`flyte.io.Dir`](packages/flyte.io/dir) | A generic directory class representing a directory with files of a specified format. |
+| [`flyte.io.EmptyDir`](packages/flyte.io/emptydir) | A sentinel :class:`Dir` representing 'no directory was produced'. |
+| [`flyte.io.File`](packages/flyte.io/file) | A generic file class representing a file with a specified format. |
+| [`flyte.io.HashFunction`](packages/flyte.io/hashfunction) | A hash method that wraps a user-provided function to compute hashes. |
+| [`flyte.io.extend.DataFrameDecoder`](packages/flyte.io.extend/dataframedecoder) |  |
+| [`flyte.io.extend.DataFrameEncoder`](packages/flyte.io.extend/dataframeencoder) |  |
+| [`flyte.io.extend.DataFrameTransformerEngine`](packages/flyte.io.extend/dataframetransformerengine) | Think of this transformer as a higher-level meta transformer that is used for all the dataframe types. |
+| [`flyte.models.ActionID`](packages/flyte.models/actionid) | A class representing the ID of an Action, nested within a Run. |
+| [`flyte.models.ActionPhase`](packages/flyte.models/actionphase) | Represents the execution phase of a Flyte action (run). |
+| [`flyte.models.CheckpointPaths`](packages/flyte.models/checkpointpaths) | Paths the platform provides for this task's checkpoint output and optional previous-attempt input. |
+| [`flyte.models.CodeBundle`](packages/flyte.models/codebundle) | A class representing a code bundle for a task. |
+| [`flyte.models.GroupData`](packages/flyte.models/groupdata) |  |
+| [`flyte.models.NativeInterface`](packages/flyte.models/nativeinterface) | A class representing the native interface for a task. |
+| [`flyte.models.PathRewrite`](packages/flyte.models/pathrewrite) | Configuration for rewriting paths during input loading. |
+| [`flyte.models.RawDataPath`](packages/flyte.models/rawdatapath) | A class representing the raw data path for a task. |
+| [`flyte.models.SerializationContext`](packages/flyte.models/serializationcontext) | This object holds serialization time contextual information, that can be used when serializing the task and. |
+| [`flyte.models.TaskContext`](packages/flyte.models/taskcontext) | A context class to hold the current task executions context. |
+| [`flyte.notify.Email`](packages/flyte.notify/email) | Send email notifications. |
+| [`flyte.notify.NamedDelivery`](packages/flyte.notify/nameddelivery) | Use a pre-configured delivery channel by name. |
+| [`flyte.notify.NamedRule`](packages/flyte.notify/namedrule) | Reference a pre-defined notification rule by name. |
+| [`flyte.notify.Notification`](packages/flyte.notify/notification) | Base notification class. |
+| [`flyte.notify.Slack`](packages/flyte.notify/slack) | Send Slack notifications with optional Block Kit formatting. |
+| [`flyte.notify.Teams`](packages/flyte.notify/teams) | Send Microsoft Teams notifications with optional Adaptive Cards. |
+| [`flyte.notify.Webhook`](packages/flyte.notify/webhook) | Send custom HTTP webhook notifications (most flexible option). |
+| [`flyte.prefetch.HuggingFaceModelInfo`](packages/flyte.prefetch/huggingfacemodelinfo) | Information about a HuggingFace model to store. |
+| [`flyte.prefetch.ShardConfig`](packages/flyte.prefetch/shardconfig) | Configuration for model sharding. |
+| [`flyte.prefetch.StoredModelInfo`](packages/flyte.prefetch/storedmodelinfo) | Information about a stored model. |
+| [`flyte.prefetch.VLLMShardArgs`](packages/flyte.prefetch/vllmshardargs) | Arguments for sharding a model using vLLM. |
+| [`flyte.remote.Action`](packages/flyte.remote/action) | A class representing an action. |
+| [`flyte.remote.ActionDetails`](packages/flyte.remote/actiondetails) | A class representing an action. |
+| [`flyte.remote.ActionInputs`](packages/flyte.remote/actioninputs) | A class representing the inputs of an action. |
+| [`flyte.remote.ActionOutputs`](packages/flyte.remote/actionoutputs) | A class representing the outputs of an action. |
+| [`flyte.remote.App`](packages/flyte.remote/app) |  |
+| [`flyte.remote.Condition`](packages/flyte.remote/condition) | A remote Condition registered within an action of a run. |
+| [`flyte.remote.Project`](packages/flyte.remote/project) | A class representing a project in the Union API. |
+| [`flyte.remote.Run`](packages/flyte.remote/run) | A class representing a run of a task. |
+| [`flyte.remote.RunDetails`](packages/flyte.remote/rundetails) | A class representing a run of a task. |
+| [`flyte.remote.Secret`](packages/flyte.remote/secret) |  |
+| [`flyte.remote.Settings`](packages/flyte.remote/settings) | Hierarchical configuration settings with inheritance support. |
+| [`flyte.remote.Task`](packages/flyte.remote/task) |  |
+| [`flyte.remote.TaskDetails`](packages/flyte.remote/taskdetails) |  |
+| [`flyte.remote.TimeFilter`](packages/flyte.remote/timefilter) | Filter for time-based fields (e. |
+| [`flyte.remote.Trigger`](packages/flyte.remote/trigger) | Represents a trigger in the Flyte platform. |
+| [`flyte.remote.User`](packages/flyte.remote/user) | Represents a user in the Flyte platform. |
+| [`flyte.report.Report`](packages/flyte.report/report) |  |
+| [`flyte.sandbox.CodeTaskTemplate`](packages/flyte.sandbox/codetasktemplate) | A sandboxed task created from a code string rather than a decorated function. |
+| [`flyte.sandbox.ImageConfig`](packages/flyte.sandbox/imageconfig) | Configuration for Docker image building at runtime. |
+| [`flyte.sandbox.SandboxedConfig`](packages/flyte.sandbox/sandboxedconfig) | Configuration for a sandboxed task executed via Monty. |
+| [`flyte.sandbox.SandboxedTaskTemplate`](packages/flyte.sandbox/sandboxedtasktemplate) | A task template that executes the function body in a Monty sandbox. |
+| [`flyte.storage.ABFS`](packages/flyte.storage/abfs) | Any Azure Blob Storage specific configuration. |
+| [`flyte.storage.GCS`](packages/flyte.storage/gcs) | Any GCS specific configuration. |
+| [`flyte.storage.S3`](packages/flyte.storage/s3) | S3 specific configuration. |
+| [`flyte.storage.Storage`](packages/flyte.storage/storage) | Data storage configuration that applies across any provider. |
+| [`flyte.syncify.Syncify`](packages/flyte.syncify/syncify) | A decorator to convert asynchronous functions or methods into synchronous ones. |
+| [`flyte.types.FlytePickle`](packages/flyte.types/flytepickle) | This type is only used by flytekit internally. |
+| [`flyte.types.Renderable`](packages/flyte.types/renderable) |  |
+| [`flyte.types.TypeEngine`](packages/flyte.types/typeengine) | Core Extensible TypeEngine of Flytekit. |
+| [`flyte.types.TypeTransformer`](packages/flyte.types/typetransformer) | Base transformer type that should be implemented for every python native type that can be handled by flytekit. |
+| [`flyte.types.TypeTransformerFailedError`](packages/flyte.types/typetransformerfailederror) |  |
+
+### Packages
+
+| Package | Description |
+|-|-|
+| [`flyte`](packages/flyte/_index) | Flyte SDK for authoring compound AI applications, services and workflows. |
+| [`flyte.ai.agents`](packages/flyte.ai.agents/_index) | flyte. |
+| [`flyte.ai.agents.agent`](packages/flyte.ai.agents.agent/_index) | Agent — a flyte-native tool-use agent harness. |
+| [`flyte.ai.agents.memory`](packages/flyte.ai.agents.memory/_index) | Dir-backed memory for :class:`flyte. |
+| [`flyte.ai.agents.protocol`](packages/flyte.ai.agents.protocol/_index) | Agent protocol for the flyte. |
+| [`flyte.ai.chat`](packages/flyte.ai.chat/_index) | flyte. |
+| [`flyte.ai.chat.app`](packages/flyte.ai.chat.app/_index) | AgentChatAppEnvironment — FastAPI-based chat UI for any Agent. |
+| [`flyte.ai.mcp`](packages/flyte.ai.mcp/_index) |  |
+| [`flyte.app`](packages/flyte.app/_index) |  |
+| [`flyte.app.extras`](packages/flyte.app.extras/_index) |  |
+| [`flyte.clustered`](packages/flyte.clustered/_index) |  |
+| [`flyte.config`](packages/flyte.config/_index) |  |
+| [`flyte.connectors`](packages/flyte.connectors/_index) |  |
+| [`flyte.connectors.utils`](packages/flyte.connectors.utils/_index) |  |
+| [`flyte.durable`](packages/flyte.durable/_index) | Flyte durable utilities. |
+| [`flyte.errors`](packages/flyte.errors/_index) | Exceptions raised by Union. |
+| [`flyte.extend`](packages/flyte.extend/_index) |  |
+| [`flyte.extras`](packages/flyte.extras/_index) | Flyte extras package. |
+| [`flyte.extras.shell`](packages/flyte.extras.shell/_index) | Shell task — wrap a CLI tool packaged in a container image. |
+| [`flyte.git`](packages/flyte.git/_index) |  |
+| [`flyte.io`](packages/flyte.io/_index) | ## IO data types. |
+| [`flyte.io.extend`](packages/flyte.io.extend/_index) |  |
+| [`flyte.models`](packages/flyte.models/_index) |  |
+| [`flyte.notify`](packages/flyte.notify/_index) | Task Notifications API for Flyte 2. |
+| [`flyte.prefetch`](packages/flyte.prefetch/_index) | Prefetch utilities for Flyte. |
+| [`flyte.remote`](packages/flyte.remote/_index) | Remote Entities that are accessible from the Union Server once deployed or created. |
+| [`flyte.report`](packages/flyte.report/_index) |  |
+| [`flyte.sandbox`](packages/flyte.sandbox/_index) | Sandbox utilities for running isolated code inside Flyte tasks. |
+| [`flyte.storage`](packages/flyte.storage/_index) |  |
+| [`flyte.syncify`](packages/flyte.syncify/_index) | # Syncify Module. |
+| [`flyte.types`](packages/flyte.types/_index) | # Flyte Type System. |
 

--- a/content/api-reference/flyte-sdk/classes/_index.md
+++ b/content/api-reference/flyte-sdk/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes & Protocols
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/_index.md
+++ b/content/api-reference/flyte-sdk/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---
@@ -9,34 +9,34 @@ layout: py_api
 
 | Package | Description |
 |-|-|
-| [`flyte`](flyte) | Flyte SDK for authoring compound AI applications, services and workflows. |
-| [`flyte.ai.agents`](flyte.ai.agents) | flyte. |
-| [`flyte.ai.agents.agent`](flyte.ai.agents.agent) | Agent — a flyte-native tool-use agent harness. |
-| [`flyte.ai.agents.memory`](flyte.ai.agents.memory) | Dir-backed memory for :class:`flyte. |
-| [`flyte.ai.agents.protocol`](flyte.ai.agents.protocol) | Agent protocol for the flyte. |
-| [`flyte.ai.chat`](flyte.ai.chat) | flyte. |
-| [`flyte.ai.chat.app`](flyte.ai.chat.app) | AgentChatAppEnvironment — FastAPI-based chat UI for any Agent. |
-| [`flyte.ai.mcp`](flyte.ai.mcp) |  |
-| [`flyte.app`](flyte.app) |  |
-| [`flyte.app.extras`](flyte.app.extras) |  |
-| [`flyte.clustered`](flyte.clustered) |  |
-| [`flyte.config`](flyte.config) |  |
-| [`flyte.connectors`](flyte.connectors) |  |
-| [`flyte.connectors.utils`](flyte.connectors.utils) |  |
-| [`flyte.durable`](flyte.durable) | Flyte durable utilities. |
-| [`flyte.errors`](flyte.errors) | Exceptions raised by Union. |
-| [`flyte.extend`](flyte.extend) |  |
-| [`flyte.extras`](flyte.extras) | Flyte extras package. |
-| [`flyte.extras.shell`](flyte.extras.shell) | Shell task — wrap a CLI tool packaged in a container image. |
-| [`flyte.git`](flyte.git) |  |
-| [`flyte.io`](flyte.io) | ## IO data types. |
-| [`flyte.io.extend`](flyte.io.extend) |  |
-| [`flyte.models`](flyte.models) |  |
-| [`flyte.notify`](flyte.notify) | Task Notifications API for Flyte 2. |
-| [`flyte.prefetch`](flyte.prefetch) | Prefetch utilities for Flyte. |
-| [`flyte.remote`](flyte.remote) | Remote Entities that are accessible from the Union Server once deployed or created. |
-| [`flyte.report`](flyte.report) |  |
-| [`flyte.sandbox`](flyte.sandbox) | Sandbox utilities for running isolated code inside Flyte tasks. |
-| [`flyte.storage`](flyte.storage) |  |
-| [`flyte.syncify`](flyte.syncify) | # Syncify Module. |
-| [`flyte.types`](flyte.types) | # Flyte Type System. |
+| [`flyte`](flyte/_index) | Flyte SDK for authoring compound AI applications, services and workflows. |
+| [`flyte.ai.agents`](flyte.ai.agents/_index) | flyte. |
+| [`flyte.ai.agents.agent`](flyte.ai.agents.agent/_index) | Agent — a flyte-native tool-use agent harness. |
+| [`flyte.ai.agents.memory`](flyte.ai.agents.memory/_index) | Dir-backed memory for :class:`flyte. |
+| [`flyte.ai.agents.protocol`](flyte.ai.agents.protocol/_index) | Agent protocol for the flyte. |
+| [`flyte.ai.chat`](flyte.ai.chat/_index) | flyte. |
+| [`flyte.ai.chat.app`](flyte.ai.chat.app/_index) | AgentChatAppEnvironment — FastAPI-based chat UI for any Agent. |
+| [`flyte.ai.mcp`](flyte.ai.mcp/_index) |  |
+| [`flyte.app`](flyte.app/_index) |  |
+| [`flyte.app.extras`](flyte.app.extras/_index) |  |
+| [`flyte.clustered`](flyte.clustered/_index) |  |
+| [`flyte.config`](flyte.config/_index) |  |
+| [`flyte.connectors`](flyte.connectors/_index) |  |
+| [`flyte.connectors.utils`](flyte.connectors.utils/_index) |  |
+| [`flyte.durable`](flyte.durable/_index) | Flyte durable utilities. |
+| [`flyte.errors`](flyte.errors/_index) | Exceptions raised by Union. |
+| [`flyte.extend`](flyte.extend/_index) |  |
+| [`flyte.extras`](flyte.extras/_index) | Flyte extras package. |
+| [`flyte.extras.shell`](flyte.extras.shell/_index) | Shell task — wrap a CLI tool packaged in a container image. |
+| [`flyte.git`](flyte.git/_index) |  |
+| [`flyte.io`](flyte.io/_index) | ## IO data types. |
+| [`flyte.io.extend`](flyte.io.extend/_index) |  |
+| [`flyte.models`](flyte.models/_index) |  |
+| [`flyte.notify`](flyte.notify/_index) | Task Notifications API for Flyte 2. |
+| [`flyte.prefetch`](flyte.prefetch/_index) | Prefetch utilities for Flyte. |
+| [`flyte.remote`](flyte.remote/_index) | Remote Entities that are accessible from the Union Server once deployed or created. |
+| [`flyte.report`](flyte.report/_index) |  |
+| [`flyte.sandbox`](flyte.sandbox/_index) | Sandbox utilities for running isolated code inside Flyte tasks. |
+| [`flyte.storage`](flyte.storage/_index) |  |
+| [`flyte.syncify`](flyte.syncify/_index) | # Syncify Module. |
+| [`flyte.types`](flyte.types/_index) | # Flyte Type System. |

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents.agent/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents.agent/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.ai.agents.agent
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents.agent/agent.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents.agent/agent.md
@@ -1,6 +1,6 @@
 ---
 title: Agent
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents.agent/agentevent.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents.agent/agentevent.md
@@ -1,6 +1,6 @@
 ---
 title: AgentEvent
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents.memory/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents.memory/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.ai.agents.memory
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents.memory/accessdenied.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents.memory/accessdenied.md
@@ -1,6 +1,6 @@
 ---
 title: AccessDenied
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents.memory/concurrencyerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents.memory/concurrencyerror.md
@@ -1,6 +1,6 @@
 ---
 title: ConcurrencyError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents.memory/memorymeta.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents.memory/memorymeta.md
@@ -1,6 +1,6 @@
 ---
 title: MemoryMeta
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents.memory/memorystore.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents.memory/memorystore.md
@@ -1,6 +1,6 @@
 ---
 title: MemoryStore
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents.memory/memorystoreerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents.memory/memorystoreerror.md
@@ -1,6 +1,6 @@
 ---
 title: MemoryStoreError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents.protocol/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents.protocol/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.ai.agents.protocol
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents.protocol/agentprotocol.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents.protocol/agentprotocol.md
@@ -1,6 +1,6 @@
 ---
 title: AgentProtocol
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents.protocol/agentresult.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents.protocol/agentresult.md
@@ -1,6 +1,6 @@
 ---
 title: AgentResult
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.ai.agents
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents/accessdenied.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents/accessdenied.md
@@ -1,6 +1,6 @@
 ---
 title: AccessDenied
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents/agent.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents/agent.md
@@ -1,6 +1,6 @@
 ---
 title: Agent
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents/agentevent.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents/agentevent.md
@@ -1,6 +1,6 @@
 ---
 title: AgentEvent
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents/agentprotocol.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents/agentprotocol.md
@@ -1,6 +1,6 @@
 ---
 title: AgentProtocol
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents/agentresult.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents/agentresult.md
@@ -1,6 +1,6 @@
 ---
 title: AgentResult
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents/agenttool.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents/agenttool.md
@@ -1,6 +1,6 @@
 ---
 title: AgentTool
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents/concurrencyerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents/concurrencyerror.md
@@ -1,6 +1,6 @@
 ---
 title: ConcurrencyError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents/llmmessage.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents/llmmessage.md
@@ -1,6 +1,6 @@
 ---
 title: LLMMessage
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents/mcpserverspec.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents/mcpserverspec.md
@@ -1,6 +1,6 @@
 ---
 title: MCPServerSpec
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents/memorymeta.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents/memorymeta.md
@@ -1,6 +1,6 @@
 ---
 title: MemoryMeta
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents/memorystore.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents/memorystore.md
@@ -1,6 +1,6 @@
 ---
 title: MemoryStore
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents/memorystoreerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents/memorystoreerror.md
@@ -1,6 +1,6 @@
 ---
 title: MemoryStoreError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents/toolfn.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents/toolfn.md
@@ -1,6 +1,6 @@
 ---
 title: ToolFn
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.chat.app/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.chat.app/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.ai.chat.app
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.chat.app/agentchatappenvironment.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.chat.app/agentchatappenvironment.md
@@ -1,6 +1,6 @@
 ---
 title: AgentChatAppEnvironment
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.chat.app/customtheme.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.chat.app/customtheme.md
@@ -1,6 +1,6 @@
 ---
 title: CustomTheme
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.chat/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.chat/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.ai.chat
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.chat/agentchatappenvironment.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.chat/agentchatappenvironment.md
@@ -1,6 +1,6 @@
 ---
 title: AgentChatAppEnvironment
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.chat/customtheme.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.chat/customtheme.md
@@ -1,6 +1,6 @@
 ---
 title: CustomTheme
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.mcp/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.mcp/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.ai.mcp
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.mcp/flytemcpappenvironment.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.mcp/flytemcpappenvironment.md
@@ -1,6 +1,6 @@
 ---
 title: FlyteMCPAppEnvironment
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.mcp/mcpappenvironment.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.mcp/mcpappenvironment.md
@@ -1,6 +1,6 @@
 ---
 title: MCPAppEnvironment
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app.extras/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app.extras/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.app.extras
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app.extras/fastapiappenvironment.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app.extras/fastapiappenvironment.md
@@ -1,6 +1,6 @@
 ---
 title: FastAPIAppEnvironment
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app.extras/fastapipassthroughauthmiddleware.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app.extras/fastapipassthroughauthmiddleware.md
@@ -1,6 +1,6 @@
 ---
 title: FastAPIPassthroughAuthMiddleware
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app.extras/flytewebhookappenvironment.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app.extras/flytewebhookappenvironment.md
@@ -1,6 +1,6 @@
 ---
 title: FlyteWebhookAppEnvironment
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.app
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app/appendpoint.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app/appendpoint.md
@@ -1,6 +1,6 @@
 ---
 title: AppEndpoint
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app/appenvironment.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app/appenvironment.md
@@ -1,6 +1,6 @@
 ---
 title: AppEnvironment
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app/connectorenvironment.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app/connectorenvironment.md
@@ -1,6 +1,6 @@
 ---
 title: ConnectorEnvironment
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app/domain.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app/domain.md
@@ -1,6 +1,6 @@
 ---
 title: Domain
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app/link.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app/link.md
@@ -1,6 +1,6 @@
 ---
 title: Link
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app/parameter.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app/parameter.md
@@ -1,6 +1,6 @@
 ---
 title: Parameter
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app/port.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app/port.md
@@ -1,6 +1,6 @@
 ---
 title: Port
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app/runoutput.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app/runoutput.md
@@ -1,6 +1,6 @@
 ---
 title: RunOutput
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app/scaling.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app/scaling.md
@@ -1,6 +1,6 @@
 ---
 title: Scaling
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app/timeouts.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app/timeouts.md
@@ -1,6 +1,6 @@
 ---
 title: Timeouts
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.clustered/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.clustered/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.clustered
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.clustered/clusteredtaskenvironment.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.clustered/clusteredtaskenvironment.md
@@ -1,6 +1,6 @@
 ---
 title: ClusteredTaskEnvironment
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.clustered/clusteredtasktemplate.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.clustered/clusteredtasktemplate.md
@@ -1,6 +1,6 @@
 ---
 title: ClusteredTaskTemplate
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.clustered/clusterfailurepolicy.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.clustered/clusterfailurepolicy.md
@@ -1,6 +1,6 @@
 ---
 title: ClusterFailurePolicy
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.clustered/torchrun.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.clustered/torchrun.md
@@ -1,6 +1,6 @@
 ---
 title: TorchRun
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.config/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.config/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.config
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.config/config.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.config/config.md
@@ -1,6 +1,6 @@
 ---
 title: Config
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.connectors.utils/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.connectors.utils/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.connectors.utils
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.connectors/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.connectors/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.connectors
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.connectors/asyncconnector.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.connectors/asyncconnector.md
@@ -1,6 +1,6 @@
 ---
 title: AsyncConnector
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.connectors/asyncconnectorexecutormixin.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.connectors/asyncconnectorexecutormixin.md
@@ -1,6 +1,6 @@
 ---
 title: AsyncConnectorExecutorMixin
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.connectors/connectorregistry.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.connectors/connectorregistry.md
@@ -1,6 +1,6 @@
 ---
 title: ConnectorRegistry
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.connectors/connectorservice.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.connectors/connectorservice.md
@@ -1,6 +1,6 @@
 ---
 title: ConnectorService
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.connectors/resource.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.connectors/resource.md
@@ -1,6 +1,6 @@
 ---
 title: Resource
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.connectors/resourcemeta.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.connectors/resourcemeta.md
@@ -1,6 +1,6 @@
 ---
 title: ResourceMeta
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.durable/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.durable/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.durable
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.errors
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/actionabortederror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/actionabortederror.md
@@ -1,6 +1,6 @@
 ---
 title: ActionAbortedError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/actionnotfounderror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/actionnotfounderror.md
@@ -1,6 +1,6 @@
 ---
 title: ActionNotFoundError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/baseruntimeerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/baseruntimeerror.md
@@ -1,6 +1,6 @@
 ---
 title: BaseRuntimeError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/codebundleerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/codebundleerror.md
@@ -1,6 +1,6 @@
 ---
 title: CodeBundleError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/conditionalreadyexistserror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/conditionalreadyexistserror.md
@@ -1,6 +1,6 @@
 ---
 title: ConditionAlreadyExistsError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/conditionfailederror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/conditionfailederror.md
@@ -1,6 +1,6 @@
 ---
 title: ConditionFailedError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/conditionnotfounderror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/conditionnotfounderror.md
@@ -1,6 +1,6 @@
 ---
 title: ConditionNotFoundError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/conditiontimedouterror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/conditiontimedouterror.md
@@ -1,6 +1,6 @@
 ---
 title: ConditionTimedoutError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/customerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/customerror.md
@@ -1,6 +1,6 @@
 ---
 title: CustomError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/deploymenterror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/deploymenterror.md
@@ -1,6 +1,6 @@
 ---
 title: DeploymentError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/imagebuilderror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/imagebuilderror.md
@@ -1,6 +1,6 @@
 ---
 title: ImageBuildError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/imagepullbackofferror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/imagepullbackofferror.md
@@ -1,6 +1,6 @@
 ---
 title: ImagePullBackOffError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/initializationerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/initializationerror.md
@@ -1,6 +1,6 @@
 ---
 title: InitializationError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/inlineiomaxbytesbreached.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/inlineiomaxbytesbreached.md
@@ -1,6 +1,6 @@
 ---
 title: InlineIOMaxBytesBreached
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/invalidimagenameerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/invalidimagenameerror.md
@@ -1,6 +1,6 @@
 ---
 title: InvalidImageNameError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/invalidpackageerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/invalidpackageerror.md
@@ -1,6 +1,6 @@
 ---
 title: InvalidPackageError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/logsnotyetavailableerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/logsnotyetavailableerror.md
@@ -1,6 +1,6 @@
 ---
 title: LogsNotYetAvailableError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/moduleloaderror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/moduleloaderror.md
@@ -1,6 +1,6 @@
 ---
 title: ModuleLoadError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/nonrecoverableerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/nonrecoverableerror.md
@@ -1,6 +1,6 @@
 ---
 title: NonRecoverableError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/notintaskcontexterror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/notintaskcontexterror.md
@@ -1,6 +1,6 @@
 ---
 title: NotInTaskContextError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/onlyasynciosupportederror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/onlyasynciosupportederror.md
@@ -1,6 +1,6 @@
 ---
 title: OnlyAsyncIOSupportedError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/oomerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/oomerror.md
@@ -1,6 +1,6 @@
 ---
 title: OOMError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/parametermaterializationerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/parametermaterializationerror.md
@@ -1,6 +1,6 @@
 ---
 title: ParameterMaterializationError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/primarycontainernotfounderror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/primarycontainernotfounderror.md
@@ -1,6 +1,6 @@
 ---
 title: PrimaryContainerNotFoundError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/remotetasknotfounderror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/remotetasknotfounderror.md
@@ -1,6 +1,6 @@
 ---
 title: RemoteTaskNotFoundError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/remotetaskusageerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/remotetaskusageerror.md
@@ -1,6 +1,6 @@
 ---
 title: RemoteTaskUsageError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/restrictedtypeerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/restrictedtypeerror.md
@@ -1,6 +1,6 @@
 ---
 title: RestrictedTypeError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/retriesexhaustederror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/retriesexhaustederror.md
@@ -1,6 +1,6 @@
 ---
 title: RetriesExhaustedError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/runtimedatavalidationerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/runtimedatavalidationerror.md
@@ -1,6 +1,6 @@
 ---
 title: RuntimeDataValidationError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/runtimesystemerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/runtimesystemerror.md
@@ -1,6 +1,6 @@
 ---
 title: RuntimeSystemError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/runtimeunknownerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/runtimeunknownerror.md
@@ -1,6 +1,6 @@
 ---
 title: RuntimeUnknownError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/runtimeusererror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/runtimeusererror.md
@@ -1,6 +1,6 @@
 ---
 title: RuntimeUserError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/slowdownerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/slowdownerror.md
@@ -1,6 +1,6 @@
 ---
 title: SlowDownError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/taskinterruptederror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/taskinterruptederror.md
@@ -1,6 +1,6 @@
 ---
 title: TaskInterruptedError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/tasktimeouterror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/tasktimeouterror.md
@@ -1,6 +1,6 @@
 ---
 title: TaskTimeoutError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/tracedoesnotallownestedtaskserror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/tracedoesnotallownestedtaskserror.md
@@ -1,6 +1,6 @@
 ---
 title: TraceDoesNotAllowNestedTasksError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/unionrpcerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/unionrpcerror.md
@@ -1,6 +1,6 @@
 ---
 title: UnionRpcError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extend/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extend/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.extend
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extend/asyncfunctiontasktemplate.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extend/asyncfunctiontasktemplate.md
@@ -1,6 +1,6 @@
 ---
 title: AsyncFunctionTaskTemplate
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extend/imagebuildengine.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extend/imagebuildengine.md
@@ -1,6 +1,6 @@
 ---
 title: ImageBuildEngine
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extend/imagebuilder.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extend/imagebuilder.md
@@ -1,6 +1,6 @@
 ---
 title: ImageBuilder
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extend/imagechecker.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extend/imagechecker.md
@@ -1,6 +1,6 @@
 ---
 title: ImageChecker
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extend/tasktemplate.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extend/tasktemplate.md
@@ -1,6 +1,6 @@
 ---
 title: TaskTemplate
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras.shell/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras.shell/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.extras.shell
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras.shell/flagspec.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras.shell/flagspec.md
@@ -1,6 +1,6 @@
 ---
 title: FlagSpec
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras.shell/glob.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras.shell/glob.md
@@ -1,6 +1,6 @@
 ---
 title: Glob
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras.shell/stderr.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras.shell/stderr.md
@@ -1,6 +1,6 @@
 ---
 title: Stderr
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras.shell/stdout.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras.shell/stdout.md
@@ -1,6 +1,6 @@
 ---
 title: Stdout
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.extras
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras/batchstats.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras/batchstats.md
@@ -1,6 +1,6 @@
 ---
 title: BatchStats
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras/containertask.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras/containertask.md
@@ -1,6 +1,6 @@
 ---
 title: ContainerTask
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---
@@ -29,6 +29,7 @@ class ContainerTask(
     output_data_dir: str | pathlib.Path,
     metadata_format: typing.Literal['JSON', 'YAML', 'PROTO'],
     local_logs: bool,
+    file_input_layout: typing.Literal['DIRECT', 'NAMED_DIR'],
     kwargs,
 )
 ```
@@ -44,6 +45,7 @@ class ContainerTask(
 | `output_data_dir` | `str \| pathlib.Path` | The directory where the output data is stored. This is a string or a Path object. |
 | `metadata_format` | `typing.Literal['JSON', 'YAML', 'PROTO']` | The format of the output file. This can be "JSON", "YAML", or "PROTO". |
 | `local_logs` | `bool` | If True, logs will be printed to the console in the local execution. |
+| `file_input_layout` | `typing.Literal['DIRECT', 'NAMED_DIR']` | How CoPilot stages File / list[File] inputs on disk. "DIRECT" (default) uses the bare path/index; "NAMED_DIR" preserves each input's original basename (and extension), so extension-sniffing tools work. |
 | `kwargs` | `**kwargs` | |
 
 ## Properties

--- a/content/api-reference/flyte-sdk/packages/flyte.extras/costestimator.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras/costestimator.md
@@ -1,6 +1,6 @@
 ---
 title: CostEstimator
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras/dynamicbatcher.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras/dynamicbatcher.md
@@ -1,6 +1,6 @@
 ---
 title: DynamicBatcher
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras/prompt.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras/prompt.md
@@ -1,6 +1,6 @@
 ---
 title: Prompt
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras/sleep.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras/sleep.md
@@ -1,6 +1,6 @@
 ---
 title: Sleep
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras/sleeptask.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras/sleeptask.md
@@ -1,6 +1,6 @@
 ---
 title: SleepTask
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras/tokenbatcher.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras/tokenbatcher.md
@@ -1,6 +1,6 @@
 ---
 title: TokenBatcher
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras/tokenestimator.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras/tokenestimator.md
@@ -1,6 +1,6 @@
 ---
 title: TokenEstimator
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.git/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.git/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.git
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.git/gitstatus.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.git/gitstatus.md
@@ -1,6 +1,6 @@
 ---
 title: GitStatus
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.io.extend/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.io.extend/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.io.extend
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.io.extend/dataframedecoder.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.io.extend/dataframedecoder.md
@@ -1,6 +1,6 @@
 ---
 title: DataFrameDecoder
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.io.extend/dataframeencoder.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.io.extend/dataframeencoder.md
@@ -1,6 +1,6 @@
 ---
 title: DataFrameEncoder
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.io.extend/dataframetransformerengine.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.io.extend/dataframetransformerengine.md
@@ -1,6 +1,6 @@
 ---
 title: DataFrameTransformerEngine
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.io/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.io/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.io
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.io/dataframe.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.io/dataframe.md
@@ -1,6 +1,6 @@
 ---
 title: DataFrame
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.io/dir.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.io/dir.md
@@ -1,6 +1,6 @@
 ---
 title: Dir
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.io/emptydir.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.io/emptydir.md
@@ -1,6 +1,6 @@
 ---
 title: EmptyDir
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.io/file.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.io/file.md
@@ -1,6 +1,6 @@
 ---
 title: File
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.io/hashfunction.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.io/hashfunction.md
@@ -1,6 +1,6 @@
 ---
 title: HashFunction
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.models/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.models/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.models
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.models/actionid.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.models/actionid.md
@@ -1,6 +1,6 @@
 ---
 title: ActionID
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.models/actionphase.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.models/actionphase.md
@@ -1,6 +1,6 @@
 ---
 title: ActionPhase
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.models/checkpointpaths.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.models/checkpointpaths.md
@@ -1,6 +1,6 @@
 ---
 title: CheckpointPaths
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.models/codebundle.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.models/codebundle.md
@@ -1,6 +1,6 @@
 ---
 title: CodeBundle
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.models/groupdata.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.models/groupdata.md
@@ -1,6 +1,6 @@
 ---
 title: GroupData
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.models/nativeinterface.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.models/nativeinterface.md
@@ -1,6 +1,6 @@
 ---
 title: NativeInterface
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.models/pathrewrite.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.models/pathrewrite.md
@@ -1,6 +1,6 @@
 ---
 title: PathRewrite
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.models/rawdatapath.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.models/rawdatapath.md
@@ -1,6 +1,6 @@
 ---
 title: RawDataPath
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.models/serializationcontext.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.models/serializationcontext.md
@@ -1,6 +1,6 @@
 ---
 title: SerializationContext
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.models/taskcontext.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.models/taskcontext.md
@@ -1,6 +1,6 @@
 ---
 title: TaskContext
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.notify/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.notify/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.notify
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.notify/email.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.notify/email.md
@@ -1,6 +1,6 @@
 ---
 title: Email
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.notify/nameddelivery.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.notify/nameddelivery.md
@@ -1,6 +1,6 @@
 ---
 title: NamedDelivery
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.notify/namedrule.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.notify/namedrule.md
@@ -1,6 +1,6 @@
 ---
 title: NamedRule
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.notify/notification.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.notify/notification.md
@@ -1,6 +1,6 @@
 ---
 title: Notification
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.notify/slack.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.notify/slack.md
@@ -1,6 +1,6 @@
 ---
 title: Slack
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.notify/teams.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.notify/teams.md
@@ -1,6 +1,6 @@
 ---
 title: Teams
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.notify/webhook.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.notify/webhook.md
@@ -1,6 +1,6 @@
 ---
 title: Webhook
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.prefetch/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.prefetch/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.prefetch
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.prefetch/huggingfacemodelinfo.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.prefetch/huggingfacemodelinfo.md
@@ -1,6 +1,6 @@
 ---
 title: HuggingFaceModelInfo
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.prefetch/shardconfig.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.prefetch/shardconfig.md
@@ -1,6 +1,6 @@
 ---
 title: ShardConfig
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.prefetch/storedmodelinfo.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.prefetch/storedmodelinfo.md
@@ -1,6 +1,6 @@
 ---
 title: StoredModelInfo
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.prefetch/vllmshardargs.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.prefetch/vllmshardargs.md
@@ -1,6 +1,6 @@
 ---
 title: VLLMShardArgs
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.remote
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/action.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/action.md
@@ -1,6 +1,6 @@
 ---
 title: Action
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/actiondetails.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/actiondetails.md
@@ -1,6 +1,6 @@
 ---
 title: ActionDetails
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/actioninputs.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/actioninputs.md
@@ -1,6 +1,6 @@
 ---
 title: ActionInputs
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/actionoutputs.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/actionoutputs.md
@@ -1,6 +1,6 @@
 ---
 title: ActionOutputs
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/app.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/app.md
@@ -1,6 +1,6 @@
 ---
 title: App
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/condition.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/condition.md
@@ -1,6 +1,6 @@
 ---
 title: Condition
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/project.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/project.md
@@ -1,6 +1,6 @@
 ---
 title: Project
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/run.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/run.md
@@ -1,6 +1,6 @@
 ---
 title: Run
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---
@@ -196,6 +196,8 @@ def listall(
     domain: str | None,
     created_at: TimeFilter | None,
     updated_at: TimeFilter | None,
+    with_labels: dict[str, str] | None,
+    with_label_keys: list[str] | None,
 ) -> AsyncIterator[Run]
 ```
 Get all runs for the current project and domain.
@@ -215,6 +217,8 @@ Get all runs for the current project and domain.
 | `domain` | `str \| None` | The domain to list runs for. Defaults to the globally configured domain. |
 | `created_at` | `TimeFilter \| None` | Filter runs by creation time range. |
 | `updated_at` | `TimeFilter \| None` | Filter runs by last-update time range. |
+| `with_labels` | `dict[str, str] \| None` | Filter runs whose labels include all of these key=value pairs (AND semantics). |
+| `with_label_keys` | `list[str] \| None` | Filter runs that have all of these label keys present (existence check). |
 
 **Returns:** An iterator of runs.
 

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/rundetails.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/rundetails.md
@@ -1,6 +1,6 @@
 ---
 title: RunDetails
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/secret.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/secret.md
@@ -1,6 +1,6 @@
 ---
 title: Secret
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/settings.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/settings.md
@@ -1,6 +1,6 @@
 ---
 title: Settings
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/task.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/task.md
@@ -1,6 +1,6 @@
 ---
 title: Task
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/taskdetails.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/taskdetails.md
@@ -1,6 +1,6 @@
 ---
 title: TaskDetails
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---
@@ -16,6 +16,7 @@ class TaskDetails(
     pb2: task_definition_pb2.TaskDetails,
     max_inline_io_bytes: int,
     overriden_queue: Optional[str],
+    overridden: bool,
 )
 ```
 | Parameter | Type | Description |
@@ -23,6 +24,7 @@ class TaskDetails(
 | `pb2` | `task_definition_pb2.TaskDetails` | |
 | `max_inline_io_bytes` | `int` | |
 | `overriden_queue` | `Optional[str]` | |
+| `overridden` | `bool` | |
 
 ## Properties
 

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/timefilter.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/timefilter.md
@@ -1,6 +1,6 @@
 ---
 title: TimeFilter
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/trigger.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/trigger.md
@@ -1,6 +1,6 @@
 ---
 title: Trigger
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/user.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/user.md
@@ -1,6 +1,6 @@
 ---
 title: User
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.report/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.report/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.report
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.report/report.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.report/report.md
@@ -1,6 +1,6 @@
 ---
 title: Report
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.sandbox/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.sandbox/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.sandbox
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.sandbox/codetasktemplate.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.sandbox/codetasktemplate.md
@@ -1,6 +1,6 @@
 ---
 title: CodeTaskTemplate
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.sandbox/imageconfig.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.sandbox/imageconfig.md
@@ -1,6 +1,6 @@
 ---
 title: ImageConfig
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.sandbox/sandboxedconfig.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.sandbox/sandboxedconfig.md
@@ -1,6 +1,6 @@
 ---
 title: SandboxedConfig
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.sandbox/sandboxedtasktemplate.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.sandbox/sandboxedtasktemplate.md
@@ -1,6 +1,6 @@
 ---
 title: SandboxedTaskTemplate
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.storage/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.storage/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.storage
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.storage/abfs.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.storage/abfs.md
@@ -1,6 +1,6 @@
 ---
 title: ABFS
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.storage/gcs.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.storage/gcs.md
@@ -1,6 +1,6 @@
 ---
 title: GCS
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.storage/s3.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.storage/s3.md
@@ -1,6 +1,6 @@
 ---
 title: S3
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.storage/storage.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.storage/storage.md
@@ -1,6 +1,6 @@
 ---
 title: Storage
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.syncify/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.syncify/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.syncify
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.syncify/syncify.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.syncify/syncify.md
@@ -1,6 +1,6 @@
 ---
 title: Syncify
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.types/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.types/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.types
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.types/flytepickle.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.types/flytepickle.md
@@ -1,6 +1,6 @@
 ---
 title: FlytePickle
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.types/renderable.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.types/renderable.md
@@ -1,6 +1,6 @@
 ---
 title: Renderable
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.types/typeengine.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.types/typeengine.md
@@ -1,6 +1,6 @@
 ---
 title: TypeEngine
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.types/typetransformer.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.types/typetransformer.md
@@ -1,6 +1,6 @@
 ---
 title: TypeTransformer
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.types/typetransformerfailederror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.types/typetransformerfailederror.md
@@ -1,6 +1,6 @@
 ---
 title: TypeTransformerFailedError
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---
@@ -953,7 +953,7 @@ if __name__ == "__main__":
 | `project` | `str \| None` | Optional The project to use for the run |
 | `domain` | `str \| None` | Optional The domain to use for the run |
 | `env_vars` | `Dict[str, str] \| None` | Optional Environment variables to set for the run |
-| `labels` | `Dict[str, str] \| None` | Optional Labels to set for the run |
+| `labels` | `Dict[str, str] \| None` | Optional user-defined labels to attach to the run as KEY=VALUE pairs, used for filtering and organizing runs (e.g. ``flyte get run --with-label team=ml``) |
 | `annotations` | `Dict[str, str] \| None` | Optional Annotations to set for the run |
 | `interruptible` | `bool \| None` | Optional If true, the run can be scheduled on interruptible instances and false implies that all tasks in the run should only be scheduled on non-interruptible instances. If not specified the original setting on all tasks is retained. |
 | `log_level` | `int \| None` | Optional Log level to set for the run. If not provided, it will be set to the default log level set using `flyte.init()` |

--- a/content/api-reference/flyte-sdk/packages/flyte/apphandle.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/apphandle.md
@@ -1,6 +1,6 @@
 ---
 title: AppHandle
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/backoff.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/backoff.md
@@ -1,6 +1,6 @@
 ---
 title: Backoff
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/basecheckpoint.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/basecheckpoint.md
@@ -1,6 +1,6 @@
 ---
 title: BaseCheckpoint
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/cache.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/cache.md
@@ -1,6 +1,6 @@
 ---
 title: Cache
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/cachepolicy.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/cachepolicy.md
@@ -1,6 +1,6 @@
 ---
 title: CachePolicy
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/checkpoint.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/checkpoint.md
@@ -1,6 +1,6 @@
 ---
 title: Checkpoint
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/conditionwebhook.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/conditionwebhook.md
@@ -1,6 +1,6 @@
 ---
 title: ConditionWebhook
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/cron.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/cron.md
@@ -1,6 +1,6 @@
 ---
 title: Cron
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/device.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/device.md
@@ -1,6 +1,6 @@
 ---
 title: Device
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/environment.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/environment.md
@@ -1,6 +1,6 @@
 ---
 title: Environment
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/fixedrate.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/fixedrate.md
@@ -1,6 +1,6 @@
 ---
 title: FixedRate
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/image.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/image.md
@@ -1,6 +1,6 @@
 ---
 title: Image
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---
@@ -123,6 +123,7 @@ def clone(
     python_version: Optional[Tuple[int, int]],
     addl_layer: Optional[Layer],
     extendable: Optional[bool],
+    platform: Union[Architecture, Tuple[Architecture, ...], None],
 ) -> Image
 ```
 Clone an existing image, optionally with a new name or registry.
@@ -142,6 +143,7 @@ registry, or other base properties.
 | `python_version` | `Optional[Tuple[int, int]]` | Python version for the image, if not specified, will use the current Python version |
 | `addl_layer` | `Optional[Layer]` | Additional layer to add to the image. This will be added to the end of the layers. |
 | `extendable` | `Optional[bool]` | Whether the image is extendable by other images. If True, the image can be used as a base image for other images, and additional layers can be added on top of it. If False, the image cannot be used as a base image for other images, and additional layers cannot be added on top of it. If None (default), defaults to False for safety. |
+| `platform` | `Union[Architecture, Tuple[Architecture, ...], None]` | Architecture(s) to build for. If not specified, the cloned image keeps the original's platform. Pass a tuple for multi-arch builds, e.g. ``("linux/amd64", "linux/arm64")``. |
 
 ### from_base()
 

--- a/content/api-reference/flyte-sdk/packages/flyte/imagebuild.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/imagebuild.md
@@ -1,6 +1,6 @@
 ---
 title: ImageBuild
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/link.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/link.md
@@ -1,6 +1,6 @@
 ---
 title: Link
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/podtemplate.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/podtemplate.md
@@ -1,6 +1,6 @@
 ---
 title: PodTemplate
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/resources.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/resources.md
@@ -1,6 +1,6 @@
 ---
 title: Resources
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/retrystrategy.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/retrystrategy.md
@@ -1,6 +1,6 @@
 ---
 title: RetryStrategy
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/reusepolicy.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/reusepolicy.md
@@ -1,6 +1,6 @@
 ---
 title: ReusePolicy
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/secret.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/secret.md
@@ -1,6 +1,6 @@
 ---
 title: Secret
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/taskenvironment.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/taskenvironment.md
@@ -1,6 +1,6 @@
 ---
 title: TaskEnvironment
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/timeout.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/timeout.md
@@ -1,6 +1,6 @@
 ---
 title: Timeout
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/trigger.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/trigger.md
@@ -1,6 +1,6 @@
 ---
 title: Trigger
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/anthropic/_index.md
+++ b/content/api-reference/integrations/anthropic/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Anthropic
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/anthropic/classes/_index.md
+++ b/content/api-reference/integrations/anthropic/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/anthropic/packages/_index.md
+++ b/content/api-reference/integrations/anthropic/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/anthropic/packages/flyteplugins.anthropic/_index.md
+++ b/content/api-reference/integrations/anthropic/packages/flyteplugins.anthropic/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.anthropic
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/anthropic/packages/flyteplugins.anthropic/agent.md
+++ b/content/api-reference/integrations/anthropic/packages/flyteplugins.anthropic/agent.md
@@ -1,6 +1,6 @@
 ---
 title: Agent
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/bigquery/_index.md
+++ b/content/api-reference/integrations/bigquery/_index.md
@@ -1,6 +1,6 @@
 ---
 title: BigQuery
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/bigquery/classes/_index.md
+++ b/content/api-reference/integrations/bigquery/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/bigquery/packages/_index.md
+++ b/content/api-reference/integrations/bigquery/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/bigquery/packages/flyteplugins.bigquery/_index.md
+++ b/content/api-reference/integrations/bigquery/packages/flyteplugins.bigquery/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.bigquery
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/bigquery/packages/flyteplugins.bigquery/bigqueryconfig.md
+++ b/content/api-reference/integrations/bigquery/packages/flyteplugins.bigquery/bigqueryconfig.md
@@ -1,6 +1,6 @@
 ---
 title: BigQueryConfig
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/bigquery/packages/flyteplugins.bigquery/bigqueryconnector.md
+++ b/content/api-reference/integrations/bigquery/packages/flyteplugins.bigquery/bigqueryconnector.md
@@ -1,6 +1,6 @@
 ---
 title: BigQueryConnector
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/bigquery/packages/flyteplugins.bigquery/bigquerytask.md
+++ b/content/api-reference/integrations/bigquery/packages/flyteplugins.bigquery/bigquerytask.md
@@ -1,6 +1,6 @@
 ---
 title: BigQueryTask
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/codegen/_index.md
+++ b/content/api-reference/integrations/codegen/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Code generation
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/codegen/classes/_index.md
+++ b/content/api-reference/integrations/codegen/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/codegen/packages/_index.md
+++ b/content/api-reference/integrations/codegen/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/_index.md
+++ b/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.codegen
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/autocoderagent.md
+++ b/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/autocoderagent.md
@@ -1,6 +1,6 @@
 ---
 title: AutoCoderAgent
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/codegenevalresult.md
+++ b/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/codegenevalresult.md
@@ -1,6 +1,6 @@
 ---
 title: CodeGenEvalResult
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/codeplan.md
+++ b/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/codeplan.md
@@ -1,6 +1,6 @@
 ---
 title: CodePlan
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/codesolution.md
+++ b/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/codesolution.md
@@ -1,6 +1,6 @@
 ---
 title: CodeSolution
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/errordiagnosis.md
+++ b/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/errordiagnosis.md
@@ -1,6 +1,6 @@
 ---
 title: ErrorDiagnosis
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/imageconfig.md
+++ b/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/imageconfig.md
@@ -1,6 +1,6 @@
 ---
 title: ImageConfig
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/dask/_index.md
+++ b/content/api-reference/integrations/dask/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Dask
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/dask/classes/_index.md
+++ b/content/api-reference/integrations/dask/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/dask/packages/_index.md
+++ b/content/api-reference/integrations/dask/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/dask/packages/flyteplugins.dask/_index.md
+++ b/content/api-reference/integrations/dask/packages/flyteplugins.dask/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.dask
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/dask/packages/flyteplugins.dask/dask.md
+++ b/content/api-reference/integrations/dask/packages/flyteplugins.dask/dask.md
@@ -1,6 +1,6 @@
 ---
 title: Dask
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/dask/packages/flyteplugins.dask/scheduler.md
+++ b/content/api-reference/integrations/dask/packages/flyteplugins.dask/scheduler.md
@@ -1,6 +1,6 @@
 ---
 title: Scheduler
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/dask/packages/flyteplugins.dask/workergroup.md
+++ b/content/api-reference/integrations/dask/packages/flyteplugins.dask/workergroup.md
@@ -1,6 +1,6 @@
 ---
 title: WorkerGroup
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/databricks/_index.md
+++ b/content/api-reference/integrations/databricks/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Databricks
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/databricks/classes/_index.md
+++ b/content/api-reference/integrations/databricks/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/databricks/packages/_index.md
+++ b/content/api-reference/integrations/databricks/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/databricks/packages/flyteplugins.databricks/_index.md
+++ b/content/api-reference/integrations/databricks/packages/flyteplugins.databricks/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.databricks
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/databricks/packages/flyteplugins.databricks/databricks.md
+++ b/content/api-reference/integrations/databricks/packages/flyteplugins.databricks/databricks.md
@@ -1,6 +1,6 @@
 ---
 title: Databricks
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/databricks/packages/flyteplugins.databricks/databricksconnector.md
+++ b/content/api-reference/integrations/databricks/packages/flyteplugins.databricks/databricksconnector.md
@@ -1,6 +1,6 @@
 ---
 title: DatabricksConnector
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/gemini/_index.md
+++ b/content/api-reference/integrations/gemini/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Gemini
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/gemini/classes/_index.md
+++ b/content/api-reference/integrations/gemini/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/gemini/packages/_index.md
+++ b/content/api-reference/integrations/gemini/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/gemini/packages/flyteplugins.gemini/_index.md
+++ b/content/api-reference/integrations/gemini/packages/flyteplugins.gemini/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.gemini
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/gemini/packages/flyteplugins.gemini/agent.md
+++ b/content/api-reference/integrations/gemini/packages/flyteplugins.gemini/agent.md
@@ -1,6 +1,6 @@
 ---
 title: Agent
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/hitl/_index.md
+++ b/content/api-reference/integrations/hitl/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Human-in-the-Loop
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/hitl/classes/_index.md
+++ b/content/api-reference/integrations/hitl/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/hitl/packages/_index.md
+++ b/content/api-reference/integrations/hitl/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/hitl/packages/flyteplugins.hitl/_index.md
+++ b/content/api-reference/integrations/hitl/packages/flyteplugins.hitl/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.hitl
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/hitl/packages/flyteplugins.hitl/event.md
+++ b/content/api-reference/integrations/hitl/packages/flyteplugins.hitl/event.md
@@ -1,6 +1,6 @@
 ---
 title: Event
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/hydra/_index.md
+++ b/content/api-reference/integrations/hydra/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Hydra
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/hydra/packages/flyteplugins.hydra/_index.md
+++ b/content/api-reference/integrations/hydra/packages/flyteplugins.hydra/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.hydra
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/jsonl/_index.md
+++ b/content/api-reference/integrations/jsonl/_index.md
@@ -1,6 +1,6 @@
 ---
 title: JSONL
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/jsonl/classes/_index.md
+++ b/content/api-reference/integrations/jsonl/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/jsonl/packages/_index.md
+++ b/content/api-reference/integrations/jsonl/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/jsonl/packages/flyteplugins.jsonl/_index.md
+++ b/content/api-reference/integrations/jsonl/packages/flyteplugins.jsonl/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.jsonl
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/jsonl/packages/flyteplugins.jsonl/jsonldir.md
+++ b/content/api-reference/integrations/jsonl/packages/flyteplugins.jsonl/jsonldir.md
@@ -1,6 +1,6 @@
 ---
 title: JsonlDir
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/jsonl/packages/flyteplugins.jsonl/jsonlfile.md
+++ b/content/api-reference/integrations/jsonl/packages/flyteplugins.jsonl/jsonlfile.md
@@ -1,6 +1,6 @@
 ---
 title: JsonlFile
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/mlflow/_index.md
+++ b/content/api-reference/integrations/mlflow/_index.md
@@ -1,6 +1,6 @@
 ---
 title: MLflow
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/mlflow/classes/_index.md
+++ b/content/api-reference/integrations/mlflow/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/mlflow/packages/_index.md
+++ b/content/api-reference/integrations/mlflow/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/mlflow/packages/flyteplugins.mlflow/_index.md
+++ b/content/api-reference/integrations/mlflow/packages/flyteplugins.mlflow/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.mlflow
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/mlflow/packages/flyteplugins.mlflow/mlflow.md
+++ b/content/api-reference/integrations/mlflow/packages/flyteplugins.mlflow/mlflow.md
@@ -1,6 +1,6 @@
 ---
 title: Mlflow
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/omegaconf/_index.md
+++ b/content/api-reference/integrations/omegaconf/_index.md
@@ -1,6 +1,6 @@
 ---
 title: OmegaConf
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/omegaconf/packages/flyteplugins.omegaconf/_index.md
+++ b/content/api-reference/integrations/omegaconf/packages/flyteplugins.omegaconf/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.omegaconf
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/openai/_index.md
+++ b/content/api-reference/integrations/openai/_index.md
@@ -1,6 +1,6 @@
 ---
 title: OpenAI
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/openai/packages/flyteplugins.openai.agents/_index.md
+++ b/content/api-reference/integrations/openai/packages/flyteplugins.openai.agents/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.openai.agents
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/papermill/_index.md
+++ b/content/api-reference/integrations/papermill/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Papermill
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/papermill/classes/_index.md
+++ b/content/api-reference/integrations/papermill/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/papermill/packages/_index.md
+++ b/content/api-reference/integrations/papermill/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/papermill/packages/flyteplugins.papermill/_index.md
+++ b/content/api-reference/integrations/papermill/packages/flyteplugins.papermill/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.papermill
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/papermill/packages/flyteplugins.papermill/notebooktask.md
+++ b/content/api-reference/integrations/papermill/packages/flyteplugins.papermill/notebooktask.md
@@ -1,6 +1,6 @@
 ---
 title: NotebookTask
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/polars/_index.md
+++ b/content/api-reference/integrations/polars/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Polars
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/polars/classes/_index.md
+++ b/content/api-reference/integrations/polars/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/polars/packages/_index.md
+++ b/content/api-reference/integrations/polars/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/polars/packages/flyteplugins.polars.df_transformer/_index.md
+++ b/content/api-reference/integrations/polars/packages/flyteplugins.polars.df_transformer/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.polars.df_transformer
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/polars/packages/flyteplugins.polars.df_transformer/parquettopolarsdecodinghandler.md
+++ b/content/api-reference/integrations/polars/packages/flyteplugins.polars.df_transformer/parquettopolarsdecodinghandler.md
@@ -1,6 +1,6 @@
 ---
 title: ParquetToPolarsDecodingHandler
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/polars/packages/flyteplugins.polars.df_transformer/parquettopolarslazyframedecodinghandler.md
+++ b/content/api-reference/integrations/polars/packages/flyteplugins.polars.df_transformer/parquettopolarslazyframedecodinghandler.md
@@ -1,6 +1,6 @@
 ---
 title: ParquetToPolarsLazyFrameDecodingHandler
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/polars/packages/flyteplugins.polars.df_transformer/polarslazyframetoparquetencodinghandler.md
+++ b/content/api-reference/integrations/polars/packages/flyteplugins.polars.df_transformer/polarslazyframetoparquetencodinghandler.md
@@ -1,6 +1,6 @@
 ---
 title: PolarsLazyFrameToParquetEncodingHandler
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/polars/packages/flyteplugins.polars.df_transformer/polarstoparquetencodinghandler.md
+++ b/content/api-reference/integrations/polars/packages/flyteplugins.polars.df_transformer/polarstoparquetencodinghandler.md
@@ -1,6 +1,6 @@
 ---
 title: PolarsToParquetEncodingHandler
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/pytorch/_index.md
+++ b/content/api-reference/integrations/pytorch/_index.md
@@ -1,6 +1,6 @@
 ---
 title: PyTorch
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/pytorch/classes/_index.md
+++ b/content/api-reference/integrations/pytorch/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/pytorch/packages/_index.md
+++ b/content/api-reference/integrations/pytorch/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/pytorch/packages/flyteplugins.pytorch/_index.md
+++ b/content/api-reference/integrations/pytorch/packages/flyteplugins.pytorch/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.pytorch
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/pytorch/packages/flyteplugins.pytorch/elastic.md
+++ b/content/api-reference/integrations/pytorch/packages/flyteplugins.pytorch/elastic.md
@@ -1,6 +1,6 @@
 ---
 title: Elastic
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/ray/_index.md
+++ b/content/api-reference/integrations/ray/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Ray
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/ray/classes/_index.md
+++ b/content/api-reference/integrations/ray/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/ray/packages/_index.md
+++ b/content/api-reference/integrations/ray/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/ray/packages/flyteplugins.ray/_index.md
+++ b/content/api-reference/integrations/ray/packages/flyteplugins.ray/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.ray
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/ray/packages/flyteplugins.ray/headnodeconfig.md
+++ b/content/api-reference/integrations/ray/packages/flyteplugins.ray/headnodeconfig.md
@@ -1,6 +1,6 @@
 ---
 title: HeadNodeConfig
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/ray/packages/flyteplugins.ray/rayjobconfig.md
+++ b/content/api-reference/integrations/ray/packages/flyteplugins.ray/rayjobconfig.md
@@ -1,6 +1,6 @@
 ---
 title: RayJobConfig
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/ray/packages/flyteplugins.ray/workernodeconfig.md
+++ b/content/api-reference/integrations/ray/packages/flyteplugins.ray/workernodeconfig.md
@@ -1,6 +1,6 @@
 ---
 title: WorkerNodeConfig
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/sglang/_index.md
+++ b/content/api-reference/integrations/sglang/_index.md
@@ -1,6 +1,6 @@
 ---
 title: SGLang
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/sglang/classes/_index.md
+++ b/content/api-reference/integrations/sglang/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/sglang/packages/_index.md
+++ b/content/api-reference/integrations/sglang/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/sglang/packages/flyteplugins.sglang/_index.md
+++ b/content/api-reference/integrations/sglang/packages/flyteplugins.sglang/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.sglang
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/sglang/packages/flyteplugins.sglang/sglangappenvironment.md
+++ b/content/api-reference/integrations/sglang/packages/flyteplugins.sglang/sglangappenvironment.md
@@ -1,6 +1,6 @@
 ---
 title: SGLangAppEnvironment
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/snowflake/_index.md
+++ b/content/api-reference/integrations/snowflake/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Snowflake
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/snowflake/classes/_index.md
+++ b/content/api-reference/integrations/snowflake/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/snowflake/packages/_index.md
+++ b/content/api-reference/integrations/snowflake/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/snowflake/packages/flyteplugins.snowflake/_index.md
+++ b/content/api-reference/integrations/snowflake/packages/flyteplugins.snowflake/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.snowflake
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/snowflake/packages/flyteplugins.snowflake/snowflake.md
+++ b/content/api-reference/integrations/snowflake/packages/flyteplugins.snowflake/snowflake.md
@@ -1,6 +1,6 @@
 ---
 title: Snowflake
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/snowflake/packages/flyteplugins.snowflake/snowflakeconfig.md
+++ b/content/api-reference/integrations/snowflake/packages/flyteplugins.snowflake/snowflakeconfig.md
@@ -1,6 +1,6 @@
 ---
 title: SnowflakeConfig
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/snowflake/packages/flyteplugins.snowflake/snowflakeconnector.md
+++ b/content/api-reference/integrations/snowflake/packages/flyteplugins.snowflake/snowflakeconnector.md
@@ -1,6 +1,6 @@
 ---
 title: SnowflakeConnector
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/spark/_index.md
+++ b/content/api-reference/integrations/spark/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Spark
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/spark/classes/_index.md
+++ b/content/api-reference/integrations/spark/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/spark/packages/_index.md
+++ b/content/api-reference/integrations/spark/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/spark/packages/flyteplugins.spark/_index.md
+++ b/content/api-reference/integrations/spark/packages/flyteplugins.spark/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.spark
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/spark/packages/flyteplugins.spark/parquettosparkdecoder.md
+++ b/content/api-reference/integrations/spark/packages/flyteplugins.spark/parquettosparkdecoder.md
@@ -1,6 +1,6 @@
 ---
 title: ParquetToSparkDecoder
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/spark/packages/flyteplugins.spark/spark.md
+++ b/content/api-reference/integrations/spark/packages/flyteplugins.spark/spark.md
@@ -1,6 +1,6 @@
 ---
 title: Spark
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/spark/packages/flyteplugins.spark/sparktoparquetencoder.md
+++ b/content/api-reference/integrations/spark/packages/flyteplugins.spark/sparktoparquetencoder.md
@@ -1,6 +1,6 @@
 ---
 title: SparkToParquetEncoder
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/vllm/_index.md
+++ b/content/api-reference/integrations/vllm/_index.md
@@ -1,6 +1,6 @@
 ---
 title: vLLM
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/vllm/classes/_index.md
+++ b/content/api-reference/integrations/vllm/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/vllm/packages/_index.md
+++ b/content/api-reference/integrations/vllm/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/vllm/packages/flyteplugins.vllm/_index.md
+++ b/content/api-reference/integrations/vllm/packages/flyteplugins.vllm/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.vllm
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/vllm/packages/flyteplugins.vllm/vllmappenvironment.md
+++ b/content/api-reference/integrations/vllm/packages/flyteplugins.vllm/vllmappenvironment.md
@@ -1,6 +1,6 @@
 ---
 title: VLLMAppEnvironment
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/wandb/_index.md
+++ b/content/api-reference/integrations/wandb/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Weights & Biases
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/wandb/classes/_index.md
+++ b/content/api-reference/integrations/wandb/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/wandb/packages/_index.md
+++ b/content/api-reference/integrations/wandb/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/wandb/packages/flyteplugins.wandb/_index.md
+++ b/content/api-reference/integrations/wandb/packages/flyteplugins.wandb/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.wandb
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/wandb/packages/flyteplugins.wandb/wandb.md
+++ b/content/api-reference/integrations/wandb/packages/flyteplugins.wandb/wandb.md
@@ -1,6 +1,6 @@
 ---
 title: Wandb
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/wandb/packages/flyteplugins.wandb/wandbsweep.md
+++ b/content/api-reference/integrations/wandb/packages/flyteplugins.wandb/wandbsweep.md
@@ -1,6 +1,6 @@
 ---
 title: WandbSweep
-version: 2.5.1
+version: 2.5.2
 variants: +flyte +union
 layout: py_api
 ---


### PR DESCRIPTION
## What

Routine regeneration of the **generated v2 API-reference pages** to track the latest PyPI release. `make check-api-docs` flagged **23 packages** at committed `2.5.1` vs PyPI-latest **`2.5.2`**; this regenerates them via the build pipeline's own targets (`make update-api-docs` → `Makefile.api.{sdk,plugins}`). **No hand-authored content.**

## Packages regenerated (2.5.1 → 2.5.2)

- `flyte` SDK + `flyte` CLI
- 20 × `flyteplugins-*`: anthropic, bigquery, codegen, dask, databricks, gemini, hitl, hydra, jsonl, mlflow, openai, omegaconf, papermill, polars, pytorch, ray, sglang, snowflake, spark, vllm, wandb

(`flyteplugins-union` 0.4.2 already current; v1 surface on the `v1` branch already current at flytekit 1.16.23 / union 0.1.203 — no v1 PR needed.)

## Scope

- 342 files, **`content/api-reference/**` only**. No `linkmap/` delta (patch bump — no new/renamed symbols).
- Notable visible changes: new `flyte get run` label filters (`--with-label`, `--with-label-key`, `--label`); refreshed Directory listings.

## Verification

- Post-regen `make check-api-docs` → **all up-to-date**.
- `make check-generated-content` → **all present**.

## Provenance

Maintenance run via `/docsy --refresh-api` (Mode E → `refresh-api-docs`). No Linear ticket (housekeeping, exempt from one-issue-per-signal); the record is the committed `regen` run report in `unionai/docsy`. Draft for human review — `unionai-docs-infra` submodule pointer **not** bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)