### PR TITLE
docs: add re-run and debug run guides

### DIFF
--- a/content/user-guide/task-deployment/debug-runs.md
+++ b/content/user-guide/task-deployment/debug-runs.md
@@ -1,0 +1,153 @@
+---
+title: Debug a run
+weight: 15
+variants: -flyte +union
+---
+
+# Debug a run
+
+When an action behaves unexpectedly, {{< key product_name >}} lets you drop into a live debugging
+session for that action — inspecting its environment, filesystem, and code from the inside instead
+of guessing from logs alone.
+
+There are two ways to debug:
+
+- **From the UI** — open a debugging session for any action with a single click.
+- **SSH into the task** (Beta) — attach your local terminal or VS Code directly to a running task
+  pod, using the `flyteplugins-union` plugin.
+
+## Debug from the UI
+
+Open the run in the UI and select the action you want to debug from the action list. In the action
+details view, click **Debug action** (the button in the top-right of the summary panel).
+
+This opens an interactive debugging session for that action, where you can explore the action's
+state directly. Debugging is scoped to the individual action, so you can debug a single nested
+action without affecting the rest of the run.
+
+## SSH into the task (Beta)
+
+> [!WARNING] Beta feature
+> SSH-into-task debugging is a Beta feature delivered through the `flyteplugins-union` plugin. Its
+> commands and APIs may change in future releases.
+
+This mode launches your run with an in-pod SSH server fronted by a small WebSocket bridge, then
+gives you a ready-to-paste `~/.ssh/config` block so you can attach your **local** `ssh` client or
+**VS Code Remote-SSH** straight into the task pod. The SSH keypair is auto-managed — you never run
+`ssh-keygen`.
+
+### Requirements
+
+- `flyte` (SDK) version **greater than 2.5.3**
+- `flyteplugins-union` version **greater than 0.5.0**
+- `openssh-server` available in the task image (bake it in for a fast cold start; otherwise it is
+  installed on the pod at startup)
+
+Install the plugin:
+
+```bash
+uv pip install flyteplugins-union
+```
+
+### Debug from the CLI
+
+`flyte debug <run-name>` does everything in one shot: it relaunches an existing run with ssh-debug
+enabled (fetching that run's code and inputs), waits for the pod's ssh route to come up, and prints
+a ready-to-paste `~/.ssh/config` block.
+
+```bash
+# Relaunch a run in debug mode and connect to its root action (a0)
+flyte debug <run-name>
+
+# Name the session, use an API key for auth, and write the Host block into ~/.ssh/config
+flyte debug <run-name> --name my-dbg --api-key --write-config
+
+# Fire-and-forget: relaunch and return immediately, without waiting for the pod to come up
+flyte debug <run-name> --no-wait
+```
+
+Only `RUN_NAME` is required; the action name defaults to the root action `a0`. Pass an action name
+as a second argument to source the task and inputs from a nested action instead.
+
+The debug run uses a **deterministic name** derived from the source run (or from `--name`), so
+re-running `flyte debug <run-name>` **reconnects to the live debug session instead of spawning a
+duplicate**. To start a fresh debug run (for example if the previous one died), pass a new `--name`.
+
+Useful options:
+
+| Option | Description |
+|---|---|
+| `--user` | SSH login user inside the pod (default `root`). |
+| `--identity-file` | Private key to authenticate with. Defaults to the auto-managed `~/.flyte/ssh-debug/id_ed25519`. |
+| `--name` | Name for this debug session — used as **both** the `~/.ssh/config` Host alias and the remote debug run name. Re-running with the same name reconnects; a new name starts a fresh debug run. |
+| `--api-key` | Authenticate the tunnel with a dedicated, long-lived API key instead of your interactive session token. |
+| `--refresh-token` | Force a fresh token instead of reusing the cached one (use if you hit auth errors). |
+| `--write-config` | Write the `Host` block into `~/.ssh/config`, replacing any prior block of the same name. |
+| `--wait` / `--no-wait` | Wait for the route to become ready and print the ssh-config (default), or relaunch and return immediately. |
+| `--timeout` | Seconds to wait for the debug route to become ready (default `300`). |
+
+### Debug programmatically
+
+The `debug()` convenience function mirrors `flyte.run()` / `flyte.rerun()`, with the ssh-debug
+environment injected so the new run comes up with `sshd`. After it returns, resolve the connection
+with `SSHDebug.connect()`:
+
+```python
+import flyte
+from flyteplugins.union import debug
+from flyteplugins.union.remote import SSHDebug
+
+flyte.init_from_config()
+
+# Launch a NEW task in debug mode...
+run = debug(my_task, x=1)
+
+# ...or relaunch an EXISTING run in debug mode (fetches its code + inputs):
+run = debug("some-prior-run")
+
+# Print a ready-to-paste ~/.ssh/config block for the run's root action (a0).
+print(SSHDebug.connect(run.name).ssh_config)
+```
+
+For the run-name form, pass `inputs={...}` to change parameters or `task_template=...` to substitute
+code. For finer control over launch settings, use `with_debugcontext()` — it is
+`flyte.with_runcontext()` preconfigured for ssh-into-task debug (it creates the auto-managed keypair
+and sets the SSH-debug environment variables), so you call `.run(...)` or `.rerun(...)` on it:
+
+```python
+from flyteplugins.union import with_debugcontext
+
+run = with_debugcontext(env_vars={"LOG_LEVEL": "20"}).run(my_task, x=1)
+```
+
+To bake `openssh-server` into the task image for a fast cold start:
+
+```python
+env = flyte.TaskEnvironment(
+    name="ssh_debug",
+    image=flyte.Image.from_debian_base(name="ssh-debug").with_apt_packages("openssh-server"),
+    resources=flyte.Resources(cpu=1, memory="1000Mi"),
+)
+```
+
+### Attach your editor
+
+Once the `Host` block is in place (use `--write-config`, or paste the printed block into
+`~/.ssh/config`), connect with either:
+
+```bash
+ssh flyte-debug
+```
+
+or, in **VS Code**: **Remote-SSH → Connect to Host → `flyte-debug`** (use the session name you chose
+with `--name`).
+
+> [!NOTE]
+> Tokens expire. If you get a `401` on reconnect, just re-run the same `flyte debug` command — it
+> reconnects and refreshes the token in place (no `--write-config` needed). For multi-day sessions,
+> use `--api-key`.
+
+## Related
+
+- [Re-run a run](./rerun-runs) — launch a new run from a previous one.
+- [Interact with runs and actions](./interacting-with-runs) — retrieve, monitor, and inspect runs and actions.

--- a/content/user-guide/task-deployment/debug-runs.md
+++ b/content/user-guide/task-deployment/debug-runs.md
@@ -55,23 +55,39 @@ uv pip install flyteplugins-union
 enabled (fetching that run's code and inputs), waits for the pod's ssh route to come up, and prints
 a ready-to-paste `~/.ssh/config` block.
 
+The canonical flow is to write the `Host` block straight into `~/.ssh/config`, then `ssh` to it:
+
 ```bash
-# Relaunch a run in debug mode and connect to its root action (a0)
-flyte debug <run-name>
-
-# Name the session, use an API key for auth, and write the Host block into ~/.ssh/config
-flyte debug <run-name> --name my-dbg --api-key --write-config
-
-# Fire-and-forget: relaunch and return immediately, without waiting for the pod to come up
-flyte debug <run-name> --no-wait
+flyte debug <run-name> --write-config
+ssh flyte-debug
 ```
 
-Only `RUN_NAME` is required; the action name defaults to the root action `a0`. Pass an action name
-as a second argument to source the task and inputs from a nested action instead.
+`--write-config` adds a `Host flyte-debug` block to your `~/.ssh/config`, so `ssh flyte-debug` (or
+**VS Code → Remote-SSH → `flyte-debug`**) connects straight into the task pod. Only `RUN_NAME` is
+required; the action name defaults to the root action `a0` — pass an action name as a second
+argument to source the task and inputs from a nested action instead.
 
-The debug run uses a **deterministic name** derived from the source run (or from `--name`), so
-re-running `flyte debug <run-name>` **reconnects to the live debug session instead of spawning a
-duplicate**. To start a fresh debug run (for example if the previous one died), pass a new `--name`.
+#### Naming a session
+
+Pass `--name` to name the debug session. The name is used as **both** the remote debug run name and
+the `~/.ssh/config` Host alias, so you then `ssh <name>`:
+
+```bash
+flyte debug <run-name> --name my-dbg --write-config
+ssh my-dbg
+```
+
+Naming lets you keep several debug sessions side by side. The debug run uses a **deterministic
+name** (derived from the source run, or from `--name`), so re-running the same command
+**reconnects to the live debug session instead of spawning a duplicate**. To start a fresh debug
+run (for example if the previous one died), pass a new `--name`.
+
+For a long-lived tunnel that survives re-logins, add `--api-key`; to relaunch without blocking on
+the pod coming up, add `--no-wait`:
+
+```bash
+flyte debug <run-name> --name my-dbg --api-key --write-config
+```
 
 Useful options:
 
@@ -85,6 +101,11 @@ Useful options:
 | `--write-config` | Write the `Host` block into `~/.ssh/config`, replacing any prior block of the same name. |
 | `--wait` / `--no-wait` | Wait for the route to become ready and print the ssh-config (default), or relaunch and return immediately. |
 | `--timeout` | Seconds to wait for the debug route to become ready (default `300`). |
+
+> [!NOTE]
+> Tokens expire. If you get a `401` on reconnect, just re-run the same `flyte debug` command — it
+> reconnects and refreshes the token in place (no `--write-config` needed). For multi-day sessions,
+> use `--api-key`.
 
 ### Debug programmatically
 
@@ -129,23 +150,6 @@ env = flyte.TaskEnvironment(
     resources=flyte.Resources(cpu=1, memory="1000Mi"),
 )
 ```
-
-### Attach your editor
-
-Once the `Host` block is in place (use `--write-config`, or paste the printed block into
-`~/.ssh/config`), connect with either:
-
-```bash
-ssh flyte-debug
-```
-
-or, in **VS Code**: **Remote-SSH → Connect to Host → `flyte-debug`** (use the session name you chose
-with `--name`).
-
-> [!NOTE]
-> Tokens expire. If you get a `401` on reconnect, just re-run the same `flyte debug` command — it
-> reconnects and refreshes the token in place (no `--write-config` needed). For multi-day sessions,
-> use `--api-key`.
 
 ## Related
 

--- a/content/user-guide/task-deployment/rerun-runs.md
+++ b/content/user-guide/task-deployment/rerun-runs.md
@@ -1,0 +1,144 @@
+---
+title: Re-run a run
+weight: 14
+variants: +flyte +union
+---
+
+# Re-run a run
+
+Every run in {{< key product_name >}} is durable: its task, code, inputs, and configuration are all
+recorded on the backend. That means you can launch a brand-new run from any previous one without
+having the original code checked out locally. This is useful for retrying a transient failure,
+reproducing a result, or tweaking a few inputs and running again.
+
+You can re-run at two levels of granularity:
+
+- **The whole run** — re-execute the entry point task (the `a0` action) and everything it calls.
+- **A single action** — re-execute one nested action on its own.
+
+And you can trigger a re-run from three places: the **UI**, the **CLI**, or **programmatically**
+with the Python SDK.
+
+## Re-run from the UI
+
+### Re-run an entire run
+
+Open the run in the UI. In the top-right corner of the run view, click **Rerun**.
+
+![Re-run a run from the UI](../_static/images/user-guide/task-deployment/rerun-run.png)
+
+This opens the launch form pre-filled with the original run's inputs, environment variables, and
+code. You can either:
+
+- Trigger the run as-is to reproduce the original execution exactly, or
+- Edit the inputs, environment variables, and other launch settings in the form before triggering
+  to run a variation.
+
+### Re-run a single action
+
+You can also re-run an individual action without re-running the whole workflow. Navigate to the
+action in the run's action list, open its details view, and use the **Rerun action** option (in the
+action menu in the top-right of the action details panel).
+
+![Re-run a single action from the UI](../_static/images/user-guide/task-deployment/rerun-action.png)
+
+This launches a new run starting from that action, using the action's recorded inputs. As with a
+full re-run, you can adjust the inputs in the launch form first.
+
+## Re-run from the CLI
+
+The CLI offers two complementary commands depending on whether you want the **original code** or
+**new local code**.
+
+### `flyte rerun` — re-run with the original code and inputs
+
+`flyte rerun` fetches the prior run's task **and** inputs from the backend and launches a new run.
+You don't need the original code checked out locally — everything is pulled from the platform:
+
+```bash
+# Re-run with the prior run's exact code and inputs
+flyte rerun <run-name>
+
+# Give the new run a name and stream its parent-action logs
+flyte rerun <run-name> --name retry-1 --follow
+```
+
+Common options:
+
+| Option | Description |
+|---|---|
+| `-p`, `--project` | Project for the new run (defaults to your config). |
+| `-d`, `--domain` | Domain for the new run (defaults to your config). |
+| `--name` | Name for the new run (a random name is generated if unset). |
+| `-e`, `--env KEY=VALUE` | Override an environment variable for the new run. Repeatable. |
+| `--label KEY=VALUE` | Set a label on the new run. Repeatable. |
+| `-f`, `--follow` | Stream the parent action's logs after launch. |
+
+> [!NOTE]
+> `flyte rerun` reuses the prior run's inputs as-is. To change input values from the command line,
+> use the programmatic `flyte.rerun(<run-name>, key=value)` form shown below.
+
+### `flyte run --rerun-from` — re-run with new local code
+
+When you've changed your code locally but want to reuse a prior run's inputs, use `flyte run` with
+the `--rerun-from` flag. This deploys **your local code** and feeds it the inputs from the prior
+run, so you don't need to re-specify any per-task input flags:
+
+```bash
+flyte run main.py main --rerun-from <run-name>
+```
+
+`--rerun-from` is remote-only — it cannot be combined with `--local`.
+
+### Choosing between the two
+
+| Command | Code | Inputs |
+|---|---|---|
+| `flyte run <file> <task>` | local | from CLI |
+| `flyte run <file> <task> --rerun-from <run>` | local | prior run's |
+| `flyte rerun <run>` | fetched from backend | prior run's |
+
+## Re-run programmatically
+
+Use `flyte.rerun()` to re-run from Python. Like the CLI, it fetches the prior run's task and inputs
+from the backend, so no local code is required:
+
+```python
+import flyte
+
+flyte.init_from_config()
+
+# Re-run a prior run with its exact inputs (task + inputs fetched from the platform):
+flyte.rerun("ul56wcvgqrb9vzhzz5l2")
+
+# Change input parameters — they are converted against the prior run's interface:
+flyte.rerun("ul56wcvgqrb9vzhzz5l2", x_list=[1, 2, 3])
+
+# Substitute new code while reusing the original run's inputs:
+flyte.rerun("ul56wcvgqrb9vzhzz5l2", task_template=fixed_task)
+```
+
+`flyte.rerun()` returns a `flyte.remote.Run`, just like `flyte.run()`, so you can monitor it, wait
+on it, and retrieve its outputs in the same way. See
+[Interact with runs and actions](./interacting-with-runs) for details.
+
+To control launch settings (name, project, domain, environment variables, labels) use
+`flyte.with_runcontext(...).rerun(...)`:
+
+```python
+flyte.with_runcontext(
+    name="retry-1",
+    env_vars={"LOG_LEVEL": "20"},
+).rerun("ul56wcvgqrb9vzhzz5l2")
+```
+
+## Related
+
+- [Interact with runs and actions](./interacting-with-runs) — retrieve, monitor, and inspect runs and actions.
+- [Run command options](./run-command-options) — the full set of `flyte run` options.
+
+{{< variant union >}}
+{{< markdown >}}
+- [Debug a run](./debug-runs) — drop into a live debugging session for an action.
+{{< /markdown >}}
+{{< /variant >}}

--- a/content/user-guide/task-deployment/rerun-runs.md
+++ b/content/user-guide/task-deployment/rerun-runs.md
@@ -85,7 +85,7 @@ the `--rerun-from` flag. This deploys **your local code** and feeds it the input
 run, so you don't need to re-specify any per-task input flags:
 
 ```bash
-flyte run main.py main --rerun-from <run-name>
+flyte run --rerun-from <run-name> main.py main
 ```
 
 `--rerun-from` is remote-only — it cannot be combined with `--local`.
@@ -95,7 +95,7 @@ flyte run main.py main --rerun-from <run-name>
 | Command | Code | Inputs |
 |---|---|---|
 | `flyte run <file> <task>` | local | from CLI |
-| `flyte run <file> <task> --rerun-from <run>` | local | prior run's |
+| `flyte run --rerun-from <run> <file> <task>` | local | prior run's |
 | `flyte rerun <run>` | fetched from backend | prior run's |
 
 ## Re-run programmatically


### PR DESCRIPTION
Adds two user-guide pages under `task-deployment/`:

- **Re-run a run** — UI Rerun (run + action), `flyte rerun` / `flyte run --rerun-from`, and `flyte.rerun()`.
- **Debug a run** (Union-only) — UI Debug action, plus the Beta SSH-into-task flow: `flyte debug <run>` and the `flyteplugins-union` `debug()` / `with_debugcontext()` APIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)