### PR TITLE
fix(v1): correct local-setup link in CLI reference pages (DOC-936)

### DIFF
--- a/content/api-reference/pyflyte-cli.md
+++ b/content/api-reference/pyflyte-cli.md
@@ -37,7 +37,7 @@ where `<{{< key cli >}}-host-url>` is the URL of your {{< key product_name >}}  
 
 These command will create the file `~/.{{< key product >}}/config.yaml` with the configuration information to connect to the {{< key product_name >}}  instance.
 
-See [Getting started &gt; Local setup](../user-guide/getting-started/local-setup) for more details.
+See [Getting started &gt; Local setup](../../user-guide/getting-started/local-setup) for more details.
 
 ## Overriding the configuration file location
 

--- a/content/api-reference/union-cli.md
+++ b/content/api-reference/union-cli.md
@@ -37,7 +37,7 @@ where `<{{< key cli >}}-host-url>` is the URL of your {{< key product_name >}}  
 
 These command will create the file `~/.{{< key product >}}/config.yaml` with the configuration information to connect to the {{< key product_name >}}  instance.
 
-See [Getting started > Local setup](../user-guide/getting-started/local-setup) for more details.
+See [Getting started > Local setup](../../user-guide/getting-started/local-setup) for more details.
 
 ## Overriding the configuration file location
 


### PR DESCRIPTION
## What

Fixes a broken relative link in two hand-authored v1 CLI reference pages.

In `content/api-reference/union-cli.md` and `content/api-reference/pyflyte-cli.md`, the link to the Local setup getting-started page used a single-level relative path:

```
](../user-guide/getting-started/local-setup)
```

These pages live at `api-reference/<page>`, so a single `../` resolves to the nonexistent `api-reference/user-guide/getting-started/local-setup`. The fix climbs two levels:

```
](../../user-guide/getting-started/local-setup)
```

Target `content/user-guide/getting-started/local-setup.md` is confirmed present on `v1`.

## Scope

- Branch: `v1` (published Flyte/Union 1.x content). This is the `v1-fix` exception — an obvious fix to a clear error in published v1 content. The equivalent pages were dropped in v2.
- 2 lines, 2 files, single surface (`unionai-docs @ v1`).

## Note on the ticket premise

DOC-936 described these as `docs-builder`/generated content. They are in fact **hand-authored** markdown files (`content/api-reference/{union-cli,pyflyte-cli}.md`) on the `v1` branch — the fix is a direct content edit, no generator involved.

Fixes [DOC-936](https://linear.app/unionai/issue/DOC-936/link-renders-incorrectly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
