### PR TITLE
docs(run-modes): clarify the two ways to run a task locally (DOC-1135)

### DIFF
--- a/content/user-guide/run-modes/running-locally.md
+++ b/content/user-guide/run-modes/running-locally.md
@@ -30,6 +30,56 @@ flyte run --local --tui hello.py main
 
 You can also run tasks programmatically using the Python SDK with `flyte.run()`. See [Run and deploy tasks](../task-deployment/_index) for details.
 
+## Two ways to run a task
+
+There are two distinct ways to run a task, and it's easy to confuse them when you're new. They differ in *who* calls `flyte.run()`.
+
+### As a script: `python hello.py`
+
+You call `flyte.run()` yourself, from inside an `if __name__ == "__main__":` block, and execute the file with plain Python:
+
+```python
+# hello.py
+import flyte
+
+env = flyte.TaskEnvironment(name="hello_env")
+
+@env.task
+def main(x_list: list[int] = list(range(10))) -> float:
+    return sum(x_list) / len(x_list)
+
+if __name__ == "__main__":
+    flyte.init_from_config()       # load your local config (.flyte/config.yaml)
+    run = flyte.run(main)          # call the task; pass inputs as keyword args
+    print(run.name)
+    run.wait()
+```
+
+Then run the file as an ordinary Python script:
+
+```bash
+python hello.py
+```
+
+Because *your code* decides which task runs and with what inputs, you pass inputs directly as arguments to `flyte.run()` — for example `flyte.run(main, x_list=[1, 2, 3])`. Use `flyte.run.aio(...)` from within async code.
+
+### Via the CLI: `flyte run`
+
+The `flyte run` CLI does the calling for you. You don't need a `__main__` block — instead you name the file and the task on the command line, and the CLI invokes it:
+
+```bash
+flyte run --local hello.py main
+```
+
+The task's **parameters become CLI options**. Each task input maps to a `--<name>` flag (run `flyte run --local hello.py main --help` to see them, with their defaults). For example, to override `x_list`:
+
+```bash
+flyte run --local hello.py main --x-list '[1, 2, 3]'
+```
+
+> [!NOTE]
+> A common first-run trip-up: invoking `flyte run` against a task whose inputs have **no defaults** without supplying them. The CLI then can't construct the input and you'll see a confusing type-converter error rather than a "missing argument" message. If you hit one, check `--help` and pass the required `--<name>` values (or give the parameters defaults in the task signature, as `main` does above).
+
 ## Terminal UI
 
 The TUI is an interactive split-screen dashboard. Task tree on the left, details and logs on the right.


### PR DESCRIPTION
## What

Adds a **"Two ways to run a task"** section to the local-run getting-started page (`content/user-guide/run-modes/running-locally.md`), addressing new-user confusion reported in DOC-1135.

The page previously mentioned `flyte run --local hello.py main` and noted that `flyte.run()` exists, but never explained the two distinct run *paths* or showed the `python hello.py` invocation — so a new user couldn't tell which to use or how inputs flow.

The new section contrasts:

- **As a script — `python hello.py`**: *your* code calls `flyte.run()` from an `if __name__ == "__main__":` block; inputs are passed as keyword args to `flyte.run()`. Includes the previously-missing `python hello.py` command.
- **Via the CLI — `flyte run`**: the CLI does the calling; no `__main__` block needed; **task parameters become `--<name>` CLI options** (with `--help` showing defaults).

It also adds a NOTE on the exact trip-up from the ticket: invoking `flyte run` against a task whose inputs have **no defaults**, without supplying them — which surfaces a confusing type-converter error rather than a "missing argument" message.

## Grounding

Snippet and CLI behavior verified against released flyte-sdk 2.x examples (`examples/basics/hello.py`, `examples/cli/default_values_cli.py`) and the existing v2 docs patterns (`flyte.init_from_config()` → `flyte.run(...)`). The `main` signature mirrors the docs' embedded `hello.py` (`x_list: list[int]`).

## Scope

- Surface: `unionai-docs @ main`, content-only (one file, inline code block — no embedded example file, so no examples-submodule change).
- Variants: `+flyte +union` (inherits the page's frontmatter; both run paths apply to both).
- Validated via a scoped Hugo build (`union` variant): the page renders and the new section is present. (`make dist` is blocked by an unrelated pre-build nbconvert/jupyter tooling issue in this environment; the integration-page "examples submodule out of date" errors are pre-existing and unrelated to this page.)

Addresses [DOC-1135](https://linear.app/unionai/issue/DOC-1135/clarify-documentation-for-new-users-to-avoid-confusion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
