### PR TITLE
docsy(v2): flyte create api-key noun; drop stale uctl commands (DOC-776)

### DIFF
--- a/content/security/identity-and-access/authentication.md
+++ b/content/security/identity-and-access/authentication.md
@@ -35,18 +35,18 @@ Union.ai uses OAuth2 / OIDC for SSO. Customers can configure any OIDC or SAML 2.
 2. API key: Create a key, use it in a script, then revoke it:
 
    ```bash
-   uctl create api-key
+   flyte create api-key --name <key-name>
    # Use the key in a script to authenticate
-   uctl delete api-key <key-id>
+   flyte delete api-key <key-name>
    # Confirm the revoked key is rejected
    ```
 
-3. Service account: Create a service account and confirm it has a distinct identity:
+3. Application identity: `flyte create api-key` provisions OAuth application credentials (an OAuth2 `client_id` + `client_secret`, encoded into the API key) with a distinct, auditable identity independent of any human user:
 
    ```bash
-   uctl create service-account
+   flyte create api-key --name <app-name>
    ```
 
-   Show the OAuth2 token exchange and confirm the service account appears as a distinct identity in the audit log.
+   Show the OAuth2 token exchange and confirm the application appears as a distinct identity in the audit log. Use [`flyte create assignment`](../../api-reference/flyte-cli#flyte-create-assignment) to bind policies that scope what the identity can do.
 
 This verification is fully self-service.

--- a/content/user-guide/authenticating.md
+++ b/content/user-guide/authenticating.md
@@ -359,6 +359,13 @@ for task in tasks:
 
 **Managing API keys**
 
+Create a key:
+```bash
+flyte create api-key --name my-ci-key
+```
+
+This creates OAuth application credentials and prints an `export FLYTE_API_KEY="..."` command to use the key. OAuth applications should not be confused with Union Apps, which are a different construct entirely.
+
 List existing keys:
 ```bash
 flyte get api-key


### PR DESCRIPTION
## What

- **`content/user-guide/authenticating.md`** — the *Managing API keys* CLI flow previously showed only `flyte get api-key` / `flyte delete api-key`. Adds the **creation** step (`flyte create api-key --name my-ci-key`) plus the OAuth-applications-vs-Union-Apps disambiguation that the CLI reference carries.
- **`content/security/identity-and-access/authentication.md`** — replaces the stale v1 `uctl create api-key` / `uctl delete api-key` / `uctl create service-account` with their `flyte` equivalents.

## Code-is-authoritative note (verify-live)

- `flyte create api-key --name <name>` is the v2 noun — verified against the CLI reference (`content/api-reference/flyte-cli.md` L273–301). It is a `flyteplugins.union` command (matches the `pip install flyteplugins-union` already in the page), "creates OAuth application credentials," and prints `export FLYTE_API_KEY=...`. The reference's own wording — *"OAuth applications should not be confused with Union Apps"* — is reused for the disambiguation.
- **v2 has no `flyte create service-account` noun** (the `flyte create` subcommands are: api-key, assignment, cluster, cluster-pool, config, policy, project, queue). So the old `uctl create service-account` verification step is reframed around its v2 realization: `flyte create api-key` provisions the OAuth2 `client_id`+`client_secret` application identity, with `flyte create assignment` binding policies. This matches the page's own API-keys-vs-service-accounts table.
- **Does NOT introduce the stale v1 `oauth-app` noun** that the ticket title suggested — that noun does not exist in the v2 CLI.

Both pages are `-flyte +union`, so the union-plugin command and the `flyte create assignment` cross-link are in-variant.

Linear: https://linear.app/unionai/issue/DOC-776

🤖 docsy draft