### PR TITLE
docsy(v1): pass Config to FlyteRemote/UnionRemote minimal example (DOC-1156)

### DIFF
--- a/content/user-guide/development-cycle/remote-management/_index.md
+++ b/content/user-guide/development-cycle/remote-management/_index.md
@@ -19,20 +19,21 @@ Ensure that you have the {{<key kit_name >}} SDK installed, import the `{{< key 
 
 ```python
 import {{< key kit_import >}}
+from flytekit.configuration import Config
 
-remote = {{< key kit_as >}}.{{< key kit_remote >}}()
+remote = {{< key kit_as >}}.{{< key kit_remote >}}(config=Config.auto())
 ```
 
 {{< variant union >}}
 {{< markdown >}}
-By default, when created with a no-argument constructor, `{{< key kit_remote >}}` will use the prevailing configuration in the local environment to connect to {{< key product_name >}},
+By default, when created with `config=Config.auto()`, `{{< key kit_remote >}}` will use the prevailing configuration in the local environment to connect to {{< key product_name >}},
 that is, the same configuration as would be used by the {{< key cli_name >}} CLI in that environment
 (see [{{< key cli_name >}} CLI configuration search path](../../../api-reference/union-cli#-key-cli--cli-configuration-search-path)).
 {{< /markdown >}}
 {{< /variant >}}
 {{< variant flyte >}}
 {{< markdown >}}
-By default, when created with a no-argument constructor, `{{< key kit_remote >}}` will use the prevailing configuration in the local environment to connect to {{< key product_name >}},
+By default, when created with `config=Config.auto()`, `{{< key kit_remote >}}` will use the prevailing configuration in the local environment to connect to {{< key product_name >}},
 that is, the same configuration as would be used by the {{< key cli_name >}} CLI in that environment
 (see [{{< key cli_name >}} CLI configuration search path](../../../api-reference/pyflyte-cli#-key-cli--cli-configuration-search-path)).
 {{< /markdown >}}


### PR DESCRIPTION
Fixes the minimal `FlyteRemote`/`UnionRemote` example on the v1 Remote management page, which instantiated the client with a no-argument constructor — that won't run because a `Config` is required.

## Change
`content/user-guide/development-cycle/remote-management/_index.md`
- Pass `config=Config.auto()` to the minimal-example constructor (matches the prevailing-local-environment behavior the surrounding prose describes, and is consistent with the fuller `Config.for_endpoint(...)` examples already further down the page).
- Add the required `from flytekit.configuration import Config` import.
- Update the two adjacent prose sentences ("when created with a no-argument constructor" → "when created with `config=Config.auto()`") so the page stays internally consistent.

This is the **`v1-fix` exception**: an obvious fix to a clear error in *published* Flyte 1.x / flytekit content. This is v1/flytekit (`FlyteRemote` + `flytekit.configuration.Config`), not the v2 `flyte` SDK — v2 uses `flyte.init()` and has no `FlyteRemote`/`Config`, so nothing changes there.

Reported by daniel.sola. Linear: DOC-1156.

Draft: needs a human glance to confirm the flytekit API wording reads well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)