### PR TITLE
docsy(v2): add alt text to images missing it (DOC-673)

### DIFF
--- a/content/deployment/byoc/data-plane-setup-on-aws.md
+++ b/content/deployment/byoc/data-plane-setup-on-aws.md
@@ -725,7 +725,7 @@ For additional security, the EKS endpoint can be configured as `Private` only. I
 
 When AWS rolls out changes to the EKS endpoint, its IP address might change. To handle this and prevent any disconnect, the Union automation sets up a "jumper" ECS container in the customer account which forwards the incoming requests to the EKS Endpoint, acting as a reverse proxy, while a Network Load Balancer exposes an stable endpoint address. In this way, you get the security of a fully private connection and a reliable channel for Union staff to manage your cluster proactively or troubleshoot issues when needed.
 
-![](../../_static/images/deployment/data-plane-setup-on-aws/aws_private_link_architecture.png)
+![Diagram of the AWS PrivateLink setup connecting Union to a private EKS endpoint through a jumper ECS reverse proxy and a Network Load Balancer](../../_static/images/deployment/data-plane-setup-on-aws/aws_private_link_architecture.png)
 
 For this setup, there are additional requirements you'll need to complete in your AWS account:
 

--- a/content/deployment/byoc/enabling-aws-resources/_index.md
+++ b/content/deployment/byoc/enabling-aws-resources/_index.md
@@ -118,7 +118,7 @@ You can then choose whether to enable **global access** or **project-domain-scop
   * Also, attach the policy called `userflyterole` to `<CustomRole>` (this will ensure that `<CustomRole>` has all the default permissions needed to allow tasks to run).
   * Attach `<CustomRole>` to the desired project-domain namespace.
 
-![](../../../_static/images/user-guide/integrations/enabling-aws-resources/union-roles.png)
+![Diagram of the AWS IAM roles and policies used for project-domain-scoped access in Union](../../../_static/images/user-guide/integrations/enabling-aws-resources/union-roles.png)
 
 ### Creating a custom policy
 

--- a/content/deployment/byoc/enabling-gcp-resources/_index.md
+++ b/content/deployment/byoc/enabling-gcp-resources/_index.md
@@ -119,7 +119,7 @@ To find the actual name of this GSA do the following:
 * In the GCP data plane project, go to **IAM & Admin > Service accounts**.
 * In the list of service account, find the one whose name and email match the pattern above. For example:
 
-![](../../../_static/images/user-guide/integrations/enabling-gcp-resources/user-flyte-gsa.png)
+![GCP IAM & Admin Service accounts list, used to find the UserFlyteGSA service account name and email](../../../_static/images/user-guide/integrations/enabling-gcp-resources/user-flyte-gsa.png)
 
 * Copy this name to document in an editor.
   You will need it later to configure each specific resource.

--- a/content/deployment/byoc/enabling-gcp-resources/enabling-google-cloud-storage.md
+++ b/content/deployment/byoc/enabling-gcp-resources/enabling-google-cloud-storage.md
@@ -24,14 +24,14 @@ To enable access to a GCS bucket you have to add the `<UserFlyteGSA>` Google Ser
 * Go to **Cloud Storage > Buckets** and select the bucket to which you want to grant access.
 * In the **Bucket details** view select the **Permissions** tab and then select **GRANT ACCESS**:
 
-![](../../../_static/images/user-guide/integrations/enabling-gcp-resources/enabling-google-cloud-storage/bucket-details.png)
+![GCS Bucket details Permissions tab with the Grant access button](../../../_static/images/user-guide/integrations/enabling-gcp-resources/enabling-google-cloud-storage/bucket-details.png)
 
 * In the **Grant access** panel:
   * Under **Add principals**, paste the actual name (in email form) of the `<UserFlyteGSA>` into the **New principals** field.
   * Under **Assign roles** add as many roles as you need.
     In the example below we add the roles enabling reading and writing: **Storage Object Viewer** and **Storage Object Creator**.
 
-![](../../../_static/images/user-guide/integrations/enabling-gcp-resources/enabling-google-cloud-storage/grant-access-to-bucket.png)
+![GCS Grant access panel assigning the Storage Object Viewer and Storage Object Creator roles to the UserFlyteGSA principal](../../../_static/images/user-guide/integrations/enabling-gcp-resources/enabling-google-cloud-storage/grant-access-to-bucket.png)
 
 * Click **SAVE**.
 

--- a/content/deployment/byoc/enabling-gcp-resources/enabling-google-secret-manager.md
+++ b/content/deployment/byoc/enabling-gcp-resources/enabling-google-secret-manager.md
@@ -30,12 +30,12 @@ Create your secrets in **Secret Manager** (see the [Secret Manager documentation
 
 Your secret should now be on the secrets list:
 
-![](../../../_static/images/user-guide/integrations/enabling-gcp-resources/enabling-google-secret-manager/secret-manager.png)
+![Google Secret Manager secrets list showing a secret named example-secret](../../../_static/images/user-guide/integrations/enabling-gcp-resources/enabling-google-secret-manager/secret-manager.png)
 
 Above we see a secret named `example-secret`.
 Clicking on it will bring us to the **Secret details** page:
 
-![](../../../_static/images/user-guide/integrations/enabling-gcp-resources/enabling-google-secret-manager/secret-details.png)
+![Google Secret Manager Secret details page for the example-secret secret](../../../_static/images/user-guide/integrations/enabling-gcp-resources/enabling-google-secret-manager/secret-details.png)
 
 The secret has three important identifiers:
 

--- a/content/deployment/byoc/platform-architecture.md
+++ b/content/deployment/byoc/platform-architecture.md
@@ -8,7 +8,7 @@ variants: -flyte +union
 
 The {{< key product_name >}} architecture consists of two virtual private clouds, referred to as planes—the control plane and the data plane.
 
-![](../../_static/images/user-guide/platform-architecture/union-architecture.png)
+![Diagram of the Union platform architecture: two virtual private clouds, the control plane and the data plane](../../_static/images/user-guide/platform-architecture/union-architecture.png)
 
 ## Control plane
 

--- a/content/deployment/flyte-configuration/monitoring.md
+++ b/content/deployment/flyte-configuration/monitoring.md
@@ -19,7 +19,7 @@ These metrics help users diagnose whether an issue is inherent to the platform o
 
 At a high level, workflow execution goes through the following discrete steps:
 
-![](../../_static/images/deployment/flyte_wf_timeline.svg)
+![Diagram of the discrete steps in a Flyte workflow execution timeline](../../_static/images/deployment/flyte_wf_timeline.svg)
 
 
 1. **Acceptance**: Measures the time consumed from receiving a service call to creating an Execution (Unknown) and moving to QUEUED.

--- a/content/deployment/flyte-configuration/performance.md
+++ b/content/deployment/flyte-configuration/performance.md
@@ -23,7 +23,7 @@ In the following sections you will learn how Flyte ensures the correct and relia
 Let's revisit the lifecycle of a workflow execution.
 The following diagram aims to summarize the process described in the [FlytePropeller Architecture](../../architecture/component-architecture/flytepropeller_architecture) and [execution timeline](../../architecture/workflow-timeline) sections, focusing on the main steps.
 
-![](../../_static/images/deployment/propeller-perf-lifecycle-01.png)
+![Diagram summarizing the main steps in the lifecycle of a FlytePropeller workflow execution](../../_static/images/deployment/propeller-perf-lifecycle-01.png)
 
 The ``Worker`` is the independent, lightweight, and idempotent process that interacts with all the components in the Propeller controller to drive executions.
 It's implemented as a ``goroutine``, and illustrated here as a hard-working gopher which:
@@ -86,7 +86,7 @@ While it's possible to easily monitor Kube API saturation using system-level met
 
 **How `ResourceVersionCache` works?**
 
-![](../../_static/images/deployment/resourceversion-01.png)
+![Diagram of how the ResourceVersionCache workflow-store policy works with the Kubernetes etcd key-value store](../../_static/images/deployment/resourceversion-01.png)
 
 Kubernetes stores the definition and state of all the resources under its management on ``etcd``: a fast, distributed and consistent key-value store.
 Every resource has a ``resourceVersion`` field representing the version of that resource as stored in ``etcd``.

--- a/content/deployment/flyte-deployment/multicluster.md
+++ b/content/deployment/flyte-deployment/multicluster.md
@@ -451,4 +451,4 @@ The process can be repeated for additional clusters.
 
 10. A successful execution should be visible on the UI, confirming it ran in the new cluster:
 
-![](../../_static/images/deployment/multicluster-execution.png)
+![Flyte UI execution view confirming a workflow ran successfully in the newly added cluster](../../_static/images/deployment/multicluster-execution.png)

--- a/content/deployment/selfmanaged/architecture/overview.md
+++ b/content/deployment/selfmanaged/architecture/overview.md
@@ -8,7 +8,7 @@ variants: -flyte +union
 
 The {{< key product_name >}} architecture consists of two components, referred to as planes — the control plane and the data plane.
 
-![](../../../_static/images/deployment/architecture.svg)
+![Diagram of the architecture showing the control plane and data plane components](../../../_static/images/deployment/architecture.svg)
 
 ## Control plane
 

--- a/content/tutorials/data-processing/micro-batching/_index.md
+++ b/content/tutorials/data-processing/micro-batching/_index.md
@@ -821,7 +821,7 @@ if __name__ == "__main__":
 
 On execution, this is what this example looks like at the Kubernetes level:
 
-![](./images/reusable-containers-k8s.png)
+![Kubernetes view of the micro-batching example: 10 worker replicas plus the driver Pod running the parent task a0](./images/reusable-containers-k8s.png)
 
 This is, 10 replicas (as defined in the `TaskEnvironment`) and the driver Pod that runs the parent task (`a0`). [Learn more about the parent task]({{< docs_home union v2 >}}/user-guide/considerations/#driver-pod-requirements).
 


### PR DESCRIPTION
Adds descriptive alt text to every Markdown image under `content/` that had empty alt (`![](…)`). Re-surveyed live; found and fixed **14** images across 11 files (0 remain).

Each alt is grounded in the image filename plus the surrounding caption/heading/paragraph, describing what the image shows in context (not "image of…"). Images that already had alt were left untouched.

## Please verify (a11y wording / image contents)
These are **drafts** — the wording deserves a human glance, and one image's exact contents I inferred from surrounding prose rather than the pixels:

- **`union-roles.png`** (`enabling-aws-resources/_index.md`) — I described it as a *diagram of the IAM roles/policies for project-domain-scoped access*, inferred from the adjacent custom-role/custom-policy steps. Please confirm it's that diagram and not a different screenshot.
- The architecture diagrams (`union-architecture.png`, `architecture.svg`, `aws_private_link_architecture.png`, `propeller-perf-lifecycle-01.png`, `resourceversion-01.png`, `flyte_wf_timeline.svg`) are described from the sentence introducing each — worth a skim to confirm the descriptions match the actual visuals.

Linear: DOC-673 (content surface; the site-logo `alt` defect is handled in a companion unionai-docs-infra PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)