### PR TITLE
docsy(v2): gate redirect chains in CI + unconditional chain-collapse (DOC-1190)

### DIFF
--- a/.github/workflows/check-redirects.yml
+++ b/.github/workflows/check-redirects.yml
@@ -46,3 +46,11 @@ jobs:
             echo "::error::Deleted pages are missing redirects. Run 'make check-deleted-pages' for details, then add redirects to unionai-docs-infra/redirects.csv or exclude paths in unionai-docs-infra/.redirects-exclude."
             exit 1
           fi
+
+      - name: Run redirect unit tests
+        run: |
+          # Static redirect suite: CSV invariants + generator logic. Includes
+          # test_no_redirect_chains_within_csv, which gates the CSV against
+          # multi-hop chains (live HTTP tests stay behind --live and don't run).
+          cd unionai-docs-infra
+          uv run --with pytest pytest tests/test_redirects.py -q


### PR DESCRIPTION
Companion to **infra#142**. Two parts:

1. **`check-redirects.yml`** gains a *Run redirect unit tests* step, so the static redirect suite — including `test_no_redirect_chains_within_csv` — becomes an actual CI gate. (Live HTTP tests stay behind `--live` and don't run.)
2. **Bumps the infra submodule** to the generator fix (`docsy/redirect-collapse-chains-always`) that runs `collapse_chains` on **every** real invocation, not only when new rename-redirects are appended.

Together these close the gap found while fixing the human-in-the-loop → External conditions move (#1087): a chain introduced by a manual CSV edit or a non-rename page move now (a) gets auto-collapsed by the generator and (b) is caught by CI if it somehow isn't.

Re-point the submodule to infra/main after infra#142 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)