### PR TITLE
docsy(v2): regenerate API reference 2.5.2 → 2.5.6 (maintenance regen)

### DIFF
--- a/content/api-reference/flyte-cli.md
+++ b/content/api-reference/flyte-cli.md
@@ -1,6 +1,6 @@
 ---
 title: "Flyte CLI"
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 weight: 3
@@ -46,6 +46,7 @@ This is the command line interface for Flyte.
 | `gen` | [`docs`](#flyte-gen-docs)  |
 | `get` | [`action`](#flyte-get-action), [`app`](#flyte-get-app), [`condition`](#flyte-get-condition), [`config`](#flyte-get-config), [`io`](#flyte-get-io), [`logs`](#flyte-get-logs), [`project`](#flyte-get-project), [`run`](#flyte-get-run), [`secret`](#flyte-get-secret), [`settings`](#flyte-get-settings), [`task`](#flyte-get-task), [`trigger`](#flyte-get-trigger)  |
 | `prefetch` | [`hf-model`](#flyte-prefetch-hf-model)  |
+| [`rerun`](#flyte-rerun) | - |
 | `run` | [`deployed-task`](#flyte-run-deployed-task)  |
 | [`serve`](#flyte-serve) | - |
 | `signal` | [`condition`](#flyte-signal-condition)  |
@@ -63,6 +64,7 @@ This is the command line interface for Flyte.
 | ------ | -- |
 | `action` | [`abort`](#flyte-abort-action), [`get`](#flyte-get-action)  |
 | `run` | [`abort`](#flyte-abort-run), [`get`](#flyte-get-run)  |
+| `ssh` | [`connect⁺`](#flyte-connect-ssh)  |
 | `api-key` | [`create⁺`](#flyte-create-api-key), [`delete⁺`](#flyte-delete-api-key), [`get⁺`](#flyte-get-api-key)  |
 | `assignment` | [`create⁺`](#flyte-create-assignment), [`delete⁺`](#flyte-delete-assignment), [`get⁺`](#flyte-get-assignment)  |
 | `cluster` | [`create⁺`](#flyte-create-cluster), [`delete⁺`](#flyte-delete-cluster), [`get⁺`](#flyte-get-cluster)  |
@@ -95,6 +97,7 @@ This is the command line interface for Flyte.
 | ------ | -- |
 | `abort` | [`action`](#flyte-abort-action), [`run`](#flyte-abort-run)  |
 | [`build`](#flyte-build) | - |
+| `connect⁺` | [`ssh⁺`](#flyte-connect-ssh)  |
 | `create` | [`api-key⁺`](#flyte-create-api-key), [`assignment⁺`](#flyte-create-assignment), [`cluster⁺`](#flyte-create-cluster), [`cluster-pool⁺`](#flyte-create-cluster-pool), [`config`](#flyte-create-config), [`policy⁺`](#flyte-create-policy), [`project`](#flyte-create-project), [`queue⁺`](#flyte-create-queue), [`role⁺`](#flyte-create-role), [`secret`](#flyte-create-secret), [`trigger`](#flyte-create-trigger), [`user⁺`](#flyte-create-user)  |
 | `delete` | [`api-key⁺`](#flyte-delete-api-key), [`app`](#flyte-delete-app), [`assignment⁺`](#flyte-delete-assignment), [`cluster⁺`](#flyte-delete-cluster), [`cluster-pool⁺`](#flyte-delete-cluster-pool), [`devbox`](#flyte-delete-devbox), [`local-cache`](#flyte-delete-local-cache), [`policy⁺`](#flyte-delete-policy), [`role⁺`](#flyte-delete-role), [`secret`](#flyte-delete-secret), [`trigger`](#flyte-delete-trigger), [`user⁺`](#flyte-delete-user)  |
 | [`deploy`](#flyte-deploy) | - |
@@ -103,6 +106,7 @@ This is the command line interface for Flyte.
 | `gen` | [`docs`](#flyte-gen-docs)  |
 | `get` | [`action`](#flyte-get-action), [`api-key⁺`](#flyte-get-api-key), [`app`](#flyte-get-app), [`assignment⁺`](#flyte-get-assignment), [`cluster⁺`](#flyte-get-cluster), [`cluster-pool⁺`](#flyte-get-cluster-pool), [`condition`](#flyte-get-condition), [`config`](#flyte-get-config), [`io`](#flyte-get-io), [`logs`](#flyte-get-logs), [`member⁺`](#flyte-get-member), [`policy⁺`](#flyte-get-policy), [`project`](#flyte-get-project), [`queue⁺`](#flyte-get-queue), [`role⁺`](#flyte-get-role), [`run`](#flyte-get-run), [`secret`](#flyte-get-secret), [`settings`](#flyte-get-settings), [`task`](#flyte-get-task), [`trigger`](#flyte-get-trigger), [`user⁺`](#flyte-get-user)  |
 | `prefetch` | [`hf-model`](#flyte-prefetch-hf-model)  |
+| [`rerun`](#flyte-rerun) | - |
 | `run` | [`deployed-task`](#flyte-run-deployed-task)  |
 | [`serve`](#flyte-serve) | - |
 | `signal` | [`condition`](#flyte-signal-condition)  |
@@ -261,6 +265,61 @@ flyte build --all --recursive ./src
 | {{< multiline >}}`--ignore-load-errors`
 `-i`{{< /multiline >}} | `boolean` | `False` | Ignore errors when loading environments, especially when using --recursive or --all. |
 | `--help` | `boolean` | `False` | Show this message and exit. |
+
+{{< variant union >}}
+{{< markdown >}}
+### flyte connect
+
+> **Note:** This command is provided by the [`flyteplugins.union`](#plugin-commands) plugin.
+
+**`flyte connect COMMAND [ARGS]...`**
+
+Connect your local machine to a running Flyte task.
+{{< /markdown >}}
+{{< /variant >}}
+
+{{< variant union >}}
+{{< markdown >}}
+#### flyte connect ssh
+
+> **Note:** This command is provided by the [`flyteplugins.union`](#plugin-commands) plugin.
+
+**`flyte connect ssh [OPTIONS] RUN_NAME [ACTION_NAME]`**
+
+Attach to a running ssh-debug task (launched with ``_F_E_SSH=1``).
+
+    Only RUN_NAME is required; ACTION_NAME defaults to the root action ``a0``.
+    The Bearer token is reused from a local cache between calls (no re-minting
+    every time); pass ``--refresh-token`` to force a new one.
+
+    Examples:
+
+        # Resolve + print the ssh-config for a debug run's root action
+        $ flyte connect ssh my-run
+
+        # A named host + login user, written into ~/.ssh/config
+        $ flyte connect ssh my-run --name my-run-dbg --user flyte --write-config
+
+        # Use a long-lived, user-specific API key for the tunnel auth
+        $ flyte connect ssh my-run --api-key --write-config
+
+        # Then connect (or VS Code -> Remote-SSH -> <name>)
+        $ ssh my-run-dbg
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--user` | `text` | `root` | SSH login user inside the pod. |
+| `--identity-file` | `text` |  | Private key to authenticate with. Defaults to the auto-managed ~/.flyte/ssh-debug/id_ed25519 (created for you; no ssh-keygen needed). |
+| {{< multiline >}}`--host-alias`
+`--name`{{< /multiline >}} | `text` | `flyte-debug` | Host name to use in the ~/.ssh/config block (use distinct names to keep several runs side by side). |
+| {{< multiline >}}`--api-key`
+`--no-api-key`{{< /multiline >}} | `boolean` | `False` | Authenticate the tunnel with a dedicated, long-lived API key (created/reused as `flyte-ssh-debug`) instead of your interactive session token. Survives re-logins and won't expire mid-session. |
+| `--refresh-token` | `boolean` | `False` | Force a fresh Bearer instead of reusing the cached one (use if you hit auth errors). |
+| `--write-config` | `boolean` | `False` | Write the Host block into ~/.ssh/config (replacing any prior block for the same name). |
+| `--timeout` | `float` | `300.0` | Seconds to wait for the debug route to become ready. |
+| `--help` | `boolean` | `False` | Show this message and exit. |
+{{< /markdown >}}
+{{< /variant >}}
 
 ### flyte create
 
@@ -1064,7 +1123,7 @@ Browse a Volume's metadata index in an interactive TUI.
         # Different project / domain than the CLI default.
         $ flyte explore volume my-run my-action --project p --domain d
 
-        # Already-downloaded Volume .json — no control plane round-trip.
+        # Already-downloaded Volume .json — no control-plane round-trip.
         $ flyte explore volume --from-file ./my-volume.json
 
         # Raw index file (sqlite | redis) — debug path.
@@ -1719,6 +1778,35 @@ $ flyte prefetch hf-model meta-llama/Llama-2-7b-hf --wait
 `--domain`{{< /multiline >}} | `text` |  | Domain to which this command applies. |
 | `--help` | `boolean` | `False` | Show this message and exit. |
 
+### flyte rerun
+
+**`flyte rerun [OPTIONS] RUN_NAME`**
+
+Re-run an existing run RUN_NAME with its original code and inputs.
+
+    Fetches the prior run's task + inputs from the platform (no local code needed) and launches a
+    new run that returns the same way ``flyte run`` does. To re-run with *new* local code (reusing
+    the prior run's inputs), use ``flyte run <file> <task> --rerun-from <run>``.
+
+    Examples:
+
+        $ flyte rerun ul56wcvgqrb9vzhzz5l2
+        $ flyte rerun ul56wcvgqrb9vzhzz5l2 --name retry-1 --follow
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| {{< multiline >}}`-p`
+`--project`{{< /multiline >}} | `text` |  | Project for the new run (defaults to config). |
+| {{< multiline >}}`-d`
+`--domain`{{< /multiline >}} | `text` |  | Domain for the new run (defaults to config). |
+| `--name` | `text` |  | Name for the new run (a random name is generated if unset). |
+| {{< multiline >}}`-e`
+`--env`{{< /multiline >}} | `text` | `Sentinel.UNSET` | Env var KEY=VALUE for the new run. Repeatable. |
+| `--label` | `text` | `Sentinel.UNSET` | Label KEY=VALUE for the new run. Repeatable. |
+| {{< multiline >}}`--follow`
+`-f`{{< /multiline >}} | `boolean` | `False` | Stream the parent action logs after launch. |
+| `--help` | `boolean` | `False` | Show this message and exit. |
+
 ### flyte run
 
 **`flyte run [OPTIONS] COMMAND [ARGS]...`**
@@ -1837,6 +1925,8 @@ flyte run hello.py my_task --help
 `-e`{{< /multiline >}} | `text` | `Sentinel.UNSET` | Environment variable to set on the run context. Format: KEY=VALUE. Can be specified multiple times, e.g. `-e LOG_LEVEL=debug -e FOO=bar`. |
 | `--max-action-concurrency` | `integer range` |  | Maximum number of actions that can run concurrently within the run. If not provided, the platform default (run.max_action_concurrency setting) applies. |
 | `--label` | `text` | `Sentinel.UNSET` | User-defined label to attach to the run. Format: KEY=VALUE. Can be specified multiple times, e.g. `--label team=ml --label env=prod`. |
+| `--rerun-from` | `text` |  | Re-run an existing run with THIS local code, reusing that run's inputs (no per-task input flags are needed). Remote-only. |
+| `--queue` | `text` |  | Queue (cluster) to send the run to. Overrides any queue set on the task. |
 | `--help` | `boolean` | `False` | Show this message and exit. |
 
 #### flyte run deployed-task

--- a/content/api-reference/flyte-cli.md
+++ b/content/api-reference/flyte-cli.md
@@ -303,7 +303,7 @@ Attach to a running ssh-debug task (launched with ``_F_E_SSH=1``).
         # Use a long-lived, user-specific API key for the tunnel auth
         $ flyte connect ssh my-run --api-key --write-config
 
-        # Then connect (or VS Code -> Remote-SSH -> <name>)
+        # Then connect (or VS Code -> Remote-SSH -> name)
         $ ssh my-run-dbg
 
 | Option | Type | Default | Description |

--- a/content/api-reference/flyte-cli.md
+++ b/content/api-reference/flyte-cli.md
@@ -288,23 +288,25 @@ Connect your local machine to a running Flyte task.
 
 Attach to a running ssh-debug task (launched with ``_F_E_SSH=1``).
 
-    Only RUN_NAME is required; ACTION_NAME defaults to the root action ``a0``.
-    The Bearer token is reused from a local cache between calls (no re-minting
-    every time); pass ``--refresh-token`` to force a new one.
+Only RUN_NAME is required; ACTION_NAME defaults to the root action ``a0``.
+The Bearer token is reused from a local cache between calls (no re-minting
+every time); pass ``--refresh-token`` to force a new one.
 
-    Examples:
+Examples:
 
-        # Resolve + print the ssh-config for a debug run's root action
-        $ flyte connect ssh my-run
+```bash
+# Resolve + print the ssh-config for a debug run's root action
+$ flyte connect ssh my-run
 
-        # A named host + login user, written into ~/.ssh/config
-        $ flyte connect ssh my-run --name my-run-dbg --user flyte --write-config
+# A named host + login user, written into ~/.ssh/config
+$ flyte connect ssh my-run --name my-run-dbg --user flyte --write-config
 
-        # Use a long-lived, user-specific API key for the tunnel auth
-        $ flyte connect ssh my-run --api-key --write-config
+# Use a long-lived, user-specific API key for the tunnel auth
+$ flyte connect ssh my-run --api-key --write-config
 
-        # Then connect (or VS Code -> Remote-SSH -> name)
-        $ ssh my-run-dbg
+# Then connect (or VS Code -> Remote-SSH -> <name>)
+$ ssh my-run-dbg
+```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -344,14 +346,16 @@ confused with Union Apps, which are a different construct entirely.
 
 Examples:
 
-    # Create an API key named "ci-pipeline"
-    $ flyte create api-key --name ci-pipeline
+```bash
+# Create an API key named "ci-pipeline"
+$ flyte create api-key --name ci-pipeline
 
-    # Create a locked-down key with no default policy attachments
-    $ flyte create api-key --name ci-pipeline --no-default-policies
+# Create a locked-down key with no default policy attachments
+$ flyte create api-key --name ci-pipeline --no-default-policies
 
-    # The output will include an export command like:
-    # export FLYTE_API_KEY="<base64-encoded-credentials>"
+# The output will include an export command like:
+# export FLYTE_API_KEY="<base64-encoded-credentials>"
+```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|

--- a/content/api-reference/flyte-cli.md
+++ b/content/api-reference/flyte-cli.md
@@ -312,10 +312,8 @@ $ ssh my-run-dbg
 |--------|------|---------|-------------|
 | `--user` | `text` | `root` | SSH login user inside the pod. |
 | `--identity-file` | `text` |  | Private key to authenticate with. Defaults to the auto-managed ~/.flyte/ssh-debug/id_ed25519 (created for you; no ssh-keygen needed). |
-| {{< multiline >}}`--host-alias`
-`--name`{{< /multiline >}} | `text` | `flyte-debug` | Host name to use in the ~/.ssh/config block (use distinct names to keep several runs side by side). |
-| {{< multiline >}}`--api-key`
-`--no-api-key`{{< /multiline >}} | `boolean` | `False` | Authenticate the tunnel with a dedicated, long-lived API key (created/reused as `flyte-ssh-debug`) instead of your interactive session token. Survives re-logins and won't expire mid-session. |
+| `--host-alias` / `--name` | `text` | `flyte-debug` | Host name to use in the ~/.ssh/config block (use distinct names to keep several runs side by side). |
+| `--api-key` / `--no-api-key` | `boolean` | `False` | Authenticate the tunnel with a dedicated, long-lived API key (created/reused as `flyte-ssh-debug`) instead of your interactive session token. Survives re-logins and won't expire mid-session. |
 | `--refresh-token` | `boolean` | `False` | Force a fresh Bearer instead of reusing the cached one (use if you hit auth errors). |
 | `--write-config` | `boolean` | `False` | Write the Host block into ~/.ssh/config (replacing any prior block for the same name). |
 | `--timeout` | `float` | `300.0` | Seconds to wait for the debug route to become ready. |

--- a/content/api-reference/flyte-cli.md
+++ b/content/api-reference/flyte-cli.md
@@ -178,16 +178,12 @@ $ flyte --config /path/to/config.yaml run ...
 | `--version` | `boolean` | `False` | Show the version and exit. |
 | `--endpoint` | `text` | `Sentinel.UNSET` | The endpoint to connect to. This will override any configuration file and simply use `pkce` to connect. |
 | `--insecure` | `boolean` |  | Use an insecure connection to the endpoint. If not specified, the CLI will use TLS. |
-| {{< multiline >}}`--image-builder`
-`--builder`{{< /multiline >}} | `choice` |  | Image builder to use for building images. Overrides the config file setting. If not specified, the builder from the config file (image.builder) is used, falling back to 'local'. |
+| `--image-builder` `--builder` | `choice` |  | Image builder to use for building images. Overrides the config file setting. If not specified, the builder from the config file (image.builder) is used, falling back to 'local'. |
 | `--auth-type` | `choice` |  | Authentication type to use for the Flyte backend. Defaults to 'pkce'. |
-| {{< multiline >}}`-v`
-`--verbose`{{< /multiline >}} | `integer` | `0` | Show verbose messages and exception traces. Repeating multiple times increases the verbosity (e.g., -vvv). |
+| `-v` `--verbose` | `integer` | `0` | Show verbose messages and exception traces. Repeating multiple times increases the verbosity (e.g., -vvv). |
 | `--org` | `text` | `Sentinel.UNSET` | The organization to which the command applies. |
-| {{< multiline >}}`-c`
-`--config`{{< /multiline >}} | `file` | `Sentinel.UNSET` | Path to the configuration file to use. If not specified, the default configuration file is used. |
-| {{< multiline >}}`--output-format`
-`-of`{{< /multiline >}} | `choice` | `table` | Output format for commands that support it. Defaults to 'table'. |
+| `-c` `--config` | `file` | `Sentinel.UNSET` | Path to the configuration file to use. If not specified, the default configuration file is used. |
+| `--output-format` `-of` | `choice` | `table` | Output format for commands that support it. Defaults to 'table'. |
 | `--log-format` | `choice` | `console` | Formatting for logs, defaults to 'console' which is meant to be human readable. 'json' is meant for machine parsing. |
 | `--user-log-level` | `choice` | `info` | Log level for user task logs. Independent of the internal Flyte log level (-v). |
 | `--reset-root-logger` | `boolean` | `False` | If set, the root logger will be reset to use Flyte logging style |
@@ -209,10 +205,8 @@ Abort an action associated with a run.
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `--reason` | `text` | `Manually aborted from the CLI` | The reason to abort the run. |
-| {{< multiline >}}`-p`
-`--project`{{< /multiline >}} | `text` |  | Project to which this command applies. |
-| {{< multiline >}}`-d`
-`--domain`{{< /multiline >}} | `text` |  | Domain to which this command applies. |
+| `-p` `--project` | `text` |  | Project to which this command applies. |
+| `-d` `--domain` | `text` |  | Domain to which this command applies. |
 | `--help` | `boolean` | `False` | Show this message and exit. |
 
 #### flyte abort run
@@ -224,10 +218,8 @@ Abort a run.
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `--reason` | `text` | `Manually aborted from the CLI` | The reason to abort the run. |
-| {{< multiline >}}`-p`
-`--project`{{< /multiline >}} | `text` |  | Project to which this command applies. |
-| {{< multiline >}}`-d`
-`--domain`{{< /multiline >}} | `text` |  | Domain to which this command applies. |
+| `-p` `--project` | `text` |  | Project to which this command applies. |
+| `-d` `--domain` | `text` |  | Domain to which this command applies. |
 | `--help` | `boolean` | `False` | Show this message and exit. |
 
 ### flyte build
@@ -259,11 +251,9 @@ flyte build --all --recursive ./src
 |--------|------|---------|-------------|
 | `--copy-style` | `choice` | `loaded_modules` | Copy style of the eventual deploy. Must match the deploy's --copy-style so the image content hash — and therefore the registry tag — lines up. |
 | `--root-dir` | `text` | `Sentinel.UNSET` | Override the root source directory, helpful when working with monorepos. |
-| {{< multiline >}}`--recursive`
-`-r`{{< /multiline >}} | `boolean` | `False` | Recursively build all environments in the current directory and its subdirectories. |
+| `--recursive` `-r` | `boolean` | `False` | Recursively build all environments in the current directory and its subdirectories. |
 | `--all` | `boolean` | `False` | Build the images for all environments in the file or directory, ignoring the file name. |
-| {{< multiline >}}`--ignore-load-errors`
-`-i`{{< /multiline >}} | `boolean` | `False` | Ignore errors when loading environments, especially when using --recursive or --all. |
+| `--ignore-load-errors` `-i` | `boolean` | `False` | Ignore errors when loading environments, especially when using --recursive or --all. |
 | `--help` | `boolean` | `False` | Show this message and exit. |
 
 {{< variant union >}}
@@ -312,8 +302,8 @@ $ ssh my-run-dbg
 |--------|------|---------|-------------|
 | `--user` | `text` | `root` | SSH login user inside the pod. |
 | `--identity-file` | `text` |  | Private key to authenticate with. Defaults to the auto-managed ~/.flyte/ssh-debug/id_ed25519 (created for you; no ssh-keygen needed). |
-| `--host-alias` / `--name` | `text` | `flyte-debug` | Host name to use in the ~/.ssh/config block (use distinct names to keep several runs side by side). |
-| `--api-key` / `--no-api-key` | `boolean` | `False` | Authenticate the tunnel with a dedicated, long-lived API key (created/reused as `flyte-ssh-debug`) instead of your interactive session token. Survives re-logins and won't expire mid-session. |
+| `--host-alias` `--name` | `text` | `flyte-debug` | Host name to use in the ~/.ssh/config block (use distinct names to keep several runs side by side). |
+| `--api-key` `--no-api-key` | `boolean` | `False` | Authenticate the tunnel with a dedicated, long-lived API key (created/reused as `flyte-ssh-debug`) instead of your interactive session token. Survives re-logins and won't expire mid-session. |
 | `--refresh-token` | `boolean` | `False` | Force a fresh Bearer instead of reusing the cached one (use if you hit auth errors). |
 | `--write-config` | `boolean` | `False` | Write the Host block into ~/.ssh/config (replacing any prior block for the same name). |
 | `--timeout` | `float` | `300.0` | Seconds to wait for the debug route to become ready. |
@@ -373,13 +363,15 @@ $ flyte create api-key --name ci-pipeline --no-default-policies
 
 Assign a policy to an identity.
 
-    Exactly one of --user-subject, --creds-subject, or --email must be provided.
+Exactly one of --user-subject, --creds-subject, or --email must be provided.
 
-    Examples:
+Examples:
 
-        $ flyte --org my-org create assignment --user-subject user-123 --policy admin
-        $ flyte --org my-org create assignment --creds-subject app-456 --policy admin
-        $ flyte --org my-org create assignment --email jane@example.com --policy admin
+```bash
+$ flyte --org my-org create assignment --user-subject user-123 --policy admin
+$ flyte --org my-org create assignment --creds-subject app-456 --policy admin
+$ flyte --org my-org create assignment --email jane@example.com --policy admin
+```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -401,11 +393,13 @@ Assign a policy to an identity.
 
 Register a new cluster.
 
-    Examples:
+Examples:
 
-        $ flyte create cluster my-cluster
+```bash
+$ flyte create cluster my-cluster
 
-        $ flyte create cluster my-cluster --pool my-pool
+$ flyte create cluster my-cluster --pool my-pool
+```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -424,14 +418,16 @@ Register a new cluster.
 
 Create a cluster pool.
 
-    A cluster pool holds the object store / secret store / image registry config
-    shared by its member clusters. Requires --file or --edit to supply the config.
+A cluster pool holds the object store / secret store / image registry config
+shared by its member clusters. Requires --file or --edit to supply the config.
 
-    Examples:
+Examples:
 
-        $ flyte create cluster-pool my-pool --edit
+```bash
+$ flyte create cluster-pool my-pool --edit
 
-        $ flyte create cluster-pool my-pool --file pool.yaml
+$ flyte create cluster-pool my-pool --file pool.yaml
+```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -454,17 +450,13 @@ If the file already exists, it will raise an error unless the `--force` option i
 | `--endpoint` | `text` | `Sentinel.UNSET` | Endpoint of the Flyte backend. |
 | `--insecure` | `boolean` | `False` | Use an insecure connection to the Flyte backend. |
 | `--org` | `text` | `Sentinel.UNSET` | Organization to use. This will override the organization in the configuration file. |
-| {{< multiline >}}`-o`
-`--output`{{< /multiline >}} | `path` | `.flyte/config.yaml` | Path to the output directory where the configuration will be saved. Defaults to current directory. |
+| `-o` `--output` | `path` | `.flyte/config.yaml` | Path to the output directory where the configuration will be saved. Defaults to current directory. |
 | `--force` | `boolean` | `False` | Force overwrite of the configuration file if it already exists. |
-| {{< multiline >}}`--image-builder`
-`--builder`{{< /multiline >}} | `choice` | `local` | Image builder to use for building images. Defaults to 'local'. |
+| `--image-builder` `--builder` | `choice` | `local` | Image builder to use for building images. Defaults to 'local'. |
 | `--auth-type` | `choice` |  | Authentication type to use for the Flyte backend. Defaults to 'pkce'. |
 | `--local-persistence` | `boolean` | `False` | Enable SQLite persistence for local run metadata, allowing past runs to be browsed via 'flyte start tui'. |
-| {{< multiline >}}`-p`
-`--project`{{< /multiline >}} | `text` |  | Project to which this command applies. |
-| {{< multiline >}}`-d`
-`--domain`{{< /multiline >}} | `text` |  | Domain to which this command applies. |
+| `-p` `--project` | `text` |  | Project to which this command applies. |
+| `-d` `--domain` | `text` |  | Domain to which this command applies. |
 | `--help` | `boolean` | `False` | Show this message and exit. |
 
 {{< variant union >}}
@@ -477,12 +469,14 @@ If the file already exists, it will raise an error unless the `--force` option i
 
 Create a policy.
 
-    Requires --file or --edit to specify bindings for the policy.
+Requires --file or --edit to specify bindings for the policy.
 
-    Examples:
+Examples:
 
-        $ flyte --org my-org create policy my-policy --edit
-        $ flyte --org my-org create policy my-policy --file policy.yaml
+```bash
+$ flyte --org my-org create policy my-policy --edit
+$ flyte --org my-org create policy my-policy --file policy.yaml
+```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -511,8 +505,7 @@ flyte create project --id my_project_id --name "My Project" --description "My pr
 | `--id` | `text` | `Sentinel.UNSET` | Unique identifier for the project (immutable). |
 | `--name` | `text` | `Sentinel.UNSET` | Display name for the project. |
 | `--description` | `text` | `` | Description for the project. |
-| {{< multiline >}}`--label`
-`-l`{{< /multiline >}} | `text` | `Sentinel.UNSET` | Labels as key=value pairs. Can be specified multiple times. |
+| `--label` `-l` | `text` | `Sentinel.UNSET` | Labels as key=value pairs. Can be specified multiple times. |
 | `--help` | `boolean` | `False` | Show this message and exit. |
 
 {{< variant union >}}
@@ -525,21 +518,23 @@ flyte create project --id my_project_id --name "My Project" --description "My pr
 
 Create a scheduling queue.
 
-    Examples:
+Examples:
 
-        $ flyte create queue my-queue --run-concurrency 100 --action-concurrency 1000
+```bash
+$ flyte create queue my-queue --run-concurrency 100 --action-concurrency 1000
 
-        $ flyte create queue gpu-queue --run-concurrency 50 --action-concurrency 500 \
-            --priority min --cluster gpu-cluster-1
+$ flyte create queue gpu-queue --run-concurrency 50 --action-concurrency 500 \
+    --priority min --cluster gpu-cluster-1
 
-        $ flyte create queue pool-queue --run-concurrency 50 --action-concurrency 500 \
-            --cluster-pool gpu-pool
+$ flyte create queue pool-queue --run-concurrency 50 --action-concurrency 500 \
+    --cluster-pool gpu-pool
 
-        $ flyte create queue backfill --run-concurrency 10 --action-concurrency 100 \
-            --depth 5000 --priority max
+$ flyte create queue backfill --run-concurrency 10 --action-concurrency 100 \
+    --depth 5000 --priority max
 
-        $ flyte create queue team-queue --run-concurrency 100 --action-concurrency 1000 \
-            --project my-project --domain production
+$ flyte create queue team-queue --run-concurrency 100 --action-concurrency 1000 \
+    --project my-project --domain production
+```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -566,12 +561,14 @@ Create a scheduling queue.
 
 Create a role.
 
-    Requires --file or --edit to specify actions for the role.
+Requires --file or --edit to specify actions for the role.
 
-    Examples:
+Examples:
 
-        $ flyte --org my-org create role my-role --edit
-        $ flyte --org my-org create role my-role --file role.yaml
+```bash
+$ flyte --org my-org create role my-role --edit
+$ flyte --org my-org create role my-role --file role.yaml
+```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -642,10 +639,8 @@ $ flyte create secret my_secret --type image_pull --from-docker-config --registr
 | `--username` | `text` | `Sentinel.UNSET` | Username for the registry (only with --registry). |
 | `--password` | `text` | `Sentinel.UNSET` | Password for the registry (only with --registry). If not provided, will prompt. |
 | `--cluster-pool` | `text` |  | Scope the secret to a cluster pool. Mutually exclusive with --project and --domain. Mutually exclusive with project, domain. |
-| {{< multiline >}}`-p`
-`--project`{{< /multiline >}} | `text` |  | Project to which this command applies. |
-| {{< multiline >}}`-d`
-`--domain`{{< /multiline >}} | `text` |  | Domain to which this command applies. |
+| `-p` `--project` | `text` |  | Project to which this command applies. |
+| `-d` `--domain` | `text` |  | Domain to which this command applies. |
 | `--help` | `boolean` | `False` | Show this message and exit. |
 
 #### flyte create trigger
@@ -668,10 +663,8 @@ This will create a trigger that runs every day at midnight.
 | `--description` | `text` | `` | Description of the trigger. |
 | `--auto-activate` | `boolean` | `True` | Whether the trigger should not be automatically activated. Defaults to True. |
 | `--trigger-time-var` | `text` | `trigger_time` | Variable name for the trigger time in the task inputs. Defaults to 'trigger_time'. |
-| {{< multiline >}}`-p`
-`--project`{{< /multiline >}} | `text` |  | Project to which this command applies. |
-| {{< multiline >}}`-d`
-`--domain`{{< /multiline >}} | `text` |  | Domain to which this command applies. |
+| `-p` `--project` | `text` |  | Project to which this command applies. |
+| `-d` `--domain` | `text` |  | Domain to which this command applies. |
 | `--help` | `boolean` | `False` | Show this message and exit. |
 
 {{< variant union >}}
@@ -684,10 +677,12 @@ This will create a trigger that runs every day at midnight.
 
 Create (invite) a new user.
 
-    Examples:
+Examples:
 
-        $ flyte --org my-org create user --first-name Jane --last-name Doe --email jane@example.com
-        $ flyte --org my-org create user --first-name Jane --last-name Doe --email jane@example.com --policy admin
+```bash
+$ flyte --org my-org create user --first-name Jane --last-name Doe --email jane@example.com
+$ flyte --org my-org create user --first-name Jane --last-name Doe --email jane@example.com --policy admin
+```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -717,11 +712,13 @@ Delete an API key.
 
 Examples:
 
-    # Delete an API key (with confirmation)
-    $ flyte delete api-key my-client-id
+```bash
+# Delete an API key (with confirmation)
+$ flyte delete api-key my-client-id
 
-    # Delete without confirmation
-    $ flyte delete api-key my-client-id --yes
+# Delete without confirmation
+$ flyte delete api-key my-client-id --yes
+```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -738,10 +735,8 @@ Delete apps from a Flyte deployment.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| {{< multiline >}}`-p`
-`--project`{{< /multiline >}} | `text` |  | Project to which this command applies. |
-| {{< multiline >}}`-d`
-`--domain`{{< /multiline >}} | `text` |  | Domain to which this command applies. |
+| `-p` `--project` | `text` |  | Project to which this command applies. |
+| `-d` `--domain` | `text` |  | Domain to which this command applies. |
 | `--help` | `boolean` | `False` | Show this message and exit. |
 
 {{< variant union >}}
@@ -754,12 +749,14 @@ Delete apps from a Flyte deployment.
 
 Unassign a policy from an identity.
 
-    One of --user-subject or --creds-subject must be provided.
+One of --user-subject or --creds-subject must be provided.
 
-    Examples:
+Examples:
 
-        $ flyte --org my-org delete assignment --user-subject user-123 --policy admin
-        $ flyte --org my-org delete assignment --creds-subject app-456 --policy admin
+```bash
+$ flyte --org my-org delete assignment --user-subject user-123 --policy admin
+$ flyte --org my-org delete assignment --creds-subject app-456 --policy admin
+```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -781,11 +778,13 @@ Unassign a policy from an identity.
 
 Delete a cluster.
 
-    Examples:
+Examples:
 
-        $ flyte delete cluster my-cluster
+```bash
+$ flyte delete cluster my-cluster
 
-        $ flyte delete cluster my-cluster --yes
+$ flyte delete cluster my-cluster --yes
+```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -804,11 +803,13 @@ Delete a cluster.
 
 Delete a cluster pool.
 
-    Examples:
+Examples:
 
-        $ flyte delete cluster-pool my-pool
+```bash
+$ flyte delete cluster-pool my-pool
 
-        $ flyte delete cluster-pool my-pool --yes
+$ flyte delete cluster-pool my-pool --yes
+```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -847,10 +848,12 @@ run history, and task caching.
 
 Delete a policy.
 
-    Examples:
+Examples:
 
-        $ flyte --org my-org delete policy my-policy
-        $ flyte --org my-org delete policy my-policy --yes
+```bash
+$ flyte --org my-org delete policy my-policy
+$ flyte --org my-org delete policy my-policy --yes
+```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -869,10 +872,12 @@ Delete a policy.
 
 Delete a role.
 
-    Examples:
+Examples:
 
-        $ flyte --org my-org delete role my-role
-        $ flyte --org my-org delete role my-role --yes
+```bash
+$ flyte --org my-org delete role my-role
+$ flyte --org my-org delete role my-role --yes
+```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -890,10 +895,8 @@ Delete a secret. The name of the secret is required.
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `--cluster-pool` | `text` |  | Scope the secret to a cluster pool. Mutually exclusive with --project and --domain. Mutually exclusive with project, domain. |
-| {{< multiline >}}`-p`
-`--project`{{< /multiline >}} | `text` |  | Project to which this command applies. |
-| {{< multiline >}}`-d`
-`--domain`{{< /multiline >}} | `text` |  | Domain to which this command applies. |
+| `-p` `--project` | `text` |  | Project to which this command applies. |
+| `-d` `--domain` | `text` |  | Domain to which this command applies. |
 | `--help` | `boolean` | `False` | Show this message and exit. |
 
 #### flyte delete trigger
@@ -904,10 +907,8 @@ Delete a trigger. The name of the trigger is required.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| {{< multiline >}}`-p`
-`--project`{{< /multiline >}} | `text` |  | Project to which this command applies. |
-| {{< multiline >}}`-d`
-`--domain`{{< /multiline >}} | `text` |  | Domain to which this command applies. |
+| `-p` `--project` | `text` |  | Project to which this command applies. |
+| `-d` `--domain` | `text` |  | Domain to which this command applies. |
 | `--help` | `boolean` | `False` | Show this message and exit. |
 
 {{< variant union >}}
@@ -920,10 +921,12 @@ Delete a trigger. The name of the trigger is required.
 
 Delete a user.
 
-    Examples:
+Examples:
 
-        $ flyte --org my-org delete user user-subject-id
-        $ flyte --org my-org delete user user-subject-id --yes
+```bash
+$ flyte --org my-org delete user user-subject-id
+$ flyte --org my-org delete user user-subject-id --yes
+```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -1030,20 +1033,15 @@ flyte deploy hello.py --help
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| {{< multiline >}}`-p`
-`--project`{{< /multiline >}} | `text` |  | Project to which this command applies. |
-| {{< multiline >}}`-d`
-`--domain`{{< /multiline >}} | `text` |  | Domain to which this command applies. |
+| `-p` `--project` | `text` |  | Project to which this command applies. |
+| `-d` `--domain` | `text` |  | Domain to which this command applies. |
 | `--version` | `text` | `Sentinel.UNSET` | Version of the environment to deploy |
-| {{< multiline >}}`--dry-run`
-`--dryrun`{{< /multiline >}} | `boolean` | `False` | Dry run. Do not actually call the backend service. |
+| `--dry-run` `--dryrun` | `boolean` | `False` | Dry run. Do not actually call the backend service. |
 | `--copy-style` | `choice` | `loaded_modules` | Copy style to use when running the task |
 | `--root-dir` | `text` | `Sentinel.UNSET` | Override the root source directory, helpful when working with monorepos. |
-| {{< multiline >}}`--recursive`
-`-r`{{< /multiline >}} | `boolean` | `False` | Recursively deploy all environments in the current directory |
+| `--recursive` `-r` | `boolean` | `False` | Recursively deploy all environments in the current directory |
 | `--all` | `boolean` | `False` | Deploy all environments in the current directory, ignoring the file name |
-| {{< multiline >}}`--ignore-load-errors`
-`-i`{{< /multiline >}} | `boolean` | `False` | Ignore errors when loading environments especially when using --recursive or --all. |
+| `--ignore-load-errors` `-i` | `boolean` | `False` | Ignore errors when loading environments especially when using --recursive or --all. |
 | `--no-sync-local-sys-paths` | `boolean` | `False` | Disable synchronization of local sys.path entries under the root directory to the remote container. |
 | `--image` | `text` | `Sentinel.UNSET` | Image to be used in the run. Format: imagename=imageuri. Can be specified multiple times. |
 | `--help` | `boolean` | `False` | Show this message and exit. |
@@ -1058,31 +1056,28 @@ flyte deploy hello.py --help
 
 Edit hierarchical settings interactively — or apply a YAML file directly.
 
-    **Interactive mode** (default). Opens settings in your ``$EDITOR``. Three
-    comment tiers appear:
+**Interactive mode** (default). Opens settings in your ``$EDITOR``. Three
+comment tiers appear:
 
-    - ``###`` section headers and the scope line
-    - ``##`` per-field descriptions and inline metadata
-    - ``#`` inactive settings (uncomment the single ``#`` to activate)
+- ``###`` section headers and the scope line
+- ``##`` per-field descriptions and inline metadata
+- ``#`` inactive settings (uncomment the single ``#`` to activate)
 
-    If the edited YAML fails to parse, the editor reopens with an error
-    header so you can fix the syntax without losing your edits. If you
-    decline to reopen — or if the server rejects the update — your buffer
-    is saved under ``~/.flyte/settings-edit-<timestamp>.yaml``.
+If the edited YAML fails to parse, the editor reopens with an error
+header so you can fix the syntax without losing your edits. If you
+decline to reopen — or if the server rejects the update — your buffer
+is saved under ``~/.flyte/settings-edit-<timestamp>.yaml``.
 
-    **Non-interactive mode**: pass ``--from-file <path>`` to skip the editor
-    entirely. The file's contents are parsed, the diff is printed, and the
-    overrides are applied without a confirmation prompt. Ideal for
-    CI/automation.
+**Non-interactive mode**: pass ``--from-file <path>`` to skip the editor
+entirely. The file's contents are parsed, the diff is printed, and the
+overrides are applied without a confirmation prompt. Ideal for
+CI/automation.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| {{< multiline >}}`--from-file`
-`-f`{{< /multiline >}} | `file` |  | Apply overrides from a YAML file and skip the editor. The file can be produced by `flyte get settings` (comment markers are honoured) or be a plain YAML mapping of flat dot-notation keys to values. |
-| {{< multiline >}}`-p`
-`--project`{{< /multiline >}} | `text` |  | Project to which this command applies. |
-| {{< multiline >}}`-d`
-`--domain`{{< /multiline >}} | `text` |  | Domain to which this command applies. |
+| `--from-file` `-f` | `file` |  | Apply overrides from a YAML file and skip the editor. The file can be produced by `flyte get settings` (comment markers are honoured) or be a plain YAML mapping of flat dot-notation keys to values. |
+| `-p` `--project` | `text` |  | Project to which this command applies. |
+| `-d` `--domain` | `text` |  | Domain to which this command applies. |
 | `--help` | `boolean` | `False` | Show this message and exit. |
 
 {{< variant union >}}
@@ -1107,29 +1102,31 @@ Explore artifacts produced by Flyte runs.
 
 Browse a Volume's metadata index in an interactive TUI.
 
-    Only RUN_NAME is required: ACTION_NAME defaults to the root action
-    ``a0``, and when ``--op-name`` is omitted the action's outputs are
-    searched for a Volume, then its inputs.
+Only RUN_NAME is required: ACTION_NAME defaults to the root action
+``a0``, and when ``--op-name`` is omitted the action's outputs are
+searched for a Volume, then its inputs.
 
-    Examples:
+Examples:
 
-        # Root action's Volume, auto-discovered.
-        $ flyte explore volume my-run
+```bash
+# Root action's Volume, auto-discovered.
+$ flyte explore volume my-run
 
-        # A specific action; still auto-discovers the Volume op.
-        $ flyte explore volume my-run my-action
+# A specific action; still auto-discovers the Volume op.
+$ flyte explore volume my-run my-action
 
-        # Pin the exact output (or input) to explore.
-        $ flyte explore volume my-run my-action --op-name ckpt
+# Pin the exact output (or input) to explore.
+$ flyte explore volume my-run my-action --op-name ckpt
 
-        # Different project / domain than the CLI default.
-        $ flyte explore volume my-run my-action --project p --domain d
+# Different project / domain than the CLI default.
+$ flyte explore volume my-run my-action --project p --domain d
 
-        # Already-downloaded Volume .json — no control-plane round-trip.
-        $ flyte explore volume --from-file ./my-volume.json
+# Already-downloaded Volume .json — no control-plane round-trip.
+$ flyte explore volume --from-file ./my-volume.json
 
-        # Raw index file (sqlite | redis) — debug path.
-        $ flyte explore volume --from-file ./index.db --store-type sqlite
+# Raw index file (sqlite | redis) — debug path.
+$ flyte explore volume --from-file ./index.db --store-type sqlite
+```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -1159,10 +1156,8 @@ Generate documentation.
 |--------|------|---------|-------------|
 | `--type` | `text` | `Sentinel.UNSET` | Type of documentation (valid: markdown) |
 | `--plugin-variants` | `text` |  | Hugo variant names for plugin commands (e.g., 'union'). When set, plugin command sections and index entries are wrapped in {{&lt; variant >}} shortcodes. Core commands appear unconditionally. |
-| {{< multiline >}}`-p`
-`--project`{{< /multiline >}} | `text` |  | Project to which this command applies. |
-| {{< multiline >}}`-d`
-`--domain`{{< /multiline >}} | `text` |  | Domain to which this command applies. |
+| `-p` `--project` | `text` |  | Project to which this command applies. |
+| `-d` `--domain` | `text` |  | Domain to which this command applies. |
 | `--help` | `boolean` | `False` | Show this message and exit. |
 
 ### flyte get
@@ -1196,10 +1191,8 @@ Get all actions for a run or details for a specific action.
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `--in-phase` | `choice` | `Sentinel.UNSET` | Filter actions by their phase. |
-| {{< multiline >}}`-p`
-`--project`{{< /multiline >}} | `text` |  | Project to which this command applies. |
-| {{< multiline >}}`-d`
-`--domain`{{< /multiline >}} | `text` |  | Domain to which this command applies. |
+| `-p` `--project` | `text` |  | Project to which this command applies. |
+| `-d` `--domain` | `text` |  | Domain to which this command applies. |
 | `--help` | `boolean` | `False` | Show this message and exit. |
 
 {{< variant union >}}
@@ -1217,14 +1210,16 @@ Otherwise, lists all API keys.
 
 Examples:
 
-    # List all API keys
-    $ flyte get api-key
+```bash
+# List all API keys
+$ flyte get api-key
 
-    # List with a limit
-    $ flyte get api-key --limit 10
+# List with a limit
+$ flyte get api-key --limit 10
 
-    # Get a specific API key
-    $ flyte get api-key my-client-id
+# Get a specific API key
+$ flyte get api-key my-client-id
+```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -1245,10 +1240,8 @@ Apps are long-running services deployed on the Flyte platform.
 |--------|------|---------|-------------|
 | `--limit` | `integer` | `100` | Limit the number of apps to fetch when listing. |
 | `--only-mine` | `boolean` | `False` | Show only apps created by the current user (you). |
-| {{< multiline >}}`-p`
-`--project`{{< /multiline >}} | `text` |  | Project to which this command applies. |
-| {{< multiline >}}`-d`
-`--domain`{{< /multiline >}} | `text` |  | Domain to which this command applies. |
+| `-p` `--project` | `text` |  | Project to which this command applies. |
+| `-d` `--domain` | `text` |  | Domain to which this command applies. |
 | `--help` | `boolean` | `False` | Show this message and exit. |
 
 {{< variant union >}}
@@ -1261,13 +1254,15 @@ Apps are long-running services deployed on the Flyte platform.
 
 Get or list assignments.
 
-    Without --user-subject or --creds-subject, lists all assignments.
+Without --user-subject or --creds-subject, lists all assignments.
 
-    Examples:
+Examples:
 
-        $ flyte --org my-org get assignment
-        $ flyte --org my-org get assignment --user-subject user-123
-        $ flyte --org my-org get assignment --creds-subject app-456
+```bash
+$ flyte --org my-org get assignment
+$ flyte --org my-org get assignment --user-subject user-123
+$ flyte --org my-org get assignment --creds-subject app-456
+```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -1287,14 +1282,16 @@ Get or list assignments.
 
 Get a cluster or list all clusters.
 
-    If NAME is provided, fetch that specific cluster and render a detailed view.
-    Otherwise list all clusters.
+If NAME is provided, fetch that specific cluster and render a detailed view.
+Otherwise list all clusters.
 
-    Examples:
+Examples:
 
-        $ flyte get cluster
+```bash
+$ flyte get cluster
 
-        $ flyte get cluster my-cluster
+$ flyte get cluster my-cluster
+```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -1313,13 +1310,15 @@ Get a cluster or list all clusters.
 
 Get or list cluster pools.
 
-    If NAME is provided, gets a specific pool. Otherwise, lists all pools.
+If NAME is provided, gets a specific pool. Otherwise, lists all pools.
 
-    Examples:
+Examples:
 
-        $ flyte get cluster-pool
+```bash
+$ flyte get cluster-pool
 
-        $ flyte get cluster-pool my-pool
+$ flyte get cluster-pool my-pool
+```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -1341,10 +1340,8 @@ resolve one.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| {{< multiline >}}`-p`
-`--project`{{< /multiline >}} | `text` |  | Project to which this command applies. |
-| {{< multiline >}}`-d`
-`--domain`{{< /multiline >}} | `text` |  | Domain to which this command applies. |
+| `-p` `--project` | `text` |  | Project to which this command applies. |
+| `-d` `--domain` | `text` |  | Domain to which this command applies. |
 | `--help` | `boolean` | `False` | Show this message and exit. |
 
 #### flyte get config
@@ -1376,14 +1373,10 @@ $ flyte get io my_run my_action
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| {{< multiline >}}`--inputs-only`
-`-i`{{< /multiline >}} | `boolean` | `False` | Show only inputs |
-| {{< multiline >}}`--outputs-only`
-`-o`{{< /multiline >}} | `boolean` | `False` | Show only outputs |
-| {{< multiline >}}`-p`
-`--project`{{< /multiline >}} | `text` |  | Project to which this command applies. |
-| {{< multiline >}}`-d`
-`--domain`{{< /multiline >}} | `text` |  | Domain to which this command applies. |
+| `--inputs-only` `-i` | `boolean` | `False` | Show only inputs |
+| `--outputs-only` `-o` | `boolean` | `False` | Show only outputs |
+| `-p` `--project` | `text` |  | Project to which this command applies. |
+| `-d` `--domain` | `text` |  | Domain to which this command applies. |
 | `--help` | `boolean` | `False` | Show this message and exit. |
 
 #### flyte get logs
@@ -1412,17 +1405,13 @@ $ flyte get logs my_run my_action --pretty --lines 50
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| {{< multiline >}}`--lines`
-`-l`{{< /multiline >}} | `integer` | `30` | Number of lines to show, only useful for --pretty |
+| `--lines` `-l` | `integer` | `30` | Number of lines to show, only useful for --pretty |
 | `--show-ts` | `boolean` | `False` | Show timestamps |
 | `--pretty` | `boolean` | `False` | Show logs in an auto-scrolling box, where number of lines is limited to `--lines` |
-| {{< multiline >}}`--attempt`
-`-a`{{< /multiline >}} | `integer` |  | Attempt number to show logs for, defaults to the latest attempt. |
+| `--attempt` `-a` | `integer` |  | Attempt number to show logs for, defaults to the latest attempt. |
 | `--filter-system` | `boolean` | `False` | Filter all system logs from the output. |
-| {{< multiline >}}`-p`
-`--project`{{< /multiline >}} | `text` |  | Project to which this command applies. |
-| {{< multiline >}}`-d`
-`--domain`{{< /multiline >}} | `text` |  | Domain to which this command applies. |
+| `-p` `--project` | `text` |  | Project to which this command applies. |
+| `-d` `--domain` | `text` |  | Domain to which this command applies. |
 | `--help` | `boolean` | `False` | Show this message and exit. |
 
 {{< variant union >}}
@@ -1435,9 +1424,11 @@ $ flyte get logs my_run my_action --pretty --lines 50
 
 List all members (users and applications) in an organization.
 
-    Examples:
+Examples:
 
-        $ flyte --org my-org get member
+```bash
+$ flyte --org my-org get member
+```
 {{< /markdown >}}
 {{< /variant >}}
 
@@ -1451,13 +1442,15 @@ List all members (users and applications) in an organization.
 
 Get or list policies.
 
-    If NAME is provided, gets a specific policy. Otherwise, lists all policies.
+If NAME is provided, gets a specific policy. Otherwise, lists all policies.
 
-    Examples:
+Examples:
 
-        $ flyte --org my-org get policy
-        $ flyte --org my-org get policy --limit 10
-        $ flyte --org my-org get policy my-policy
+```bash
+$ flyte --org my-org get policy
+$ flyte --org my-org get policy --limit 10
+$ flyte --org my-org get policy my-policy
+```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -1490,17 +1483,19 @@ show archived projects instead.
 
 Get a queue or list all queues.
 
-    If NAME is provided, fetch that specific queue with its current metrics.
-    Use --watch to stream live metrics with progress bars.
-    Otherwise list all queues.
+If NAME is provided, fetch that specific queue with its current metrics.
+Use --watch to stream live metrics with progress bars.
+Otherwise list all queues.
 
-    Examples:
+Examples:
 
-        $ flyte get queue
+```bash
+$ flyte get queue
 
-        $ flyte get queue my-queue
+$ flyte get queue my-queue
 
-        $ flyte get queue my-queue --watch
+$ flyte get queue my-queue --watch
+```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -1522,13 +1517,15 @@ Get a queue or list all queues.
 
 Get or list roles.
 
-    If NAME is provided, gets a specific role. Otherwise, lists all roles.
+If NAME is provided, gets a specific role. Otherwise, lists all roles.
 
-    Examples:
+Examples:
 
-        $ flyte --org my-org get role
-        $ flyte --org my-org get role --limit 10
-        $ flyte --org my-org get role my-role
+```bash
+$ flyte --org my-org get role
+$ flyte --org my-org get role --limit 10
+$ flyte --org my-org get role my-role
+```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -1561,11 +1558,18 @@ $ flyte get run --with-label team=ml --with-label env=prod
 $ flyte get run --with-label-key team
 ```
 
+You can show only runs that have a paused action (waiting on a human in the loop):
+
+```bash
+$ flyte get run --paused-only
+```
+
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `--limit` | `integer` | `100` | Limit the number of runs to fetch when listing. |
 | `--in-phase` | `choice` | `Sentinel.UNSET` | Filter runs by their status. |
 | `--only-mine` | `boolean` | `False` | Show only runs created by the current user (you). |
+| `--paused-only` | `boolean` | `False` | Show only runs that have a paused action (waiting on a human in the loop). |
 | `--task-name` | `text` |  | Filter runs by task name. |
 | `--task-version` | `text` |  | Filter runs by task version. |
 | `--created-after` | `datetime` |  | Show runs created at or after this datetime (UTC). Accepts ISO dates, 'now', 'today', or 'now - 1 day'. |
@@ -1574,10 +1578,8 @@ $ flyte get run --with-label-key team
 | `--updated-before` | `datetime` |  | Show runs updated before this datetime (UTC). |
 | `--with-label` | `text` | `()` | Filter runs that have this label key=value. Can be specified multiple times (AND semantics). |
 | `--with-label-key` | `text` | `()` | Filter runs that have this label key present (existence check). Can be specified multiple times. |
-| {{< multiline >}}`-p`
-`--project`{{< /multiline >}} | `text` |  | Project to which this command applies. |
-| {{< multiline >}}`-d`
-`--domain`{{< /multiline >}} | `text` |  | Domain to which this command applies. |
+| `-p` `--project` | `text` |  | Project to which this command applies. |
+| `-d` `--domain` | `text` |  | Domain to which this command applies. |
 | `--help` | `boolean` | `False` | Show this message and exit. |
 
 #### flyte get secret
@@ -1589,10 +1591,8 @@ Get a list of all secrets, or details of a specific secret by name.
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `--cluster-pool` | `text` |  | Scope the secret to a cluster pool. Mutually exclusive with --project and --domain. Mutually exclusive with project, domain. |
-| {{< multiline >}}`-p`
-`--project`{{< /multiline >}} | `text` |  | Project to which this command applies. |
-| {{< multiline >}}`-d`
-`--domain`{{< /multiline >}} | `text` |  | Domain to which this command applies. |
+| `-p` `--project` | `text` |  | Project to which this command applies. |
+| `-d` `--domain` | `text` |  | Domain to which this command applies. |
 | `--help` | `boolean` | `False` | Show this message and exit. |
 
 #### flyte get settings
@@ -1632,12 +1632,9 @@ Use `flyte edit settings` to interactively modify these values.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| {{< multiline >}}`--to-file`
-`-o`{{< /multiline >}} | `file` |  | Write the scope's YAML to this file instead of printing it. The file round-trips through `flyte edit settings --from-file`. |
-| {{< multiline >}}`-p`
-`--project`{{< /multiline >}} | `text` |  | Project to which this command applies. |
-| {{< multiline >}}`-d`
-`--domain`{{< /multiline >}} | `text` |  | Domain to which this command applies. |
+| `--to-file` `-o` | `file` |  | Write the scope's YAML to this file instead of printing it. The file round-trips through `flyte edit settings --from-file`. |
+| `-p` `--project` | `text` |  | Project to which this command applies. |
+| `-d` `--domain` | `text` |  | Domain to which this command applies. |
 | `--help` | `boolean` | `False` | Show this message and exit. |
 
 #### flyte get task
@@ -1652,10 +1649,8 @@ Currently, both `name` and `version` are required to get a specific task.
 |--------|------|---------|-------------|
 | `--limit` | `integer` | `100` | Limit the number of tasks to fetch. |
 | `--entrypoint` | `boolean` | `False` | Show only entrypoint tasks. |
-| {{< multiline >}}`-p`
-`--project`{{< /multiline >}} | `text` |  | Project to which this command applies. |
-| {{< multiline >}}`-d`
-`--domain`{{< /multiline >}} | `text` |  | Domain to which this command applies. |
+| `-p` `--project` | `text` |  | Project to which this command applies. |
+| `-d` `--domain` | `text` |  | Domain to which this command applies. |
 | `--help` | `boolean` | `False` | Show this message and exit. |
 
 #### flyte get trigger
@@ -1667,10 +1662,8 @@ Get a list of all triggers, or details of a specific trigger by name.
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `--limit` | `integer` | `100` | Limit the number of triggers to fetch. |
-| {{< multiline >}}`-p`
-`--project`{{< /multiline >}} | `text` |  | Project to which this command applies. |
-| {{< multiline >}}`-d`
-`--domain`{{< /multiline >}} | `text` |  | Domain to which this command applies. |
+| `-p` `--project` | `text` |  | Project to which this command applies. |
+| `-d` `--domain` | `text` |  | Domain to which this command applies. |
 | `--help` | `boolean` | `False` | Show this message and exit. |
 
 {{< variant union >}}
@@ -1683,14 +1676,16 @@ Get a list of all triggers, or details of a specific trigger by name.
 
 Get or list users.
 
-    If SUBJECT is provided, gets a specific user. Otherwise, lists all users.
+If SUBJECT is provided, gets a specific user. Otherwise, lists all users.
 
-    Examples:
+Examples:
 
-        $ flyte --org my-org get user
-        $ flyte --org my-org get user --limit 10
-        $ flyte --org my-org get user user-subject-id
-        $ flyte --org my-org get user --email jane@example.com
+```bash
+$ flyte --org my-org get user
+$ flyte --org my-org get user --limit 10
+$ flyte --org my-org get user user-subject-id
+$ flyte --org my-org get user --email jane@example.com
+```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -1744,9 +1739,11 @@ Then run:
 
 ```bash
 $ flyte prefetch hf-model meta-llama/Llama-2-70b-hf \
-    --shard-config shard_config.yaml \
-    --accelerator A100:8 \
-    --hf-token-key HF_TOKEN
+```bash
+--shard-config shard_config.yaml \
+--accelerator A100:8 \
+--hf-token-key HF_TOKEN
+```
 ```
 
 **Wait for Completion:**
@@ -1774,10 +1771,8 @@ $ flyte prefetch hf-model meta-llama/Llama-2-7b-hf --wait
 | `--disk` | `text` | `50Gi` | Disk storage request for the prefetch task (e.g., '100Gi', '500Gi'). |
 | `--shm` | `text` |  | Shared memory request for the prefetch task (e.g., '100Gi', 'auto'). |
 | `--shard-config` | `path` | `Sentinel.UNSET` | Path to a YAML file containing sharding configuration. The file should have 'engine' (currently only 'vllm') and 'args' keys. |
-| {{< multiline >}}`-p`
-`--project`{{< /multiline >}} | `text` |  | Project to which this command applies. |
-| {{< multiline >}}`-d`
-`--domain`{{< /multiline >}} | `text` |  | Domain to which this command applies. |
+| `-p` `--project` | `text` |  | Project to which this command applies. |
+| `-d` `--domain` | `text` |  | Domain to which this command applies. |
 | `--help` | `boolean` | `False` | Show this message and exit. |
 
 ### flyte rerun
@@ -1786,27 +1781,25 @@ $ flyte prefetch hf-model meta-llama/Llama-2-7b-hf --wait
 
 Re-run an existing run RUN_NAME with its original code and inputs.
 
-    Fetches the prior run's task + inputs from the platform (no local code needed) and launches a
-    new run that returns the same way ``flyte run`` does. To re-run with *new* local code (reusing
-    the prior run's inputs), use ``flyte run <file> <task> --rerun-from <run>``.
+Fetches the prior run's task + inputs from the platform (no local code needed) and launches a
+new run that returns the same way ``flyte run`` does. To re-run with *new* local code (reusing
+the prior run's inputs), use ``flyte run <file> <task> --rerun-from <run>``.
 
-    Examples:
+Examples:
 
-        $ flyte rerun ul56wcvgqrb9vzhzz5l2
-        $ flyte rerun ul56wcvgqrb9vzhzz5l2 --name retry-1 --follow
+```bash
+$ flyte rerun ul56wcvgqrb9vzhzz5l2
+$ flyte rerun ul56wcvgqrb9vzhzz5l2 --name retry-1 --follow
+```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| {{< multiline >}}`-p`
-`--project`{{< /multiline >}} | `text` |  | Project for the new run (defaults to config). |
-| {{< multiline >}}`-d`
-`--domain`{{< /multiline >}} | `text` |  | Domain for the new run (defaults to config). |
+| `-p` `--project` | `text` |  | Project for the new run (defaults to config). |
+| `-d` `--domain` | `text` |  | Domain for the new run (defaults to config). |
 | `--name` | `text` |  | Name for the new run (a random name is generated if unset). |
-| {{< multiline >}}`-e`
-`--env`{{< /multiline >}} | `text` | `Sentinel.UNSET` | Env var KEY=VALUE for the new run. Repeatable. |
+| `-e` `--env` | `text` | `Sentinel.UNSET` | Env var KEY=VALUE for the new run. Repeatable. |
 | `--label` | `text` | `Sentinel.UNSET` | Label KEY=VALUE for the new run. Repeatable. |
-| {{< multiline >}}`--follow`
-`-f`{{< /multiline >}} | `boolean` | `False` | Stream the parent action logs after launch. |
+| `--follow` `-f` | `boolean` | `False` | Stream the parent action logs after launch. |
 | `--help` | `boolean` | `False` | Show this message and exit. |
 
 ### flyte run
@@ -1905,26 +1898,22 @@ flyte run hello.py my_task --help
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| {{< multiline >}}`-p`
-`--project`{{< /multiline >}} | `text` |  | Project to which this command applies. |
-| {{< multiline >}}`-d`
-`--domain`{{< /multiline >}} | `text` |  | Domain to which this command applies. |
+| `-p` `--project` | `text` |  | Project to which this command applies. |
+| `-d` `--domain` | `text` |  | Domain to which this command applies. |
 | `--local` | `boolean` | `False` | Run the task locally |
 | `--copy-style` | `choice` | `loaded_modules` | Copy style to use when running the task |
 | `--root-dir` | `text` | `Sentinel.UNSET` | Override the root source directory, helpful when working with monorepos. |
 | `--raw-data-path` | `text` | `Sentinel.UNSET` | Override the output prefix used to store offloaded data types. e.g. s3://bucket/ |
 | `--service-account` | `text` | `Sentinel.UNSET` | Kubernetes service account. If not provided, the configured default will be used |
 | `--name` | `text` | `Sentinel.UNSET` | Name of the run. If not provided, a random name will be generated. |
-| {{< multiline >}}`--follow`
-`-f`{{< /multiline >}} | `boolean` | `False` | Wait and watch logs for the parent action. If not provided, the CLI will exit after successfully launching a remote execution with a link to the UI. |
+| `--follow` `-f` | `boolean` | `False` | Wait and watch logs for the parent action. If not provided, the CLI will exit after successfully launching a remote execution with a link to the UI. |
 | `--tui` | `boolean` | `False` | Show interactive TUI for local execution (requires flyte[tui]). |
 | `--image` | `text` | `Sentinel.UNSET` | Image to be used in the run. Format: imagename=imageuri. Can be specified multiple times. |
 | `--no-sync-local-sys-paths` | `boolean` | `False` | Disable synchronization of local sys.path entries under the root directory to the remote container. |
 | `--run-project` | `text` |  | Run the remote task in this project, only applicable when using `deployed-task` subcommand. |
 | `--run-domain` | `text` |  | Run the remote task in this domain, only applicable when using `deployed-task` subcommand. |
 | `--debug` | `boolean` | `False` | Run the task as a VSCode debug task. Starts a code-server in the container so you can connect via the UI to interactively debug/run the task. |
-| {{< multiline >}}`--env`
-`-e`{{< /multiline >}} | `text` | `Sentinel.UNSET` | Environment variable to set on the run context. Format: KEY=VALUE. Can be specified multiple times, e.g. `-e LOG_LEVEL=debug -e FOO=bar`. |
+| `--env` `-e` | `text` | `Sentinel.UNSET` | Environment variable to set on the run context. Format: KEY=VALUE. Can be specified multiple times, e.g. `-e LOG_LEVEL=debug -e FOO=bar`. |
 | `--max-action-concurrency` | `integer range` |  | Maximum number of actions that can run concurrently within the run. If not provided, the platform default (run.max_action_concurrency setting) applies. |
 | `--label` | `text` | `Sentinel.UNSET` | User-defined label to attach to the run. Format: KEY=VALUE. Can be specified multiple times, e.g. `--label team=ml --label env=prod`. |
 | `--rerun-from` | `text` |  | Re-run an existing run with THIS local code, reusing that run's inputs (no per-task input flags are needed). Remote-only. |
@@ -1939,10 +1928,8 @@ Run remote task from the Flyte backend
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| {{< multiline >}}`-p`
-`--project`{{< /multiline >}} | `text` |  | Project to which this command applies. |
-| {{< multiline >}}`-d`
-`--domain`{{< /multiline >}} | `text` |  | Domain to which this command applies. |
+| `-p` `--project` | `text` |  | Project to which this command applies. |
+| `-d` `--domain` | `text` |  | Domain to which this command applies. |
 | `--help` | `boolean` | `False` | Show this message and exit. |
 
 ### flyte serve
@@ -2019,20 +2006,16 @@ Serving deployed apps is not currently supported through this CLI command.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| {{< multiline >}}`-p`
-`--project`{{< /multiline >}} | `text` |  | Project to which this command applies. |
-| {{< multiline >}}`-d`
-`--domain`{{< /multiline >}} | `text` |  | Domain to which this command applies. |
+| `-p` `--project` | `text` |  | Project to which this command applies. |
+| `-d` `--domain` | `text` |  | Domain to which this command applies. |
 | `--copy-style` | `choice` | `loaded_modules` | Copy style to use when serving the app |
 | `--root-dir` | `text` | `Sentinel.UNSET` | Override the root source directory, helpful when working with monorepos. |
 | `--service-account` | `text` | `Sentinel.UNSET` | Kubernetes service account. If not provided, the configured default will be used |
 | `--name` | `text` | `Sentinel.UNSET` | Name of the app deployment. If not provided, the app environment name will be used. |
-| {{< multiline >}}`--follow`
-`-f`{{< /multiline >}} | `boolean` | `False` | Wait and watch logs for the app. If not provided, the CLI will exit after successfully deploying the app with a link to the UI. |
+| `--follow` `-f` | `boolean` | `False` | Wait and watch logs for the app. If not provided, the CLI will exit after successfully deploying the app with a link to the UI. |
 | `--image` | `text` | `Sentinel.UNSET` | Image to be used in the serve. Format: imagename=imageuri. Can be specified multiple times. |
 | `--no-sync-local-sys-paths` | `boolean` | `False` | Disable synchronization of local sys.path entries under the root directory to the remote container. |
-| {{< multiline >}}`--env-var`
-`-e`{{< /multiline >}} | `text` | `Sentinel.UNSET` | Environment variable to set in the app. Format: KEY=VALUE. Can be specified multiple times. Example: --env-var LOG_LEVEL=DEBUG --env-var DATABASE_URL=postgresql://... |
+| `--env-var` `-e` | `text` | `Sentinel.UNSET` | Environment variable to set in the app. Format: KEY=VALUE. Can be specified multiple times. Example: --env-var LOG_LEVEL=DEBUG --env-var DATABASE_URL=postgresql://... |
 | `--local` | `boolean` | `False` | Serve the app locally on localhost instead of deploying to the Flyte backend. The app will be served on the port defined in the AppEnvironment. |
 | `--help` | `boolean` | `False` | Show this message and exit. |
 
@@ -2056,10 +2039,8 @@ integer literals for int, decimal literals for float, any string for str).
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| {{< multiline >}}`-p`
-`--project`{{< /multiline >}} | `text` |  | Project to which this command applies. |
-| {{< multiline >}}`-d`
-`--domain`{{< /multiline >}} | `text` |  | Domain to which this command applies. |
+| `-p` `--project` | `text` |  | Project to which this command applies. |
+| `-d` `--domain` | `text` |  | Domain to which this command applies. |
 | `--help` | `boolean` | `False` | Show this message and exit. |
 
 ### flyte start
@@ -2129,13 +2110,10 @@ flyte update app <app_name> --activate | --deactivate [--wait] [--project <proje
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| {{< multiline >}}`--activate`
-`--deactivate`{{< /multiline >}} | `boolean` |  | Activate or deactivate app. |
+| `--activate` `--deactivate` | `boolean` |  | Activate or deactivate app. |
 | `--wait` | `boolean` | `False` | Wait for the app to reach the desired state. |
-| {{< multiline >}}`-p`
-`--project`{{< /multiline >}} | `text` |  | Project to which this command applies. |
-| {{< multiline >}}`-d`
-`--domain`{{< /multiline >}} | `text` |  | Domain to which this command applies. |
+| `-p` `--project` | `text` |  | Project to which this command applies. |
+| `-d` `--domain` | `text` |  | Domain to which this command applies. |
 | `--help` | `boolean` | `False` | Show this message and exit. |
 
 {{< variant union >}}
@@ -2148,11 +2126,13 @@ flyte update app <app_name> --activate | --deactivate [--wait] [--project <proje
 
 Update a cluster pool interactively.
 
-    Opens the pool in your $EDITOR as YAML. Save and close to apply changes.
+Opens the pool in your $EDITOR as YAML. Save and close to apply changes.
 
-    Examples:
+Examples:
 
-        $ flyte update cluster-pool my-pool
+```bash
+$ flyte update cluster-pool my-pool
+```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -2170,12 +2150,14 @@ Update a cluster pool interactively.
 
 Update a policy interactively.
 
-    Opens the policy in your $EDITOR as YAML. Save and close to apply changes.
-    Bindings that are added or removed will be applied to the policy.
+Opens the policy in your $EDITOR as YAML. Save and close to apply changes.
+Bindings that are added or removed will be applied to the policy.
 
-    Examples:
+Examples:
 
-        $ flyte --org my-org update policy my-policy
+```bash
+$ flyte --org my-org update policy my-policy
+```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -2204,10 +2186,8 @@ flyte update project my_project --label team=ml --label env=prod
 |--------|------|---------|-------------|
 | `--name` | `text` |  | Update the project display name. |
 | `--description` | `text` |  | Update the project description. |
-| {{< multiline >}}`--label`
-`-l`{{< /multiline >}} | `text` | `Sentinel.UNSET` | Set labels as key=value pairs. Can be specified multiple times. Replaces all existing labels. |
-| {{< multiline >}}`--archive`
-`--unarchive`{{< /multiline >}} | `boolean` |  | Archive or unarchive the project. |
+| `--label` `-l` | `text` | `Sentinel.UNSET` | Set labels as key=value pairs. Can be specified multiple times. Replaces all existing labels. |
+| `--archive` `--unarchive` | `boolean` |  | Archive or unarchive the project. |
 | `--help` | `boolean` | `False` | Show this message and exit. |
 
 {{< variant union >}}
@@ -2220,17 +2200,19 @@ flyte update project my_project --label team=ml --label env=prod
 
 Update a queue.
 
-    Use --drain to begin draining (stops new submissions).
-    Use --activate to re-activate a draining or drained queue.
-    Use --edit to interactively modify queue configuration.
+Use --drain to begin draining (stops new submissions).
+Use --activate to re-activate a draining or drained queue.
+Use --edit to interactively modify queue configuration.
 
-    Examples:
+Examples:
 
-        $ flyte update queue my-queue --drain
+```bash
+$ flyte update queue my-queue --drain
 
-        $ flyte update queue my-queue --activate
+$ flyte update queue my-queue --activate
 
-        $ flyte update queue my-queue --edit
+$ flyte update queue my-queue --edit
+```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -2253,11 +2235,13 @@ Update a queue.
 
 Update a role interactively.
 
-    Opens the role in your $EDITOR as YAML. Save and close to apply changes.
+Opens the role in your $EDITOR as YAML. Save and close to apply changes.
 
-    Examples:
+Examples:
 
-        $ flyte --org my-org update role my-role
+```bash
+$ flyte --org my-org update role my-role
+```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -2281,12 +2265,9 @@ flyte update trigger <trigger_name> <task_name> --activate | --deactivate
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| {{< multiline >}}`--activate`
-`--deactivate`{{< /multiline >}} | `boolean` | `Sentinel.UNSET` | Activate or deactivate the trigger. |
-| {{< multiline >}}`-p`
-`--project`{{< /multiline >}} | `text` |  | Project to which this command applies. |
-| {{< multiline >}}`-d`
-`--domain`{{< /multiline >}} | `text` |  | Domain to which this command applies. |
+| `--activate` `--deactivate` | `boolean` | `Sentinel.UNSET` | Activate or deactivate the trigger. |
+| `-p` `--project` | `text` |  | Project to which this command applies. |
+| `-d` `--domain` | `text` |  | Domain to which this command applies. |
 | `--help` | `boolean` | `False` | Show this message and exit. |
 
 ### flyte whoami

--- a/content/api-reference/flyte-sdk/_index.md
+++ b/content/api-reference/flyte-sdk/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Flyte SDK
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 weight: 4

--- a/content/api-reference/flyte-sdk/classes/_index.md
+++ b/content/api-reference/flyte-sdk/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes & Protocols
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/_index.md
+++ b/content/api-reference/flyte-sdk/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents.agent/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents.agent/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.ai.agents.agent
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents.agent/agent.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents.agent/agent.md
@@ -1,6 +1,6 @@
 ---
 title: Agent
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---
@@ -55,10 +55,11 @@ code_mode:
     expression becomes the observation for the next turn; the loop ends when
     the LLM replies with plain text (no code block). This unlocks generated
     control flow (loops, ``flyte_map`` fan-out, intermediate aggregation)
-    while still dispatching ``@env.task`` tools durably on-cluster. Requires
-    ``pydantic-monty`` in the runtime image. Note: per-tool HITL approval is
-    not enforced in code mode, since tools are invoked from inside the
-    sandbox rather than as discrete approved calls.
+    while still dispatching ``@env.task`` tools durably on-cluster. Tools
+    with a ``call_handler`` run through that handler in code mode as well.
+    Requires ``pydantic-monty`` in the runtime image. Note: per-tool HITL
+    approval is not enforced in code mode, since tools are invoked from inside
+    the sandbox rather than as discrete approved calls.
 
 
 ## Parameters

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents.agent/agentevent.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents.agent/agentevent.md
@@ -1,6 +1,6 @@
 ---
 title: AgentEvent
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents.memory/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents.memory/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.ai.agents.memory
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents.memory/accessdenied.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents.memory/accessdenied.md
@@ -1,6 +1,6 @@
 ---
 title: AccessDenied
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents.memory/concurrencyerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents.memory/concurrencyerror.md
@@ -1,6 +1,6 @@
 ---
 title: ConcurrencyError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents.memory/memorymeta.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents.memory/memorymeta.md
@@ -1,6 +1,6 @@
 ---
 title: MemoryMeta
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents.memory/memorystore.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents.memory/memorystore.md
@@ -1,6 +1,6 @@
 ---
 title: MemoryStore
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents.memory/memorystoreerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents.memory/memorystoreerror.md
@@ -1,6 +1,6 @@
 ---
 title: MemoryStoreError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents.protocol/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents.protocol/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.ai.agents.protocol
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents.protocol/agentprotocol.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents.protocol/agentprotocol.md
@@ -1,6 +1,6 @@
 ---
 title: AgentProtocol
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents.protocol/agentresult.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents.protocol/agentresult.md
@@ -1,6 +1,6 @@
 ---
 title: AgentResult
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.ai.agents
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents/accessdenied.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents/accessdenied.md
@@ -1,6 +1,6 @@
 ---
 title: AccessDenied
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents/agent.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents/agent.md
@@ -1,6 +1,6 @@
 ---
 title: Agent
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---
@@ -55,10 +55,11 @@ code_mode:
     expression becomes the observation for the next turn; the loop ends when
     the LLM replies with plain text (no code block). This unlocks generated
     control flow (loops, ``flyte_map`` fan-out, intermediate aggregation)
-    while still dispatching ``@env.task`` tools durably on-cluster. Requires
-    ``pydantic-monty`` in the runtime image. Note: per-tool HITL approval is
-    not enforced in code mode, since tools are invoked from inside the
-    sandbox rather than as discrete approved calls.
+    while still dispatching ``@env.task`` tools durably on-cluster. Tools
+    with a ``call_handler`` run through that handler in code mode as well.
+    Requires ``pydantic-monty`` in the runtime image. Note: per-tool HITL
+    approval is not enforced in code mode, since tools are invoked from inside
+    the sandbox rather than as discrete approved calls.
 
 
 ## Parameters

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents/agentevent.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents/agentevent.md
@@ -1,6 +1,6 @@
 ---
 title: AgentEvent
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents/agentprotocol.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents/agentprotocol.md
@@ -1,6 +1,6 @@
 ---
 title: AgentProtocol
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents/agentresult.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents/agentresult.md
@@ -1,6 +1,6 @@
 ---
 title: AgentResult
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents/agenttool.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents/agenttool.md
@@ -1,6 +1,6 @@
 ---
 title: AgentTool
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---
@@ -35,6 +35,8 @@ class AgentTool(
     source: Literal['function', 'task', 'trace', 'remote_task', 'mcp', 'custom'],
     target: Any,
     call_handler: ToolCallHandler | None,
+    call_llm: LLMCallable | None,
+    model: str | None,
 )
 ```
 | Parameter | Type | Description |
@@ -47,13 +49,38 @@ class AgentTool(
 | `source` | `Literal['function', 'task', 'trace', 'remote_task', 'mcp', 'custom']` | |
 | `target` | `Any` | |
 | `call_handler` | `ToolCallHandler \| None` | |
+| `call_llm` | `LLMCallable \| None` | |
+| `model` | `str \| None` | |
 
 ## Methods
 
 | Method | Description |
 |-|-|
+| [`aio()`](#aio) | Invoke the tool, routing through ``call_handler`` when one is registered. |
 | [`to_openai_format()`](#to_openai_format) | Convert to the OpenAI / litellm tools schema. |
 
+
+### aio()
+
+```python
+def aio(
+    args: *args,
+    kwargs: **kwargs,
+) -> Any
+```
+Invoke the tool, routing through ``call_handler`` when one is registered.
+
+Mirrors :meth:`~flyte._task.TaskTemplate.aio` enough for ``flyte.map`` and
+in-task calls on ``@tool``-wrapped tasks. When a ``call_handler`` is set,
+it runs with :attr:`call_llm` and :attr:`model` (or their defaults).
+Otherwise, durable ``@env.task`` / remote-task targets delegate to their
+underlying ``.aio``; everything else goes through :meth:`execute`.
+
+
+| Parameter | Type | Description |
+|-|-|-|
+| `args` | `*args` | |
+| `kwargs` | `**kwargs` | |
 
 ### to_openai_format()
 

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents/concurrencyerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents/concurrencyerror.md
@@ -1,6 +1,6 @@
 ---
 title: ConcurrencyError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents/llmmessage.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents/llmmessage.md
@@ -1,6 +1,6 @@
 ---
 title: LLMMessage
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents/mcpserverspec.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents/mcpserverspec.md
@@ -1,6 +1,6 @@
 ---
 title: MCPServerSpec
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents/memorymeta.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents/memorymeta.md
@@ -1,6 +1,6 @@
 ---
 title: MemoryMeta
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents/memorystore.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents/memorystore.md
@@ -1,6 +1,6 @@
 ---
 title: MemoryStore
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents/memorystoreerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents/memorystoreerror.md
@@ -1,6 +1,6 @@
 ---
 title: MemoryStoreError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.agents/toolfn.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.agents/toolfn.md
@@ -1,6 +1,6 @@
 ---
 title: ToolFn
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.chat.app/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.chat.app/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.ai.chat.app
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.chat.app/agentchatappenvironment.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.chat.app/agentchatappenvironment.md
@@ -1,6 +1,6 @@
 ---
 title: AgentChatAppEnvironment
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.chat.app/customtheme.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.chat.app/customtheme.md
@@ -1,6 +1,6 @@
 ---
 title: CustomTheme
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.chat/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.chat/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.ai.chat
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.chat/agentchatappenvironment.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.chat/agentchatappenvironment.md
@@ -1,6 +1,6 @@
 ---
 title: AgentChatAppEnvironment
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.chat/customtheme.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.chat/customtheme.md
@@ -1,6 +1,6 @@
 ---
 title: CustomTheme
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.mcp/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.mcp/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.ai.mcp
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.mcp/flytemcpappenvironment.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.mcp/flytemcpappenvironment.md
@@ -1,6 +1,6 @@
 ---
 title: FlyteMCPAppEnvironment
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.ai.mcp/mcpappenvironment.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.ai.mcp/mcpappenvironment.md
@@ -1,6 +1,6 @@
 ---
 title: MCPAppEnvironment
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app.extras/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app.extras/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.app.extras
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app.extras/fastapiappenvironment.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app.extras/fastapiappenvironment.md
@@ -1,6 +1,6 @@
 ---
 title: FastAPIAppEnvironment
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app.extras/fastapipassthroughauthmiddleware.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app.extras/fastapipassthroughauthmiddleware.md
@@ -1,6 +1,6 @@
 ---
 title: FastAPIPassthroughAuthMiddleware
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app.extras/flytewebhookappenvironment.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app.extras/flytewebhookappenvironment.md
@@ -1,6 +1,6 @@
 ---
 title: FlyteWebhookAppEnvironment
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.app
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app/appendpoint.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app/appendpoint.md
@@ -1,6 +1,6 @@
 ---
 title: AppEndpoint
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app/appenvironment.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app/appenvironment.md
@@ -1,6 +1,6 @@
 ---
 title: AppEnvironment
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app/connectorenvironment.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app/connectorenvironment.md
@@ -1,6 +1,6 @@
 ---
 title: ConnectorEnvironment
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app/domain.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app/domain.md
@@ -1,6 +1,6 @@
 ---
 title: Domain
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app/link.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app/link.md
@@ -1,6 +1,6 @@
 ---
 title: Link
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app/parameter.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app/parameter.md
@@ -1,6 +1,6 @@
 ---
 title: Parameter
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app/port.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app/port.md
@@ -1,6 +1,6 @@
 ---
 title: Port
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app/runoutput.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app/runoutput.md
@@ -1,6 +1,6 @@
 ---
 title: RunOutput
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app/scaling.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app/scaling.md
@@ -1,6 +1,6 @@
 ---
 title: Scaling
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.app/timeouts.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.app/timeouts.md
@@ -1,6 +1,6 @@
 ---
 title: Timeouts
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.clustered/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.clustered/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.clustered
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.clustered/clusteredtaskenvironment.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.clustered/clusteredtaskenvironment.md
@@ -1,6 +1,6 @@
 ---
 title: ClusteredTaskEnvironment
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.clustered/clusteredtasktemplate.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.clustered/clusteredtasktemplate.md
@@ -1,6 +1,6 @@
 ---
 title: ClusteredTaskTemplate
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.clustered/clusterfailurepolicy.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.clustered/clusterfailurepolicy.md
@@ -1,6 +1,6 @@
 ---
 title: ClusterFailurePolicy
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.clustered/torchrun.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.clustered/torchrun.md
@@ -1,6 +1,6 @@
 ---
 title: TorchRun
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.config/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.config/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.config
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.config/config.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.config/config.md
@@ -1,6 +1,6 @@
 ---
 title: Config
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.connectors.utils/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.connectors.utils/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.connectors.utils
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.connectors/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.connectors/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.connectors
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.connectors/asyncconnector.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.connectors/asyncconnector.md
@@ -1,6 +1,6 @@
 ---
 title: AsyncConnector
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.connectors/asyncconnectorexecutormixin.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.connectors/asyncconnectorexecutormixin.md
@@ -1,6 +1,6 @@
 ---
 title: AsyncConnectorExecutorMixin
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.connectors/connectorregistry.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.connectors/connectorregistry.md
@@ -1,6 +1,6 @@
 ---
 title: ConnectorRegistry
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.connectors/connectorservice.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.connectors/connectorservice.md
@@ -1,6 +1,6 @@
 ---
 title: ConnectorService
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.connectors/resource.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.connectors/resource.md
@@ -1,6 +1,6 @@
 ---
 title: Resource
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.connectors/resourcemeta.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.connectors/resourcemeta.md
@@ -1,6 +1,6 @@
 ---
 title: ResourceMeta
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.durable/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.durable/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.durable
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.errors
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/actionabortederror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/actionabortederror.md
@@ -1,6 +1,6 @@
 ---
 title: ActionAbortedError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/actionnotfounderror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/actionnotfounderror.md
@@ -1,6 +1,6 @@
 ---
 title: ActionNotFoundError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/baseruntimeerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/baseruntimeerror.md
@@ -1,6 +1,6 @@
 ---
 title: BaseRuntimeError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/codebundleerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/codebundleerror.md
@@ -1,6 +1,6 @@
 ---
 title: CodeBundleError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/conditionalreadyexistserror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/conditionalreadyexistserror.md
@@ -1,6 +1,6 @@
 ---
 title: ConditionAlreadyExistsError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/conditionfailederror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/conditionfailederror.md
@@ -1,6 +1,6 @@
 ---
 title: ConditionFailedError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/conditionnotfounderror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/conditionnotfounderror.md
@@ -1,6 +1,6 @@
 ---
 title: ConditionNotFoundError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/conditiontimedouterror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/conditiontimedouterror.md
@@ -1,6 +1,6 @@
 ---
 title: ConditionTimedoutError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/customerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/customerror.md
@@ -1,6 +1,6 @@
 ---
 title: CustomError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/deploymenterror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/deploymenterror.md
@@ -1,6 +1,6 @@
 ---
 title: DeploymentError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/imagebuilderror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/imagebuilderror.md
@@ -1,6 +1,6 @@
 ---
 title: ImageBuildError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/imagepullbackofferror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/imagepullbackofferror.md
@@ -1,6 +1,6 @@
 ---
 title: ImagePullBackOffError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/initializationerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/initializationerror.md
@@ -1,6 +1,6 @@
 ---
 title: InitializationError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/inlineiomaxbytesbreached.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/inlineiomaxbytesbreached.md
@@ -1,6 +1,6 @@
 ---
 title: InlineIOMaxBytesBreached
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/invalidimagenameerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/invalidimagenameerror.md
@@ -1,6 +1,6 @@
 ---
 title: InvalidImageNameError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/invalidpackageerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/invalidpackageerror.md
@@ -1,6 +1,6 @@
 ---
 title: InvalidPackageError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/logsnotyetavailableerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/logsnotyetavailableerror.md
@@ -1,6 +1,6 @@
 ---
 title: LogsNotYetAvailableError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/moduleloaderror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/moduleloaderror.md
@@ -1,6 +1,6 @@
 ---
 title: ModuleLoadError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/nonrecoverableerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/nonrecoverableerror.md
@@ -1,6 +1,6 @@
 ---
 title: NonRecoverableError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/notintaskcontexterror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/notintaskcontexterror.md
@@ -1,6 +1,6 @@
 ---
 title: NotInTaskContextError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/onlyasynciosupportederror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/onlyasynciosupportederror.md
@@ -1,6 +1,6 @@
 ---
 title: OnlyAsyncIOSupportedError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/oomerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/oomerror.md
@@ -1,6 +1,6 @@
 ---
 title: OOMError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/parametermaterializationerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/parametermaterializationerror.md
@@ -1,6 +1,6 @@
 ---
 title: ParameterMaterializationError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/primarycontainernotfounderror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/primarycontainernotfounderror.md
@@ -1,6 +1,6 @@
 ---
 title: PrimaryContainerNotFoundError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/remotetasknotfounderror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/remotetasknotfounderror.md
@@ -1,6 +1,6 @@
 ---
 title: RemoteTaskNotFoundError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/remotetaskusageerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/remotetaskusageerror.md
@@ -1,6 +1,6 @@
 ---
 title: RemoteTaskUsageError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/restrictedtypeerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/restrictedtypeerror.md
@@ -1,6 +1,6 @@
 ---
 title: RestrictedTypeError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/retriesexhaustederror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/retriesexhaustederror.md
@@ -1,6 +1,6 @@
 ---
 title: RetriesExhaustedError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/runtimedatavalidationerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/runtimedatavalidationerror.md
@@ -1,6 +1,6 @@
 ---
 title: RuntimeDataValidationError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/runtimesystemerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/runtimesystemerror.md
@@ -1,6 +1,6 @@
 ---
 title: RuntimeSystemError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/runtimeunknownerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/runtimeunknownerror.md
@@ -1,6 +1,6 @@
 ---
 title: RuntimeUnknownError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/runtimeusererror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/runtimeusererror.md
@@ -1,6 +1,6 @@
 ---
 title: RuntimeUserError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/slowdownerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/slowdownerror.md
@@ -1,6 +1,6 @@
 ---
 title: SlowDownError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/taskinterruptederror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/taskinterruptederror.md
@@ -1,6 +1,6 @@
 ---
 title: TaskInterruptedError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/tasktimeouterror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/tasktimeouterror.md
@@ -1,6 +1,6 @@
 ---
 title: TaskTimeoutError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/tracedoesnotallownestedtaskserror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/tracedoesnotallownestedtaskserror.md
@@ -1,6 +1,6 @@
 ---
 title: TraceDoesNotAllowNestedTasksError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.errors/unionrpcerror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.errors/unionrpcerror.md
@@ -1,6 +1,6 @@
 ---
 title: UnionRpcError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extend/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extend/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.extend
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extend/asyncfunctiontasktemplate.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extend/asyncfunctiontasktemplate.md
@@ -1,6 +1,6 @@
 ---
 title: AsyncFunctionTaskTemplate
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extend/imagebuildengine.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extend/imagebuildengine.md
@@ -1,6 +1,6 @@
 ---
 title: ImageBuildEngine
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extend/imagebuilder.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extend/imagebuilder.md
@@ -1,6 +1,6 @@
 ---
 title: ImageBuilder
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extend/imagechecker.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extend/imagechecker.md
@@ -1,6 +1,6 @@
 ---
 title: ImageChecker
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extend/tasktemplate.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extend/tasktemplate.md
@@ -1,6 +1,6 @@
 ---
 title: TaskTemplate
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras.shell/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras.shell/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.extras.shell
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras.shell/flagspec.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras.shell/flagspec.md
@@ -1,6 +1,6 @@
 ---
 title: FlagSpec
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras.shell/glob.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras.shell/glob.md
@@ -1,6 +1,6 @@
 ---
 title: Glob
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras.shell/stderr.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras.shell/stderr.md
@@ -1,6 +1,6 @@
 ---
 title: Stderr
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras.shell/stdout.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras.shell/stdout.md
@@ -1,6 +1,6 @@
 ---
 title: Stdout
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.extras
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras/batchstats.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras/batchstats.md
@@ -1,6 +1,6 @@
 ---
 title: BatchStats
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras/containertask.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras/containertask.md
@@ -1,6 +1,6 @@
 ---
 title: ContainerTask
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras/costestimator.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras/costestimator.md
@@ -1,6 +1,6 @@
 ---
 title: CostEstimator
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras/dynamicbatcher.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras/dynamicbatcher.md
@@ -1,6 +1,6 @@
 ---
 title: DynamicBatcher
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras/prompt.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras/prompt.md
@@ -1,6 +1,6 @@
 ---
 title: Prompt
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras/sleep.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras/sleep.md
@@ -1,6 +1,6 @@
 ---
 title: Sleep
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras/sleeptask.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras/sleeptask.md
@@ -1,6 +1,6 @@
 ---
 title: SleepTask
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras/tokenbatcher.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras/tokenbatcher.md
@@ -1,6 +1,6 @@
 ---
 title: TokenBatcher
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.extras/tokenestimator.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.extras/tokenestimator.md
@@ -1,6 +1,6 @@
 ---
 title: TokenEstimator
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.git/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.git/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.git
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.git/gitstatus.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.git/gitstatus.md
@@ -1,6 +1,6 @@
 ---
 title: GitStatus
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.io.extend/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.io.extend/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.io.extend
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.io.extend/dataframedecoder.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.io.extend/dataframedecoder.md
@@ -1,6 +1,6 @@
 ---
 title: DataFrameDecoder
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.io.extend/dataframeencoder.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.io.extend/dataframeencoder.md
@@ -1,6 +1,6 @@
 ---
 title: DataFrameEncoder
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.io.extend/dataframetransformerengine.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.io.extend/dataframetransformerengine.md
@@ -1,6 +1,6 @@
 ---
 title: DataFrameTransformerEngine
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.io/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.io/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.io
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.io/dataframe.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.io/dataframe.md
@@ -1,6 +1,6 @@
 ---
 title: DataFrame
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.io/dir.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.io/dir.md
@@ -1,6 +1,6 @@
 ---
 title: Dir
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.io/emptydir.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.io/emptydir.md
@@ -1,6 +1,6 @@
 ---
 title: EmptyDir
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.io/file.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.io/file.md
@@ -1,6 +1,6 @@
 ---
 title: File
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.io/hashfunction.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.io/hashfunction.md
@@ -1,6 +1,6 @@
 ---
 title: HashFunction
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.models/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.models/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.models
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.models/actionid.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.models/actionid.md
@@ -1,6 +1,6 @@
 ---
 title: ActionID
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.models/actionphase.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.models/actionphase.md
@@ -1,6 +1,6 @@
 ---
 title: ActionPhase
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.models/checkpointpaths.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.models/checkpointpaths.md
@@ -1,6 +1,6 @@
 ---
 title: CheckpointPaths
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.models/codebundle.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.models/codebundle.md
@@ -1,6 +1,6 @@
 ---
 title: CodeBundle
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.models/groupdata.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.models/groupdata.md
@@ -1,6 +1,6 @@
 ---
 title: GroupData
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.models/nativeinterface.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.models/nativeinterface.md
@@ -1,6 +1,6 @@
 ---
 title: NativeInterface
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.models/pathrewrite.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.models/pathrewrite.md
@@ -1,6 +1,6 @@
 ---
 title: PathRewrite
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.models/rawdatapath.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.models/rawdatapath.md
@@ -1,6 +1,6 @@
 ---
 title: RawDataPath
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.models/serializationcontext.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.models/serializationcontext.md
@@ -1,6 +1,6 @@
 ---
 title: SerializationContext
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.models/taskcontext.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.models/taskcontext.md
@@ -1,6 +1,6 @@
 ---
 title: TaskContext
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.notify/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.notify/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.notify
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.notify/email.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.notify/email.md
@@ -1,6 +1,6 @@
 ---
 title: Email
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.notify/nameddelivery.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.notify/nameddelivery.md
@@ -1,6 +1,6 @@
 ---
 title: NamedDelivery
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.notify/namedrule.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.notify/namedrule.md
@@ -1,6 +1,6 @@
 ---
 title: NamedRule
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.notify/notification.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.notify/notification.md
@@ -1,6 +1,6 @@
 ---
 title: Notification
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.notify/slack.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.notify/slack.md
@@ -1,6 +1,6 @@
 ---
 title: Slack
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.notify/teams.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.notify/teams.md
@@ -1,6 +1,6 @@
 ---
 title: Teams
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.notify/webhook.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.notify/webhook.md
@@ -1,6 +1,6 @@
 ---
 title: Webhook
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.prefetch/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.prefetch/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.prefetch
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.prefetch/huggingfacemodelinfo.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.prefetch/huggingfacemodelinfo.md
@@ -1,6 +1,6 @@
 ---
 title: HuggingFaceModelInfo
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.prefetch/shardconfig.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.prefetch/shardconfig.md
@@ -1,6 +1,6 @@
 ---
 title: ShardConfig
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.prefetch/storedmodelinfo.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.prefetch/storedmodelinfo.md
@@ -1,6 +1,6 @@
 ---
 title: StoredModelInfo
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.prefetch/vllmshardargs.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.prefetch/vllmshardargs.md
@@ -1,6 +1,6 @@
 ---
 title: VLLMShardArgs
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.remote
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/action.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/action.md
@@ -1,6 +1,6 @@
 ---
 title: Action
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/actiondetails.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/actiondetails.md
@@ -1,6 +1,6 @@
 ---
 title: ActionDetails
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---
@@ -20,6 +20,7 @@ class ActionDetails(
     _inputs: ActionInputs | None,
     _outputs: ActionOutputs | None,
     _preserve_original_types: bool,
+    _action_data: dataproxy_service_pb2.GetActionDataResponse | None,
 )
 ```
 | Parameter | Type | Description |
@@ -28,6 +29,7 @@ class ActionDetails(
 | `_inputs` | `ActionInputs \| None` | |
 | `_outputs` | `ActionOutputs \| None` | |
 | `_preserve_original_types` | `bool` | |
+| `_action_data` | `dataproxy_service_pb2.GetActionDataResponse \| None` | |
 
 ## Properties
 
@@ -60,11 +62,15 @@ class ActionDetails(
 | [`get()`](#get) | Get a run by its ID or name. |
 | [`get_details()`](#get_details) | Get the details of the action. |
 | [`get_phase_transitions()`](#get_phase_transitions) | Get the phase transitions for a specific attempt, showing the granular breakdown. |
+| [`input_literals()`](#input_literals) | Return the action's raw input literals keyed by input name, without reconstructing types. |
 | [`inputs()`](#inputs) | Return the inputs of the action. |
 | [`logs_available()`](#logs_available) | Check if logs are available for the action, optionally for a specific attempt. |
+| [`output_literals()`](#output_literals) | Return the action's raw output literals keyed by output name (``o0``, ``o1``,. |
 | [`outputs()`](#outputs) | Returns the outputs of the action, returns instantly if outputs are already cached, else fetches them and. |
 | [`to_dict()`](#to_dict) | Convert the object to a JSON-serializable dictionary. |
 | [`to_json()`](#to_json) | Convert the object to a JSON string. |
+| [`typed_inputs()`](#typed_inputs) | Fetch the action's inputs and re-hydrate the requested ones into caller-supplied types. |
+| [`typed_outputs()`](#typed_outputs) | Fetch the action's outputs and re-hydrate the requested ones into caller-supplied types. |
 | [`watch()`](#watch) | Watch the action for updates. |
 | [`watch_updates()`](#watch_updates) | Watch for updates to the action details, yielding each update until the action is done. |
 
@@ -146,6 +152,15 @@ of time spent in each phase (queued, initializing, running, etc.).
 List of PhaseTransitionInfo objects, one for each phase the action went through.
 
 
+### input_literals()
+
+```python
+def input_literals()
+```
+Return the action's raw input literals keyed by input name, without reconstructing types.
+The input-side equivalent of :meth:`output_literals`.
+
+
 ### inputs()
 
 ```python
@@ -169,6 +184,20 @@ If attempt is None, it checks for the latest attempt.
 | Parameter | Type | Description |
 |-|-|-|
 | `attempt` | `int \| None` | |
+
+### output_literals()
+
+```python
+def output_literals()
+```
+Return the action's raw output literals keyed by output name (``o0``, ``o1``, ...) without
+reconstructing the producer's types from the stored schema.
+
+Unlike :meth:`outputs`, this never calls ``guess_python_type``, so it can't fail (or pay the
+cost) when an output's type isn't reconstructable on the client, and it returns every output
+even if a sibling's type is un-guessable. Pair it with :meth:`typed_outputs` (or
+``TypeEngine.literal_map_to_kwargs``) to decode the specific outputs you care about.
+
 
 ### outputs()
 
@@ -203,6 +232,50 @@ Convert the object to a JSON string.
 
 
 **Returns:** str: A JSON string representation of the object.
+
+### typed_inputs()
+
+```python
+def typed_inputs(
+    types: Dict[str, type],
+    deserializers: Dict[type, Callable[[Any], Any]] | None,
+) -> Dict[str, Any]
+```
+Fetch the action's inputs and re-hydrate the requested ones into caller-supplied types.
+The input-side equivalent of :meth:`typed_outputs`; ``deserializers`` works the same way.
+
+
+| Parameter | Type | Description |
+|-|-|-|
+| `types` | `Dict[str, type]` | |
+| `deserializers` | `Dict[type, Callable[[Any], Any]] \| None` | |
+
+### typed_outputs()
+
+```python
+def typed_outputs(
+    types: Dict[str, type],
+    deserializers: Dict[type, Callable[[Any], Any]] | None,
+) -> Dict[str, Any]
+```
+Fetch the action's outputs and re-hydrate the requested ones into caller-supplied types.
+
+This is the supported "give me this action's ``o0`` as ``MyModel``" path:
+
+* Only the outputs named in ``types`` are converted -- sibling outputs are never
+  reconstructed, so an un-reconstructable sibling type can't fail the whole fetch.
+* Because you supply the type, the result is your real class (with its validators, methods
+  and custom (de)serializers), not a permissive schema-derived look-alike.
+
+    present in the action's outputs.
+
+
+| Parameter | Type | Description |
+|-|-|-|
+| `types` | `Dict[str, type]` | Mapping of output name (``o0``, ``o1``, ...) to the Python type to decode into. |
+| `deserializers` | `Dict[type, Callable[[Any], Any]] \| None` | Optional mapping of Python type -&gt; a callable that builds an instance from the raw (pre-validation) payload, e.g. ``{MyModel: MyModel.load}``. When a requested output's type appears here, the raw payload is handed to the callable instead of the default decode/``model_validate`` -- the hook for versioned-schema models that must migrate historical payloads before validation. Types not listed use the normal decode. |
+
+**Returns:** Mapping of output name to decoded value, restricted to the requested names that are
 
 ### watch()
 

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/actioninputs.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/actioninputs.md
@@ -1,6 +1,6 @@
 ---
 title: ActionInputs
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/actionoutputs.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/actionoutputs.md
@@ -1,6 +1,6 @@
 ---
 title: ActionOutputs
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/app.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/app.md
@@ -1,6 +1,6 @@
 ---
 title: App
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/condition.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/condition.md
@@ -1,6 +1,6 @@
 ---
 title: Condition
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/project.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/project.md
@@ -1,6 +1,6 @@
 ---
 title: Project
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/run.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/run.md
@@ -1,6 +1,6 @@
 ---
 title: Run
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---
@@ -47,13 +47,17 @@ class Run(
 | [`get()`](#get) | Get the current run. |
 | [`get_debug_url()`](#get_debug_url) | Get the debug URL of the run. |
 | [`get_logs()`](#get_logs) | Get logs for the run as an iterator of strings. |
+| [`input_literals()`](#input_literals) | Raw input literals of the run's action, without reconstructing types. |
 | [`inputs()`](#inputs) | Get the inputs of the run. |
 | [`listall()`](#listall) | Get all runs for the current project and domain. |
+| [`output_literals()`](#output_literals) | Raw output literals of the run's action, without reconstructing types. |
 | [`outputs()`](#outputs) | Get the outputs of the run. |
 | [`show_logs()`](#show_logs) |  |
 | [`sync()`](#sync) | Sync the run with the remote server. |
 | [`to_dict()`](#to_dict) | Convert the object to a JSON-serializable dictionary. |
 | [`to_json()`](#to_json) | Convert the object to a JSON string. |
+| [`typed_inputs()`](#typed_inputs) | Re-hydrate the run's requested inputs into caller-supplied types. |
+| [`typed_outputs()`](#typed_outputs) | Re-hydrate the run's requested outputs into caller-supplied types. |
 | [`wait()`](#wait) | Wait for the run to complete, displaying a rich progress panel with status transitions,. |
 | [`watch()`](#watch) | Watch the run for updates, updating the internal Run state with latest details. |
 
@@ -163,6 +167,21 @@ via `.aio()` (returns `AsyncIterator[str]`).
 | `filter_system` | `bool` | If True, filter out system-generated log lines. |
 | `show_ts` | `bool` | If True, prefix each line with an ISO-8601 timestamp. |
 
+### input_literals()
+
+
+> [!NOTE] This method can be called both synchronously or asynchronously.
+> Default invocation is sync and will block.
+> To call it asynchronously, use the function `.aio()` on the method name itself, e.g.,:
+> `result = await <Run instance>.input_literals.aio()`.
+```python
+def input_literals()
+```
+Raw input literals of the run's action, without reconstructing types.
+
+See :meth:`ActionDetails.input_literals`.
+
+
 ### inputs()
 
 
@@ -221,6 +240,21 @@ Get all runs for the current project and domain.
 | `with_label_keys` | `list[str] \| None` | Filter runs that have all of these label keys present (existence check). |
 
 **Returns:** An iterator of runs.
+
+### output_literals()
+
+
+> [!NOTE] This method can be called both synchronously or asynchronously.
+> Default invocation is sync and will block.
+> To call it asynchronously, use the function `.aio()` on the method name itself, e.g.,:
+> `result = await <Run instance>.output_literals.aio()`.
+```python
+def output_literals()
+```
+Raw output literals of the run's action, without reconstructing types.
+
+See :meth:`ActionDetails.output_literals`.
+
 
 ### outputs()
 
@@ -288,6 +322,52 @@ Convert the object to a JSON string.
 
 
 **Returns:** str: A JSON string representation of the object.
+
+### typed_inputs()
+
+
+> [!NOTE] This method can be called both synchronously or asynchronously.
+> Default invocation is sync and will block.
+> To call it asynchronously, use the function `.aio()` on the method name itself, e.g.,:
+> `result = await <Run instance>.typed_inputs.aio()`.
+```python
+def typed_inputs(
+    types: Dict[str, type],
+    deserializers: Dict[type, Callable[[Any], Any]] | None,
+) -> Dict[str, Any]
+```
+Re-hydrate the run's requested inputs into caller-supplied types.
+
+See :meth:`ActionDetails.typed_inputs`.
+
+
+| Parameter | Type | Description |
+|-|-|-|
+| `types` | `Dict[str, type]` | |
+| `deserializers` | `Dict[type, Callable[[Any], Any]] \| None` | |
+
+### typed_outputs()
+
+
+> [!NOTE] This method can be called both synchronously or asynchronously.
+> Default invocation is sync and will block.
+> To call it asynchronously, use the function `.aio()` on the method name itself, e.g.,:
+> `result = await <Run instance>.typed_outputs.aio()`.
+```python
+def typed_outputs(
+    types: Dict[str, type],
+    deserializers: Dict[type, Callable[[Any], Any]] | None,
+) -> Dict[str, Any]
+```
+Re-hydrate the run's requested outputs into caller-supplied types.
+
+See :meth:`ActionDetails.typed_outputs`.
+
+
+| Parameter | Type | Description |
+|-|-|-|
+| `types` | `Dict[str, type]` | |
+| `deserializers` | `Dict[type, Callable[[Any], Any]] \| None` | |
 
 ### wait()
 

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/rundetails.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/rundetails.md
@@ -1,6 +1,6 @@
 ---
 title: RunDetails
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---
@@ -41,10 +41,14 @@ class RunDetails(
 | [`done()`](#done) | Check if the run is in a terminal state (completed or failed). |
 | [`get()`](#get) | Get a run by its ID or name. |
 | [`get_details()`](#get_details) | Get the details of the run. |
+| [`input_literals()`](#input_literals) | Raw input literals without reconstructing types. |
 | [`inputs()`](#inputs) | Placeholder for inputs. |
+| [`output_literals()`](#output_literals) | Raw output literals without reconstructing types. |
 | [`outputs()`](#outputs) | Placeholder for outputs. |
 | [`to_dict()`](#to_dict) | Convert the object to a JSON-serializable dictionary. |
 | [`to_json()`](#to_json) | Convert the object to a JSON string. |
+| [`typed_inputs()`](#typed_inputs) | Re-hydrate requested inputs into caller-supplied types. |
+| [`typed_outputs()`](#typed_outputs) | Re-hydrate requested outputs into caller-supplied types. |
 
 
 ### done()
@@ -99,12 +103,28 @@ Get the details of the run. This is a placeholder for getting the run details.
 | `cls` |  | |
 | `run_id` | `identifier_pb2.RunIdentifier` | |
 
+### input_literals()
+
+```python
+def input_literals()
+```
+Raw input literals without reconstructing types. See :meth:`ActionDetails.input_literals`.
+
+
 ### inputs()
 
 ```python
 def inputs()
 ```
 Placeholder for inputs. This can be extended to handle inputs from the run context.
+
+
+### output_literals()
+
+```python
+def output_literals()
+```
+Raw output literals without reconstructing types. See :meth:`ActionDetails.output_literals`.
 
 
 ### outputs()
@@ -136,4 +156,36 @@ Convert the object to a JSON string.
 
 
 **Returns:** str: A JSON string representation of the object.
+
+### typed_inputs()
+
+```python
+def typed_inputs(
+    types: Dict[str, type],
+    deserializers: Dict[type, Callable[[Any], Any]] | None,
+) -> Dict[str, Any]
+```
+Re-hydrate requested inputs into caller-supplied types. See :meth:`ActionDetails.typed_inputs`.
+
+
+| Parameter | Type | Description |
+|-|-|-|
+| `types` | `Dict[str, type]` | |
+| `deserializers` | `Dict[type, Callable[[Any], Any]] \| None` | |
+
+### typed_outputs()
+
+```python
+def typed_outputs(
+    types: Dict[str, type],
+    deserializers: Dict[type, Callable[[Any], Any]] | None,
+) -> Dict[str, Any]
+```
+Re-hydrate requested outputs into caller-supplied types. See :meth:`ActionDetails.typed_outputs`.
+
+
+| Parameter | Type | Description |
+|-|-|-|
+| `types` | `Dict[str, type]` | |
+| `deserializers` | `Dict[type, Callable[[Any], Any]] \| None` | |
 

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/secret.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/secret.md
@@ -1,6 +1,6 @@
 ---
 title: Secret
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/settings.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/settings.md
@@ -1,6 +1,6 @@
 ---
 title: Settings
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/task.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/task.md
@@ -1,6 +1,6 @@
 ---
 title: Task
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/taskdetails.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/taskdetails.md
@@ -1,6 +1,6 @@
 ---
 title: TaskDetails
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/timefilter.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/timefilter.md
@@ -1,6 +1,6 @@
 ---
 title: TimeFilter
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/trigger.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/trigger.md
@@ -1,6 +1,6 @@
 ---
 title: Trigger
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.remote/user.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.remote/user.md
@@ -1,6 +1,6 @@
 ---
 title: User
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.report/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.report/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.report
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.report/report.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.report/report.md
@@ -1,6 +1,6 @@
 ---
 title: Report
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.sandbox/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.sandbox/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.sandbox
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.sandbox/codetasktemplate.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.sandbox/codetasktemplate.md
@@ -1,6 +1,6 @@
 ---
 title: CodeTaskTemplate
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.sandbox/imageconfig.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.sandbox/imageconfig.md
@@ -1,6 +1,6 @@
 ---
 title: ImageConfig
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.sandbox/sandboxedconfig.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.sandbox/sandboxedconfig.md
@@ -1,6 +1,6 @@
 ---
 title: SandboxedConfig
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.sandbox/sandboxedtasktemplate.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.sandbox/sandboxedtasktemplate.md
@@ -1,6 +1,6 @@
 ---
 title: SandboxedTaskTemplate
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.storage/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.storage/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.storage
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.storage/abfs.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.storage/abfs.md
@@ -1,6 +1,6 @@
 ---
 title: ABFS
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.storage/gcs.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.storage/gcs.md
@@ -1,6 +1,6 @@
 ---
 title: GCS
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.storage/s3.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.storage/s3.md
@@ -1,6 +1,6 @@
 ---
 title: S3
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.storage/storage.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.storage/storage.md
@@ -1,6 +1,6 @@
 ---
 title: Storage
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.syncify/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.syncify/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.syncify
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.syncify/syncify.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.syncify/syncify.md
@@ -1,6 +1,6 @@
 ---
 title: Syncify
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.types/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.types/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte.types
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.types/flytepickle.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.types/flytepickle.md
@@ -1,6 +1,6 @@
 ---
 title: FlytePickle
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.types/renderable.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.types/renderable.md
@@ -1,6 +1,6 @@
 ---
 title: Renderable
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.types/typeengine.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.types/typeengine.md
@@ -1,6 +1,6 @@
 ---
 title: TypeEngine
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.types/typetransformer.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.types/typetransformer.md
@@ -1,6 +1,6 @@
 ---
 title: TypeTransformer
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte.types/typetransformerfailederror.md
+++ b/content/api-reference/flyte-sdk/packages/flyte.types/typetransformerfailederror.md
@@ -1,6 +1,6 @@
 ---
 title: TypeTransformerFailedError
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/_index.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyte
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---
@@ -68,6 +68,7 @@ Flyte SDK for authoring compound AI applications, services and workflows.
 | [`latest_checkpoint()`](#latest_checkpoint) | Return the file under *root* matching *glob_pattern* with the largest ``key(path)``, or ``None``. |
 | [`map()`](#map) | Map a function over the provided arguments with concurrent execution. |
 | [`new_condition()`](#new_condition) | Create a condition that can be awaited in a workflow. |
+| [`rerun()`](#rerun) | Re-run a prior run, returning a new `Run`. |
 | [`run()`](#run) | Run a task with the given parameters. |
 | [`run_python_script()`](#run_python_script) | Package and run a Python script on a remote Flyte cluster. |
 | [`serve()`](#serve) | Serve a Flyte app using an AppEnvironment. |
@@ -727,6 +728,38 @@ delivers the result as an inline ``Literal`` (protobuf scalar/primitive) in the
 
 **Returns:** An instance of _Condition representing the created condition
 
+#### rerun()
+
+
+> [!NOTE] This method can be called both synchronously or asynchronously.
+> Default invocation is sync and will block.
+> To call it asynchronously, use the function `.aio()` on the method name itself, e.g.,:
+> `result = await rerun.aio()`.
+```python
+def rerun(
+    run_name: str,
+    action_name: str,
+    task_template: TaskTemplate[P, R, F] | None,
+    inputs: Any,
+) -> Run
+```
+Re-run a prior run, returning a new `Run`.
+
+`rerun("r1")` reuses the prior run's exact inputs (fetching its code from the platform);
+pass keyword inputs to change parameters (`rerun("r1", x=2)`), or `task_template=` to substitute
+code. Use `with_runcontext(...).rerun(...)` to apply run-context overrides (env_vars, recover, …).
+
+
+
+| Parameter | Type | Description |
+|-|-|-|
+| `run_name` | `str` | Name of the prior run to re-run. |
+| `action_name` | `str` | Action within the prior run to source the task + inputs from (default `a0`). |
+| `task_template` | `TaskTemplate[P, R, F] \| None` | Optional task to substitute for the prior run's code. |
+| `inputs` | `Any` | Optional native keyword inputs to change parameters; omit to reuse prior inputs. |
+
+**Returns:** the new Run.
+
 #### run()
 
 
@@ -907,6 +940,7 @@ def with_runcontext(
     cache_lookup_scope: CacheLookupScope,
     preserve_original_types: bool,
     debug: bool,
+    recover: bool | str | None,
     _tracker: Any,
 ) -> _Runner
 ```
@@ -968,6 +1002,7 @@ if __name__ == "__main__":
 | `cache_lookup_scope` | `CacheLookupScope` | Optional Scope to use for the run. This is used to specify the scope to use for cache lookups. If not specified, it will be set to the default scope (global unless overridden at the system level). |
 | `preserve_original_types` | `bool` | Optional If true, the type engine will preserve original types (e.g., pd.DataFrame) when guessing python types from literal types. If false (default), it will return the generic flyte.io.DataFrame. This option is automatically set to True if interactive_mode is True unless overridden explicitly by this parameter. |
 | `debug` | `bool` | Optional If true, the task will be run as a VSCode debug task, starting a code-server in the container so users can connect via the UI to interactively debug/run the task. |
+| `recover` | `bool \| str \| None` | Recover (reuse a prior run's succeeded actions, re-running only what failed or changed). ``True`` recovers from the run being rerun — only valid with ``.rerun(...)``; a run-name string recovers from that named run and is the only form valid on ``.run(...)``. Remote-only. Not yet supported by the backend (raises NotImplementedError at submit until flyteidl2 RunSpec.recover ships). |
 | `_tracker` | `Any` | This is an internal only parameter used by the CLI to render the TUI. |
 
 **Returns:** runner

--- a/content/api-reference/flyte-sdk/packages/flyte/apphandle.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/apphandle.md
@@ -1,6 +1,6 @@
 ---
 title: AppHandle
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/backoff.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/backoff.md
@@ -1,6 +1,6 @@
 ---
 title: Backoff
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/basecheckpoint.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/basecheckpoint.md
@@ -1,6 +1,6 @@
 ---
 title: BaseCheckpoint
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/cache.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/cache.md
@@ -1,6 +1,6 @@
 ---
 title: Cache
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/cachepolicy.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/cachepolicy.md
@@ -1,6 +1,6 @@
 ---
 title: CachePolicy
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/checkpoint.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/checkpoint.md
@@ -1,6 +1,6 @@
 ---
 title: Checkpoint
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/conditionwebhook.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/conditionwebhook.md
@@ -1,6 +1,6 @@
 ---
 title: ConditionWebhook
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/cron.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/cron.md
@@ -1,6 +1,6 @@
 ---
 title: Cron
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/device.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/device.md
@@ -1,6 +1,6 @@
 ---
 title: Device
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/environment.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/environment.md
@@ -1,6 +1,6 @@
 ---
 title: Environment
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/fixedrate.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/fixedrate.md
@@ -1,6 +1,6 @@
 ---
 title: FixedRate
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/image.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/image.md
@@ -1,6 +1,6 @@
 ---
 title: Image
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/imagebuild.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/imagebuild.md
@@ -1,6 +1,6 @@
 ---
 title: ImageBuild
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/link.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/link.md
@@ -1,6 +1,6 @@
 ---
 title: Link
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/podtemplate.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/podtemplate.md
@@ -1,6 +1,6 @@
 ---
 title: PodTemplate
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/resources.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/resources.md
@@ -1,6 +1,6 @@
 ---
 title: Resources
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/retrystrategy.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/retrystrategy.md
@@ -1,6 +1,6 @@
 ---
 title: RetryStrategy
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/reusepolicy.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/reusepolicy.md
@@ -1,6 +1,6 @@
 ---
 title: ReusePolicy
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/secret.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/secret.md
@@ -1,6 +1,6 @@
 ---
 title: Secret
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/taskenvironment.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/taskenvironment.md
@@ -1,6 +1,6 @@
 ---
 title: TaskEnvironment
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/timeout.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/timeout.md
@@ -1,6 +1,6 @@
 ---
 title: Timeout
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/flyte-sdk/packages/flyte/trigger.md
+++ b/content/api-reference/flyte-sdk/packages/flyte/trigger.md
@@ -1,6 +1,6 @@
 ---
 title: Trigger
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/anthropic/_index.md
+++ b/content/api-reference/integrations/anthropic/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Anthropic
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/anthropic/classes/_index.md
+++ b/content/api-reference/integrations/anthropic/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/anthropic/packages/_index.md
+++ b/content/api-reference/integrations/anthropic/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/anthropic/packages/flyteplugins.anthropic/_index.md
+++ b/content/api-reference/integrations/anthropic/packages/flyteplugins.anthropic/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.anthropic
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/anthropic/packages/flyteplugins.anthropic/agent.md
+++ b/content/api-reference/integrations/anthropic/packages/flyteplugins.anthropic/agent.md
@@ -1,6 +1,6 @@
 ---
 title: Agent
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/bigquery/_index.md
+++ b/content/api-reference/integrations/bigquery/_index.md
@@ -1,6 +1,6 @@
 ---
 title: BigQuery
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/bigquery/classes/_index.md
+++ b/content/api-reference/integrations/bigquery/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/bigquery/packages/_index.md
+++ b/content/api-reference/integrations/bigquery/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/bigquery/packages/flyteplugins.bigquery/_index.md
+++ b/content/api-reference/integrations/bigquery/packages/flyteplugins.bigquery/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.bigquery
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/bigquery/packages/flyteplugins.bigquery/bigqueryconfig.md
+++ b/content/api-reference/integrations/bigquery/packages/flyteplugins.bigquery/bigqueryconfig.md
@@ -1,6 +1,6 @@
 ---
 title: BigQueryConfig
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/bigquery/packages/flyteplugins.bigquery/bigqueryconnector.md
+++ b/content/api-reference/integrations/bigquery/packages/flyteplugins.bigquery/bigqueryconnector.md
@@ -1,6 +1,6 @@
 ---
 title: BigQueryConnector
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/bigquery/packages/flyteplugins.bigquery/bigquerytask.md
+++ b/content/api-reference/integrations/bigquery/packages/flyteplugins.bigquery/bigquerytask.md
@@ -1,6 +1,6 @@
 ---
 title: BigQueryTask
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/codegen/_index.md
+++ b/content/api-reference/integrations/codegen/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Code generation
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/codegen/classes/_index.md
+++ b/content/api-reference/integrations/codegen/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/codegen/packages/_index.md
+++ b/content/api-reference/integrations/codegen/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/_index.md
+++ b/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.codegen
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/autocoderagent.md
+++ b/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/autocoderagent.md
@@ -1,6 +1,6 @@
 ---
 title: AutoCoderAgent
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/codegenevalresult.md
+++ b/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/codegenevalresult.md
@@ -1,6 +1,6 @@
 ---
 title: CodeGenEvalResult
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/codeplan.md
+++ b/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/codeplan.md
@@ -1,6 +1,6 @@
 ---
 title: CodePlan
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/codesolution.md
+++ b/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/codesolution.md
@@ -1,6 +1,6 @@
 ---
 title: CodeSolution
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/errordiagnosis.md
+++ b/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/errordiagnosis.md
@@ -1,6 +1,6 @@
 ---
 title: ErrorDiagnosis
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/imageconfig.md
+++ b/content/api-reference/integrations/codegen/packages/flyteplugins.codegen/imageconfig.md
@@ -1,6 +1,6 @@
 ---
 title: ImageConfig
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/dask/_index.md
+++ b/content/api-reference/integrations/dask/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Dask
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/dask/classes/_index.md
+++ b/content/api-reference/integrations/dask/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/dask/packages/_index.md
+++ b/content/api-reference/integrations/dask/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/dask/packages/flyteplugins.dask/_index.md
+++ b/content/api-reference/integrations/dask/packages/flyteplugins.dask/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.dask
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/dask/packages/flyteplugins.dask/dask.md
+++ b/content/api-reference/integrations/dask/packages/flyteplugins.dask/dask.md
@@ -1,6 +1,6 @@
 ---
 title: Dask
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/dask/packages/flyteplugins.dask/scheduler.md
+++ b/content/api-reference/integrations/dask/packages/flyteplugins.dask/scheduler.md
@@ -1,6 +1,6 @@
 ---
 title: Scheduler
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/dask/packages/flyteplugins.dask/workergroup.md
+++ b/content/api-reference/integrations/dask/packages/flyteplugins.dask/workergroup.md
@@ -1,6 +1,6 @@
 ---
 title: WorkerGroup
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/databricks/_index.md
+++ b/content/api-reference/integrations/databricks/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Databricks
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/databricks/classes/_index.md
+++ b/content/api-reference/integrations/databricks/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/databricks/packages/_index.md
+++ b/content/api-reference/integrations/databricks/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/databricks/packages/flyteplugins.databricks/_index.md
+++ b/content/api-reference/integrations/databricks/packages/flyteplugins.databricks/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.databricks
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/databricks/packages/flyteplugins.databricks/databricks.md
+++ b/content/api-reference/integrations/databricks/packages/flyteplugins.databricks/databricks.md
@@ -1,6 +1,6 @@
 ---
 title: Databricks
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/databricks/packages/flyteplugins.databricks/databricksconnector.md
+++ b/content/api-reference/integrations/databricks/packages/flyteplugins.databricks/databricksconnector.md
@@ -1,6 +1,6 @@
 ---
 title: DatabricksConnector
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/gemini/_index.md
+++ b/content/api-reference/integrations/gemini/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Gemini
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/gemini/classes/_index.md
+++ b/content/api-reference/integrations/gemini/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/gemini/packages/_index.md
+++ b/content/api-reference/integrations/gemini/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/gemini/packages/flyteplugins.gemini/_index.md
+++ b/content/api-reference/integrations/gemini/packages/flyteplugins.gemini/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.gemini
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/gemini/packages/flyteplugins.gemini/agent.md
+++ b/content/api-reference/integrations/gemini/packages/flyteplugins.gemini/agent.md
@@ -1,6 +1,6 @@
 ---
 title: Agent
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/hitl/_index.md
+++ b/content/api-reference/integrations/hitl/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Human-in-the-Loop
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/hitl/classes/_index.md
+++ b/content/api-reference/integrations/hitl/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/hitl/packages/_index.md
+++ b/content/api-reference/integrations/hitl/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/hitl/packages/flyteplugins.hitl/_index.md
+++ b/content/api-reference/integrations/hitl/packages/flyteplugins.hitl/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.hitl
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/hitl/packages/flyteplugins.hitl/event.md
+++ b/content/api-reference/integrations/hitl/packages/flyteplugins.hitl/event.md
@@ -1,6 +1,6 @@
 ---
 title: Event
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/hydra/_index.md
+++ b/content/api-reference/integrations/hydra/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Hydra
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/hydra/packages/flyteplugins.hydra/_index.md
+++ b/content/api-reference/integrations/hydra/packages/flyteplugins.hydra/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.hydra
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/jsonl/_index.md
+++ b/content/api-reference/integrations/jsonl/_index.md
@@ -1,6 +1,6 @@
 ---
 title: JSONL
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/jsonl/classes/_index.md
+++ b/content/api-reference/integrations/jsonl/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/jsonl/packages/_index.md
+++ b/content/api-reference/integrations/jsonl/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/jsonl/packages/flyteplugins.jsonl/_index.md
+++ b/content/api-reference/integrations/jsonl/packages/flyteplugins.jsonl/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.jsonl
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/jsonl/packages/flyteplugins.jsonl/jsonldir.md
+++ b/content/api-reference/integrations/jsonl/packages/flyteplugins.jsonl/jsonldir.md
@@ -1,6 +1,6 @@
 ---
 title: JsonlDir
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/jsonl/packages/flyteplugins.jsonl/jsonlfile.md
+++ b/content/api-reference/integrations/jsonl/packages/flyteplugins.jsonl/jsonlfile.md
@@ -1,6 +1,6 @@
 ---
 title: JsonlFile
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/mlflow/_index.md
+++ b/content/api-reference/integrations/mlflow/_index.md
@@ -1,6 +1,6 @@
 ---
 title: MLflow
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/mlflow/classes/_index.md
+++ b/content/api-reference/integrations/mlflow/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/mlflow/packages/_index.md
+++ b/content/api-reference/integrations/mlflow/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/mlflow/packages/flyteplugins.mlflow/_index.md
+++ b/content/api-reference/integrations/mlflow/packages/flyteplugins.mlflow/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.mlflow
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/mlflow/packages/flyteplugins.mlflow/mlflow.md
+++ b/content/api-reference/integrations/mlflow/packages/flyteplugins.mlflow/mlflow.md
@@ -1,6 +1,6 @@
 ---
 title: Mlflow
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/omegaconf/_index.md
+++ b/content/api-reference/integrations/omegaconf/_index.md
@@ -1,6 +1,6 @@
 ---
 title: OmegaConf
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/omegaconf/packages/flyteplugins.omegaconf/_index.md
+++ b/content/api-reference/integrations/omegaconf/packages/flyteplugins.omegaconf/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.omegaconf
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/openai/_index.md
+++ b/content/api-reference/integrations/openai/_index.md
@@ -1,6 +1,6 @@
 ---
 title: OpenAI
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/openai/packages/flyteplugins.openai.agents/_index.md
+++ b/content/api-reference/integrations/openai/packages/flyteplugins.openai.agents/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.openai.agents
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/papermill/_index.md
+++ b/content/api-reference/integrations/papermill/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Papermill
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/papermill/classes/_index.md
+++ b/content/api-reference/integrations/papermill/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/papermill/packages/_index.md
+++ b/content/api-reference/integrations/papermill/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/papermill/packages/flyteplugins.papermill/_index.md
+++ b/content/api-reference/integrations/papermill/packages/flyteplugins.papermill/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.papermill
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/papermill/packages/flyteplugins.papermill/notebooktask.md
+++ b/content/api-reference/integrations/papermill/packages/flyteplugins.papermill/notebooktask.md
@@ -1,6 +1,6 @@
 ---
 title: NotebookTask
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/polars/_index.md
+++ b/content/api-reference/integrations/polars/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Polars
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/polars/classes/_index.md
+++ b/content/api-reference/integrations/polars/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/polars/packages/_index.md
+++ b/content/api-reference/integrations/polars/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/polars/packages/flyteplugins.polars.df_transformer/_index.md
+++ b/content/api-reference/integrations/polars/packages/flyteplugins.polars.df_transformer/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.polars.df_transformer
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/polars/packages/flyteplugins.polars.df_transformer/parquettopolarsdecodinghandler.md
+++ b/content/api-reference/integrations/polars/packages/flyteplugins.polars.df_transformer/parquettopolarsdecodinghandler.md
@@ -1,6 +1,6 @@
 ---
 title: ParquetToPolarsDecodingHandler
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/polars/packages/flyteplugins.polars.df_transformer/parquettopolarslazyframedecodinghandler.md
+++ b/content/api-reference/integrations/polars/packages/flyteplugins.polars.df_transformer/parquettopolarslazyframedecodinghandler.md
@@ -1,6 +1,6 @@
 ---
 title: ParquetToPolarsLazyFrameDecodingHandler
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/polars/packages/flyteplugins.polars.df_transformer/polarslazyframetoparquetencodinghandler.md
+++ b/content/api-reference/integrations/polars/packages/flyteplugins.polars.df_transformer/polarslazyframetoparquetencodinghandler.md
@@ -1,6 +1,6 @@
 ---
 title: PolarsLazyFrameToParquetEncodingHandler
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/polars/packages/flyteplugins.polars.df_transformer/polarstoparquetencodinghandler.md
+++ b/content/api-reference/integrations/polars/packages/flyteplugins.polars.df_transformer/polarstoparquetencodinghandler.md
@@ -1,6 +1,6 @@
 ---
 title: PolarsToParquetEncodingHandler
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/pytorch/_index.md
+++ b/content/api-reference/integrations/pytorch/_index.md
@@ -1,6 +1,6 @@
 ---
 title: PyTorch
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/pytorch/classes/_index.md
+++ b/content/api-reference/integrations/pytorch/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/pytorch/packages/_index.md
+++ b/content/api-reference/integrations/pytorch/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/pytorch/packages/flyteplugins.pytorch/_index.md
+++ b/content/api-reference/integrations/pytorch/packages/flyteplugins.pytorch/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.pytorch
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/pytorch/packages/flyteplugins.pytorch/elastic.md
+++ b/content/api-reference/integrations/pytorch/packages/flyteplugins.pytorch/elastic.md
@@ -1,6 +1,6 @@
 ---
 title: Elastic
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/ray/_index.md
+++ b/content/api-reference/integrations/ray/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Ray
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/ray/classes/_index.md
+++ b/content/api-reference/integrations/ray/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/ray/packages/_index.md
+++ b/content/api-reference/integrations/ray/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/ray/packages/flyteplugins.ray/_index.md
+++ b/content/api-reference/integrations/ray/packages/flyteplugins.ray/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.ray
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/ray/packages/flyteplugins.ray/headnodeconfig.md
+++ b/content/api-reference/integrations/ray/packages/flyteplugins.ray/headnodeconfig.md
@@ -1,6 +1,6 @@
 ---
 title: HeadNodeConfig
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/ray/packages/flyteplugins.ray/rayjobconfig.md
+++ b/content/api-reference/integrations/ray/packages/flyteplugins.ray/rayjobconfig.md
@@ -1,6 +1,6 @@
 ---
 title: RayJobConfig
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/ray/packages/flyteplugins.ray/workernodeconfig.md
+++ b/content/api-reference/integrations/ray/packages/flyteplugins.ray/workernodeconfig.md
@@ -1,6 +1,6 @@
 ---
 title: WorkerNodeConfig
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/sglang/_index.md
+++ b/content/api-reference/integrations/sglang/_index.md
@@ -1,6 +1,6 @@
 ---
 title: SGLang
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/sglang/classes/_index.md
+++ b/content/api-reference/integrations/sglang/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/sglang/packages/_index.md
+++ b/content/api-reference/integrations/sglang/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/sglang/packages/flyteplugins.sglang/_index.md
+++ b/content/api-reference/integrations/sglang/packages/flyteplugins.sglang/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.sglang
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/sglang/packages/flyteplugins.sglang/sglangappenvironment.md
+++ b/content/api-reference/integrations/sglang/packages/flyteplugins.sglang/sglangappenvironment.md
@@ -1,6 +1,6 @@
 ---
 title: SGLangAppEnvironment
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/snowflake/_index.md
+++ b/content/api-reference/integrations/snowflake/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Snowflake
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/snowflake/classes/_index.md
+++ b/content/api-reference/integrations/snowflake/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/snowflake/packages/_index.md
+++ b/content/api-reference/integrations/snowflake/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/snowflake/packages/flyteplugins.snowflake/_index.md
+++ b/content/api-reference/integrations/snowflake/packages/flyteplugins.snowflake/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.snowflake
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/snowflake/packages/flyteplugins.snowflake/snowflake.md
+++ b/content/api-reference/integrations/snowflake/packages/flyteplugins.snowflake/snowflake.md
@@ -1,6 +1,6 @@
 ---
 title: Snowflake
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/snowflake/packages/flyteplugins.snowflake/snowflakeconfig.md
+++ b/content/api-reference/integrations/snowflake/packages/flyteplugins.snowflake/snowflakeconfig.md
@@ -1,6 +1,6 @@
 ---
 title: SnowflakeConfig
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/snowflake/packages/flyteplugins.snowflake/snowflakeconnector.md
+++ b/content/api-reference/integrations/snowflake/packages/flyteplugins.snowflake/snowflakeconnector.md
@@ -1,6 +1,6 @@
 ---
 title: SnowflakeConnector
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/spark/_index.md
+++ b/content/api-reference/integrations/spark/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Spark
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/spark/classes/_index.md
+++ b/content/api-reference/integrations/spark/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/spark/packages/_index.md
+++ b/content/api-reference/integrations/spark/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/spark/packages/flyteplugins.spark/_index.md
+++ b/content/api-reference/integrations/spark/packages/flyteplugins.spark/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.spark
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/spark/packages/flyteplugins.spark/parquettosparkdecoder.md
+++ b/content/api-reference/integrations/spark/packages/flyteplugins.spark/parquettosparkdecoder.md
@@ -1,6 +1,6 @@
 ---
 title: ParquetToSparkDecoder
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/spark/packages/flyteplugins.spark/spark.md
+++ b/content/api-reference/integrations/spark/packages/flyteplugins.spark/spark.md
@@ -1,6 +1,6 @@
 ---
 title: Spark
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/spark/packages/flyteplugins.spark/sparktoparquetencoder.md
+++ b/content/api-reference/integrations/spark/packages/flyteplugins.spark/sparktoparquetencoder.md
@@ -1,6 +1,6 @@
 ---
 title: SparkToParquetEncoder
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/vllm/_index.md
+++ b/content/api-reference/integrations/vllm/_index.md
@@ -1,6 +1,6 @@
 ---
 title: vLLM
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/vllm/classes/_index.md
+++ b/content/api-reference/integrations/vllm/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/vllm/packages/_index.md
+++ b/content/api-reference/integrations/vllm/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/vllm/packages/flyteplugins.vllm/_index.md
+++ b/content/api-reference/integrations/vllm/packages/flyteplugins.vllm/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.vllm
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/vllm/packages/flyteplugins.vllm/vllmappenvironment.md
+++ b/content/api-reference/integrations/vllm/packages/flyteplugins.vllm/vllmappenvironment.md
@@ -1,6 +1,6 @@
 ---
 title: VLLMAppEnvironment
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/wandb/_index.md
+++ b/content/api-reference/integrations/wandb/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Weights & Biases
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/wandb/classes/_index.md
+++ b/content/api-reference/integrations/wandb/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/wandb/packages/_index.md
+++ b/content/api-reference/integrations/wandb/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/wandb/packages/flyteplugins.wandb/_index.md
+++ b/content/api-reference/integrations/wandb/packages/flyteplugins.wandb/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.wandb
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/wandb/packages/flyteplugins.wandb/wandb.md
+++ b/content/api-reference/integrations/wandb/packages/flyteplugins.wandb/wandb.md
@@ -1,6 +1,6 @@
 ---
 title: Wandb
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/integrations/wandb/packages/flyteplugins.wandb/wandbsweep.md
+++ b/content/api-reference/integrations/wandb/packages/flyteplugins.wandb/wandbsweep.md
@@ -1,6 +1,6 @@
 ---
 title: WandbSweep
-version: 2.5.2
+version: 2.5.6
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/union-plugin/_index.md
+++ b/content/api-reference/union-plugin/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Union plugin
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 weight: 5
@@ -16,6 +16,7 @@ weight: 5
 
 | Class | Description |
 |-|-|
+| [`flyteplugins.union.debug.SSHDebug`](packages/flyteplugins.union.debug/sshdebug) | Resolved SSH-into-task connect info for a running debug action. |
 | [`flyteplugins.union.errors.VolumeCommandError`](packages/flyteplugins.union.errors/volumecommanderror) | A backend CLI invocation (e. |
 | [`flyteplugins.union.errors.VolumeCommitError`](packages/flyteplugins.union.errors/volumecommiterror) | A keep-alive checkpoint could not be made durable: the writeback staging. |
 | [`flyteplugins.union.errors.VolumeError`](packages/flyteplugins.union.errors/volumeerror) | Base for Volume *system* failures — infra/runtime problems the caller. |
@@ -27,6 +28,7 @@ weight: 5
 | [`flyteplugins.union.errors.VolumeNotMounted`](packages/flyteplugins.union.errors/volumenotmounted) | An operation that needs a live mount was called on an unmounted Volume. |
 | [`flyteplugins.union.errors.VolumeStoreTypeNotSet`](packages/flyteplugins.union.errors/volumestoretypenotset) | The Volume's ``metadata_store_type`` is unset and couldn't be resolved. |
 | [`flyteplugins.union.errors.VolumeUnmountError`](packages/flyteplugins.union.errors/volumeunmounterror) | The volume could not be unmounted (``fusermount`` kept returning EBUSY). |
+| [`flyteplugins.union.errors.VolumeUnmountUnsupportedError`](packages/flyteplugins.union.errors/volumeunmountunsupportederror) | The runtime cannot unmount the FUSE client at all because ``fusermount``. |
 | [`flyteplugins.union.errors.VolumeUsageError`](packages/flyteplugins.union.errors/volumeusageerror) | Base for Volume *user* errors — caller misuse the caller can fix. |
 | [`flyteplugins.union.io.ActionRef`](packages/flyteplugins.union.io/actionref) | Provenance: the action (one task execution within a run) that. |
 | [`flyteplugins.union.io.ROVolume`](packages/flyteplugins.union.io/rovolume) | Immutable, versioned volume — PRD §Core Concepts. |
@@ -40,6 +42,7 @@ weight: 5
 | [`flyteplugins.union.remote.Policy`](packages/flyteplugins.union.remote/policy) | Represents a Union RBAC Policy. |
 | [`flyteplugins.union.remote.Queue`](packages/flyteplugins.union.remote/queue) | Represents a Union scheduling queue. |
 | [`flyteplugins.union.remote.Role`](packages/flyteplugins.union.remote/role) | Represents a Union RBAC Role. |
+| [`flyteplugins.union.remote.SSHDebug`](packages/flyteplugins.union.remote/sshdebug) | Resolved SSH-into-task connect info for a running debug action. |
 | [`flyteplugins.union.remote.User`](packages/flyteplugins.union.remote/user) | Represents a Union user. |
 | [`flyteplugins.union.remote.VolumeExplore`](packages/flyteplugins.union.remote/volumeexplore) | A resolved :class:`Volume` plus the IO to inspect and walk its lineage. |
 | [`flyteplugins.union.remote.VolumeResolveError`](packages/flyteplugins.union.remote/volumeresolveerror) | No (or ambiguous) Volume-typed value could be resolved on an action. |
@@ -52,6 +55,7 @@ weight: 5
 | [`flyteplugins.union.cli`](packages/flyteplugins.union.cli/_index) |  |
 | [`flyteplugins.union.cli.cluster_pool`](packages/flyteplugins.union.cli.cluster_pool/_index) |  |
 | [`flyteplugins.union.cli.queue`](packages/flyteplugins.union.cli.queue/_index) |  |
+| [`flyteplugins.union.debug`](packages/flyteplugins.union.debug/_index) | SSH-into-task debug helpers. |
 | [`flyteplugins.union.errors`](packages/flyteplugins.union.errors/_index) | Volume-specific runtime errors. |
 | [`flyteplugins.union.internal.validate.validate.validate_pb2`](packages/flyteplugins.union.internal.validate.validate.validate_pb2/_index) | Generated protocol buffer code. |
 | [`flyteplugins.union.io`](packages/flyteplugins.union.io/_index) | Persistent, mountable :class:`Volume` type for the Flyte SDK v2. |
@@ -59,4 +63,5 @@ weight: 5
 | [`flyteplugins.union.utils`](packages/flyteplugins.union.utils/_index) | Public utilities for ``flyteplugins. |
 | [`flyteplugins.union.utils.auth`](packages/flyteplugins.union.utils.auth/_index) |  |
 | [`flyteplugins.union.utils.image`](packages/flyteplugins.union.utils.image/_index) | Shared helpers for building :class:`flyte. |
+| [`flyteplugins.union.ws_proxy`](packages/flyteplugins.union.ws_proxy/_index) | Stdio <-> WebSocket proxy used as an ssh ``ProxyCommand`` for ssh-into-task. |
 

--- a/content/api-reference/union-plugin/classes/_index.md
+++ b/content/api-reference/union-plugin/classes/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Classes
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---
@@ -9,6 +9,7 @@ layout: py_api
 
 | Class | Description |
 |-|-|
+| [`flyteplugins.union.debug.SSHDebug`](../packages/flyteplugins.union.debug/sshdebug) |Resolved SSH-into-task connect info for a running debug action. |
 | [`flyteplugins.union.errors.VolumeCommandError`](../packages/flyteplugins.union.errors/volumecommanderror) |A backend CLI invocation (e. |
 | [`flyteplugins.union.errors.VolumeCommitError`](../packages/flyteplugins.union.errors/volumecommiterror) |A keep-alive checkpoint could not be made durable: the writeback staging. |
 | [`flyteplugins.union.errors.VolumeError`](../packages/flyteplugins.union.errors/volumeerror) |Base for Volume *system* failures — infra/runtime problems the caller. |
@@ -20,6 +21,7 @@ layout: py_api
 | [`flyteplugins.union.errors.VolumeNotMounted`](../packages/flyteplugins.union.errors/volumenotmounted) |An operation that needs a live mount was called on an unmounted Volume. |
 | [`flyteplugins.union.errors.VolumeStoreTypeNotSet`](../packages/flyteplugins.union.errors/volumestoretypenotset) |The Volume's ``metadata_store_type`` is unset and couldn't be resolved. |
 | [`flyteplugins.union.errors.VolumeUnmountError`](../packages/flyteplugins.union.errors/volumeunmounterror) |The volume could not be unmounted (``fusermount`` kept returning EBUSY). |
+| [`flyteplugins.union.errors.VolumeUnmountUnsupportedError`](../packages/flyteplugins.union.errors/volumeunmountunsupportederror) |The runtime cannot unmount the FUSE client at all because ``fusermount``. |
 | [`flyteplugins.union.errors.VolumeUsageError`](../packages/flyteplugins.union.errors/volumeusageerror) |Base for Volume *user* errors — caller misuse the caller can fix. |
 | [`flyteplugins.union.io.ActionRef`](../packages/flyteplugins.union.io/actionref) |Provenance: the action (one task execution within a run) that. |
 | [`flyteplugins.union.io.ROVolume`](../packages/flyteplugins.union.io/rovolume) |Immutable, versioned volume — PRD §Core Concepts. |
@@ -33,6 +35,7 @@ layout: py_api
 | [`flyteplugins.union.remote.Policy`](../packages/flyteplugins.union.remote/policy) |Represents a Union RBAC Policy. |
 | [`flyteplugins.union.remote.Queue`](../packages/flyteplugins.union.remote/queue) |Represents a Union scheduling queue. |
 | [`flyteplugins.union.remote.Role`](../packages/flyteplugins.union.remote/role) |Represents a Union RBAC Role. |
+| [`flyteplugins.union.remote.SSHDebug`](../packages/flyteplugins.union.remote/sshdebug) |Resolved SSH-into-task connect info for a running debug action. |
 | [`flyteplugins.union.remote.User`](../packages/flyteplugins.union.remote/user) |Represents a Union user. |
 | [`flyteplugins.union.remote.VolumeExplore`](../packages/flyteplugins.union.remote/volumeexplore) |A resolved :class:`Volume` plus the IO to inspect and walk its lineage. |
 | [`flyteplugins.union.remote.VolumeResolveError`](../packages/flyteplugins.union.remote/volumeresolveerror) |No (or ambiguous) Volume-typed value could be resolved on an action. |

--- a/content/api-reference/union-plugin/packages/_index.md
+++ b/content/api-reference/union-plugin/packages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Packages
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---
@@ -12,6 +12,7 @@ layout: py_api
 | [`flyteplugins.union.cli`](flyteplugins.union.cli/_index) |  |
 | [`flyteplugins.union.cli.cluster_pool`](flyteplugins.union.cli.cluster_pool/_index) |  |
 | [`flyteplugins.union.cli.queue`](flyteplugins.union.cli.queue/_index) |  |
+| [`flyteplugins.union.debug`](flyteplugins.union.debug/_index) | SSH-into-task debug helpers. |
 | [`flyteplugins.union.errors`](flyteplugins.union.errors/_index) | Volume-specific runtime errors. |
 | [`flyteplugins.union.internal.validate.validate.validate_pb2`](flyteplugins.union.internal.validate.validate.validate_pb2/_index) | Generated protocol buffer code. |
 | [`flyteplugins.union.io`](flyteplugins.union.io/_index) | Persistent, mountable :class:`Volume` type for the Flyte SDK v2. |
@@ -19,3 +20,4 @@ layout: py_api
 | [`flyteplugins.union.utils`](flyteplugins.union.utils/_index) | Public utilities for ``flyteplugins. |
 | [`flyteplugins.union.utils.auth`](flyteplugins.union.utils.auth/_index) |  |
 | [`flyteplugins.union.utils.image`](flyteplugins.union.utils.image/_index) | Shared helpers for building :class:`flyte. |
+| [`flyteplugins.union.ws_proxy`](flyteplugins.union.ws_proxy/_index) | Stdio <-> WebSocket proxy used as an ssh ``ProxyCommand`` for ssh-into-task. |

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.cli.cluster_pool/_index.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.cli.cluster_pool/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.union.cli.cluster_pool
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.cli.queue/_index.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.cli.queue/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.union.cli.queue
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.cli/_index.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.cli/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.union.cli
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.debug/_index.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.debug/_index.md
@@ -1,0 +1,66 @@
+---
+title: flyteplugins.union.debug
+version: 0.4.3
+variants: +flyte +union
+layout: py_api
+---
+
+# flyteplugins.union.debug
+
+SSH-into-task debug helpers.
+
+`with_debugcontext(...)` is `flyte.with_runcontext(...)` preconfigured for
+ssh-into-task debug: it creates/uses the auto-managed debug keypair and sets the
+``_F_E_SSH`` / ``_F_SSH_PK`` / ``_F_E_VS`` env vars, then forwards everything
+else to `flyte.with_runcontext`. After the run starts, resolve the connection
+with `SSHDebug.connect(run.name)` (or the `flyte connect ssh <run>` CLI).
+
+Example:
+```python
+import flyte
+from flyteplugins.union.debug import with_debugcontext, SSHDebug
+
+flyte.init_from_config()
+run = with_debugcontext().run(my_task, x=1)
+print(SSHDebug.connect(run.name).ssh_config)   # paste into ~/.ssh/config, then `ssh flyte-debug`
+```
+## Directory
+
+### Classes
+
+| Class | Description |
+|-|-|
+| [`SSHDebug`](../flyteplugins.union.debug/sshdebug) | Resolved SSH-into-task connect info for a running debug action. |
+
+### Methods
+
+| Method | Description |
+|-|-|
+| [`with_debugcontext()`](#with_debugcontext) | Like `flyte. |
+
+
+## Methods
+
+#### with_debugcontext()
+
+```python
+def with_debugcontext(
+    mode: Any,
+    env_vars: Optional[Dict[str, str]],
+    kwargs,
+)
+```
+Like `flyte.with_runcontext`, but preconfigured for ssh-into-task debug.
+
+Ensures the auto-managed debug keypair exists and merges the ssh-debug env
+(``_F_E_SSH`` / ``_F_SSH_PK`` / ``_F_E_VS``) into *env_vars*; all other
+arguments are forwarded unchanged. Returns the same runner as
+`with_runcontext`, so call ``.run(task, ...)`` on it.
+
+
+| Parameter | Type | Description |
+|-|-|-|
+| `mode` | `Any` | |
+| `env_vars` | `Optional[Dict[str, str]]` | |
+| `kwargs` | `**kwargs` | |
+

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.debug/sshdebug.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.debug/sshdebug.md
@@ -1,0 +1,147 @@
+---
+title: SSHDebug
+version: 0.4.3
+variants: +flyte +union
+layout: py_api
+---
+
+# SSHDebug
+
+**Package:** `flyteplugins.union.debug`
+
+Resolved SSH-into-task connect info for a running debug action.
+
+
+## Parameters
+
+```python
+class SSHDebug(
+    run_name: str,
+    action_name: str,
+    wss_url: str,
+    ssh_config: str,
+    host_alias: str,
+    headers_file: Optional[str],
+)
+```
+| Parameter | Type | Description |
+|-|-|-|
+| `run_name` | `str` | |
+| `action_name` | `str` | |
+| `wss_url` | `str` | |
+| `ssh_config` | `str` | |
+| `host_alias` | `str` | |
+| `headers_file` | `Optional[str]` | |
+
+## Methods
+
+| Method | Description |
+|-|-|
+| [`connect()`](#connect) | Resolve connect info for a running ssh-debug action. |
+| [`ensure_api_key()`](#ensure_api_key) | Ensure a dedicated, long-lived API key (client credentials) exists; return it encoded. |
+| [`ensure_keypair()`](#ensure_keypair) | Ensure the auto-managed debug keypair exists; return (private_key_path, public_key). |
+| [`launch_env()`](#launch_env) | Env vars to enable ssh-debug on a run, with the debug pubkey auto-injected. |
+
+
+### connect()
+
+
+> [!NOTE] This method can be called both synchronously or asynchronously.
+> Default invocation is sync and will block.
+> To call it asynchronously, use the function `.aio()` on the method name itself, e.g.,:
+> `result = await SSHDebug.connect.aio()`.
+```python
+def connect(
+    cls,
+    run_name: str,
+    action_name: str,
+    user: str,
+    identity_file: Optional[str],
+    host_alias: str,
+    use_api_key: bool,
+    refresh_token: bool,
+    headers_file: Optional[str],
+    timeout: float,
+    poll_interval: float,
+) -> 'SSHDebug'
+```
+Resolve connect info for a running ssh-debug action.
+
+Polls the action until its ``:6060`` IDE route is ready (or *timeout*),
+mints (or reuses a cached) Bearer token for the ingress, writes the
+headers file, and renders the ssh-config block. *identity_file* defaults
+to the auto-managed ``~/.flyte/ssh-debug/id_ed25519`` (created on launch).
+
+
+
+| Parameter | Type | Description |
+|-|-|-|
+| `cls` |  | |
+| `run_name` | `str` | |
+| `action_name` | `str` | |
+| `user` | `str` | |
+| `identity_file` | `Optional[str]` | |
+| `host_alias` | `str` | |
+| `use_api_key` | `bool` | |
+| `refresh_token` | `bool` | |
+| `headers_file` | `Optional[str]` | |
+| `timeout` | `float` | |
+| `poll_interval` | `float` | |
+
+**Raises**
+
+| Exception | Description |
+|-|-|
+| `TimeoutError` | if the debug route never becomes ready. |
+
+### ensure_api_key()
+
+```python
+def ensure_api_key(
+    name: str,
+) -> str
+```
+Ensure a dedicated, long-lived API key (client credentials) exists; return it encoded.
+
+Reuses the locally-stored key if it still exists server-side (verified with
+``ApiKey.get`` — the "api-key get to check for existence" path). Otherwise
+creates a fresh one and stores it 0600. Use this for headless, reusable auth
+that doesn't expire mid-session like an interactive user JWT.
+
+
+| Parameter | Type | Description |
+|-|-|-|
+| `name` | `str` | |
+
+### ensure_keypair()
+
+```python
+def ensure_keypair()
+```
+Ensure the auto-managed debug keypair exists; return (private_key_path, public_key).
+
+Generates an ed25519 keypair at ``~/.flyte/ssh-debug/id_ed25519`` the first
+time, then reuses it. The public key is what gets injected into the run
+(``_F_SSH_PK``); the private key is what ``flyte connect ssh`` authenticates
+with. Idempotent.
+
+
+### launch_env()
+
+```python
+def launch_env(
+    extra: Optional[dict],
+) -> dict
+```
+Env vars to enable ssh-debug on a run, with the debug pubkey auto-injected.
+
+Use with the run launcher so users don't manage keys or env vars::
+
+    run = flyte.with_runcontext(env_vars=SSHDebug.launch_env()).run(task)
+    info = SSHDebug.connect(run.name)   # uses the same auto-managed key
+
+
+| Parameter | Type | Description |
+|-|-|-|
+| `extra` | `Optional[dict]` | |
+

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.errors/_index.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.errors/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.union.errors
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---
@@ -34,5 +34,6 @@ envelope) via the ``_code`` class attribute; subclasses just override it.
 | [`VolumeNotMounted`](../flyteplugins.union.errors/volumenotmounted) | An operation that needs a live mount was called on an unmounted Volume. |
 | [`VolumeStoreTypeNotSet`](../flyteplugins.union.errors/volumestoretypenotset) | The Volume's ``metadata_store_type`` is unset and couldn't be resolved. |
 | [`VolumeUnmountError`](../flyteplugins.union.errors/volumeunmounterror) | The volume could not be unmounted (``fusermount`` kept returning EBUSY). |
+| [`VolumeUnmountUnsupportedError`](../flyteplugins.union.errors/volumeunmountunsupportederror) | The runtime cannot unmount the FUSE client at all because ``fusermount``. |
 | [`VolumeUsageError`](../flyteplugins.union.errors/volumeusageerror) | Base for Volume *user* errors — caller misuse the caller can fix. |
 

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.errors/volumecommanderror.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.errors/volumecommanderror.md
@@ -1,6 +1,6 @@
 ---
 title: VolumeCommandError
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.errors/volumecommiterror.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.errors/volumecommiterror.md
@@ -1,6 +1,6 @@
 ---
 title: VolumeCommitError
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.errors/volumeerror.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.errors/volumeerror.md
@@ -1,6 +1,6 @@
 ---
 title: VolumeError
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.errors/volumemigratenoop.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.errors/volumemigratenoop.md
@@ -1,6 +1,6 @@
 ---
 title: VolumeMigrateNoop
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.errors/volumemounterror.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.errors/volumemounterror.md
@@ -1,6 +1,6 @@
 ---
 title: VolumeMountError
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.errors/volumemounttimeout.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.errors/volumemounttimeout.md
@@ -1,6 +1,6 @@
 ---
 title: VolumeMountTimeout
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.errors/volumenoindex.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.errors/volumenoindex.md
@@ -1,6 +1,6 @@
 ---
 title: VolumeNoIndex
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.errors/volumenotforkable.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.errors/volumenotforkable.md
@@ -1,6 +1,6 @@
 ---
 title: VolumeNotForkable
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.errors/volumenotmounted.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.errors/volumenotmounted.md
@@ -1,6 +1,6 @@
 ---
 title: VolumeNotMounted
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.errors/volumestoretypenotset.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.errors/volumestoretypenotset.md
@@ -1,6 +1,6 @@
 ---
 title: VolumeStoreTypeNotSet
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.errors/volumeunmounterror.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.errors/volumeunmounterror.md
@@ -1,6 +1,6 @@
 ---
 title: VolumeUnmountError
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.errors/volumeunmountunsupportederror.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.errors/volumeunmountunsupportederror.md
@@ -1,0 +1,32 @@
+---
+title: VolumeUnmountUnsupportedError
+version: 0.4.3
+variants: +flyte +union
+layout: py_api
+---
+
+# VolumeUnmountUnsupportedError
+
+**Package:** `flyteplugins.union.errors`
+
+The runtime cannot unmount the FUSE client at all because ``fusermount``
+can't reach its mount table (``/etc/mtab`` is missing, read-only, or
+unwritable). Unlike a transient :class:`VolumeUnmountError` (EBUSY), retrying
+won't help — the image is missing the ``/etc/mtab`` → ``/proc/self/mounts``
+symlink most base images carry. The terminal seal treats this as recoverable:
+it falls back to a keep-alive (live) commit, leaving the mount in place. A
+kind of :class:`VolumeUnmountError`, so ``except VolumeUnmountError`` catches
+it too.
+
+
+## Parameters
+
+```python
+class VolumeUnmountUnsupportedError(
+    message: str,
+)
+```
+| Parameter | Type | Description |
+|-|-|-|
+| `message` | `str` | |
+

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.errors/volumeusageerror.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.errors/volumeusageerror.md
@@ -1,6 +1,6 @@
 ---
 title: VolumeUsageError
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.internal.validate.validate.validate_pb2/_index.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.internal.validate.validate.validate_pb2/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.union.internal.validate.validate.validate_pb2
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.io/_index.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.io/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.union.io
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---
@@ -35,7 +35,7 @@ under :mod:`flyteplugins.union.io._internal` and is not part of the public API.
 
 | Method | Description |
 |-|-|
-| [`with_high_throughput_volume_deps()`](#with_high_throughput_volume_deps) | Provision the in-pod Redis metadata daemon on ``base`` for Volumes that. |
+| [`with_high_throughput_volume_deps()`](#with_high_throughput_volume_deps) | Prepare ``base`` for high-throughput (Redis-backed) Volumes. |
 
 
 ## Methods
@@ -47,11 +47,14 @@ def with_high_throughput_volume_deps(
     base: Image,
 ) -> Image
 ```
-Provision the in-pod Redis metadata daemon on ``base`` for Volumes that
-use ``metadata_store_type="redis"``.
+Prepare ``base`` for high-throughput (Redis-backed) Volumes.
 
 Returns a new :class:`flyte.Image` that, on top of ``base``:
 
+* installs ``fuse3`` — the ``fusermount3`` userspace helper JuiceFS execs to
+  mount the FUSE filesystem. *Every* Volume mount needs this under the
+  default unprivileged :meth:`flyte.PodTemplate.allow_fuse`; without it the
+  mount client exits immediately with ``fuse: fuse is not installed``;
 * installs ``redis-server`` / ``redis-tools`` (the in-pod daemon the Redis
   store runs against), and
 * sets ``UNION_VOLUME_METADATA_STORE=redis`` so volumes created in this
@@ -59,11 +62,11 @@ Returns a new :class:`flyte.Image` that, on top of ``base``:
   without the caller passing ``metadata_store_type=`` each time (still
   overridable per-volume).
 
-This is the **only** image helper Volumes need. The default SQLite store
-runs in-process and mounts via raw syscalls under ``CAP_SYS_ADMIN`` +
-``/dev/fuse`` (``enable_fuse_mount=True`` on the
-:class:`flyte.TaskEnvironment`) — so a plain image that pip-installs
-``flyteplugins-union`` Just Works for it, no extra apt packages.
+With this helper the image is complete: just add
+``pod_template=flyte.PodTemplate().allow_fuse()`` to the
+:class:`flyte.TaskEnvironment` and Volumes mount and run. For the default
+SQLite store you don't need Redis, but you *do* still need ``fuse3`` —
+install it with ``image.with_apt_packages("fuse3")`` (see :meth:`Volume.mount`).
 
 
 | Parameter | Type | Description |

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.io/actionref.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.io/actionref.md
@@ -1,6 +1,6 @@
 ---
 title: ActionRef
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.io/rovolume.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.io/rovolume.md
@@ -1,6 +1,6 @@
 ---
 title: ROVolume
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---
@@ -66,6 +66,13 @@ validated to form a valid model.
 | `produced_by` | `typing.Optional[flyteplugins.union.io._base_volume.ActionRef]` | |
 | `parent_produced_by` | `typing.Optional[flyteplugins.union.io._base_volume.ActionRef]` | |
 
+## Properties
+
+| Property | Type | Description |
+|-|-|-|
+| `locator` | `Optional[str]` | The object-store address of *this* published version, or ``None`` if the volume has never been sealed (a fresh :meth:`new` / :meth:`empty`).  It's the path of this version's metadata object (``produced_by.locator`` — the JSON value :func:`_publish_metadata` writes), which carries the complete Volume: ``index``, ``bucket``, ``metadata_store_type``, stats, and lineage. Persist it anywhere (a task output, your own store, a config) and recover the exact version later with :meth:`from_locator` — that's the across-run handle that doesn't depend on name or live task context.  Available immediately off a :meth:`RWVolume.commit` / ``finalize`` / :meth:`fork` result, since each stamps ``produced_by`` on the version it publishes. ``None`` before the first seal — there's no version to point at yet.  Durability note: the address lives under the producing action's output path, so it stays resolvable as long as that action's artifacts are retained. |
+| `mount_path` | `Optional[Path]` | Where this handle is currently mounted, or ``None`` if not mounted.  Set by :meth:`mount` and cleared by the terminal seal (:meth:`RWVolume.finalize` / auto-finalize). Use it to locate files without re-deriving the path: ``(vol.mount_path / "data.bin")``. |
+
 ## Methods
 
 | Method | Description |
@@ -73,9 +80,10 @@ validated to form a valid model.
 | [`commit()`](#commit) | **Deprecated. |
 | [`empty()`](#empty) | Declare a brand-new volume. |
 | [`fork()`](#fork) | Branch this immutable into a new writable working copy. |
+| [`from_locator()`](#from_locator) | Load a previously published volume version by its :attr:`locator`. |
 | [`migrate_metadata_store_type()`](#migrate_metadata_store_type) | Re-host this Volume's metadata on ``new_metadata_store_type``. |
 | [`model_post_init()`](#model_post_init) | This function is meant to behave like a BaseModel method to initialize private attributes. |
-| [`mount()`](#mount) | Mount this volume read-only at ``mount_path``. |
+| [`mount()`](#mount) | Mount this volume read-only at ``mount_path`` and return the path. |
 | [`new()`](#new) | PRD §Lifecycle: create a fresh empty :class:`RWVolume`. |
 
 
@@ -83,8 +91,8 @@ validated to form a valid model.
 
 ```python
 def commit(
-    mount_path: str,
-    meta_dir: str,
+    mount_path: Optional[str],
+    meta_dir: Optional[str],
     timeout: float,
     message: Optional[str],
 ) -> 'Volume'
@@ -102,8 +110,8 @@ working; it emits :class:`DeprecationWarning`.
 
 | Parameter | Type | Description |
 |-|-|-|
-| `mount_path` | `str` | |
-| `meta_dir` | `str` | |
+| `mount_path` | `Optional[str]` | |
+| `meta_dir` | `Optional[str]` | |
 | `timeout` | `float` | |
 | `message` | `Optional[str]` | |
 
@@ -127,18 +135,24 @@ task context as ``{raw_data_root}/{project}/{domain}/volumes`` —
 following Flyte's own layout for offloaded data. Must be called
 from inside a task in that case.
 
+Regardless of store type, *mounting* the returned Volume needs a
+FUSE-capable image and pod — the ``fuse3`` apt package and
+``flyte.PodTemplate().allow_fuse()`` — see :meth:`mount` for the full
+runtime requirements.
+
 ``metadata_store_type`` controls the in-pod metadata backend. When
 omitted it resolves from ``$UNION_VOLUME_METADATA_STORE`` and
 otherwise defaults to ``"sqlite"``.
 
 * ``"sqlite"`` (default) keeps the namespace in a local SQLite file —
-  runs in-process with no extra package in the task image, and supports
-  :meth:`fork`.
+  runs in-process and needs no *extra* package beyond ``fuse3``, and
+  supports :meth:`fork`.
 * ``"redis"`` runs an in-process ``redis-server`` and persists the
   namespace as an RDB snapshot — faster than the embedded stores for
-  metadata-heavy workloads, but requires ``redis-server`` in the image
-  (see :func:`with_high_throughput_volume_deps`, which also sets
-  ``$UNION_VOLUME_METADATA_STORE=redis`` so it is the default there).
+  metadata-heavy workloads, but additionally requires ``redis-server``
+  in the image. Use :func:`with_high_throughput_volume_deps`, which
+  installs ``fuse3`` + ``redis-server`` and sets
+  ``$UNION_VOLUME_METADATA_STORE=redis`` so Redis is the default there.
 
 The choice is baked into the Volume and travels with it through
 lineage; subsequent mounts of the same Volume must use the same
@@ -170,7 +184,7 @@ the consumer's env.
 ```python
 def fork(
     name: str,
-    meta_dir: str,
+    meta_dir: Optional[str],
     timeout: float,
 ) -> 'RWVolume'
 ```
@@ -185,15 +199,42 @@ colliding on shared keys.
 | Parameter | Type | Description |
 |-|-|-|
 | `name` | `str` | |
-| `meta_dir` | `str` | |
+| `meta_dir` | `Optional[str]` | |
 | `timeout` | `float` | |
+
+### from_locator()
+
+```python
+def from_locator(
+    locator: str,
+) -> 'ROVolume'
+```
+Load a previously published volume version by its :attr:`locator`.
+
+The inverse of :attr:`locator`: download the metadata object at
+``locator`` (the full serialized Volume value) and reconstruct it as an
+immutable :class:`ROVolume` — ``index``, ``bucket``,
+``metadata_store_type``, stats and lineage all recovered, so the result
+is mountable read-only (or :meth:`fork`-able to branch + write) without
+any other arguments. This is how you reference a specific volume version
+across runs: stash ``vol.locator`` somewhere, then ``Volume.from_locator``
+it back later.
+
+Reads only the metadata object; the index and chunks are fetched lazily
+by :meth:`mount`. Needs object-store credentials for ``locator`` but no
+active task context. Raises :class:`VolumeError` if ``locator`` is empty.
+
+
+| Parameter | Type | Description |
+|-|-|-|
+| `locator` | `str` | |
 
 ### migrate_metadata_store_type()
 
 ```python
 def migrate_metadata_store_type(
     new_metadata_store_type: str,
-    meta_dir: str,
+    meta_dir: Optional[str],
     new_meta_dir: Optional[str],
 ) -> 'Volume'
 ```
@@ -226,7 +267,7 @@ one of the stores is ``"redis"``).
 | Parameter | Type | Description |
 |-|-|-|
 | `new_metadata_store_type` | `str` | |
-| `meta_dir` | `str` | |
+| `meta_dir` | `Optional[str]` | |
 | `new_meta_dir` | `Optional[str]` | |
 
 ### model_post_init()
@@ -250,28 +291,29 @@ It takes context as an argument since that's what pydantic-core passes when call
 
 ```python
 def mount(
-    mount_path: str,
-    meta_dir: str,
-    cache_dir: str,
+    mount_path: Optional[str],
+    meta_dir: Optional[str],
+    cache_dir: Optional[str],
     timeout: float,
     attr_cache: float,
     entry_cache: float,
     dir_entry_cache: float,
-)
+) -> Path
 ```
-Mount this volume read-only at ``mount_path``.
+Mount this volume read-only at ``mount_path`` and return the path.
 
-``read_only`` is intentionally absent from the signature — an
-:class:`ROVolume` is statically un-writable, so the writeback /
-upload-delay knobs that only make sense for write-paths are
+Unset paths default to this volume's name-keyed locations (see
+:meth:`Volume.mount`). ``read_only`` is intentionally absent from the
+signature — an :class:`ROVolume` is statically un-writable, so the
+writeback / upload-delay knobs that only make sense for write-paths are
 omitted too.
 
 
 | Parameter | Type | Description |
 |-|-|-|
-| `mount_path` | `str` | |
-| `meta_dir` | `str` | |
-| `cache_dir` | `str` | |
+| `mount_path` | `Optional[str]` | |
+| `meta_dir` | `Optional[str]` | |
+| `cache_dir` | `Optional[str]` | |
 | `timeout` | `float` | |
 | `attr_cache` | `float` | |
 | `entry_cache` | `float` | |
@@ -300,6 +342,10 @@ Equivalent in mechanics to :meth:`empty`, but:
 
 Prefer :meth:`new` in new code; :meth:`empty` is retained for
 existing callers that already declare ``-&gt; Volume``.
+
+Creating the handle does no I/O; the first :meth:`mount` formats the
+namespace and needs a FUSE-capable image + pod (``fuse3`` and
+``allow_fuse()`` — see :meth:`mount`).
 
 
 | Parameter | Type | Description |

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.io/rwvolume.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.io/rwvolume.md
@@ -1,6 +1,6 @@
 ---
 title: RWVolume
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---
@@ -69,6 +69,13 @@ validated to form a valid model.
 | `produced_by` | `typing.Optional[flyteplugins.union.io._base_volume.ActionRef]` | |
 | `parent_produced_by` | `typing.Optional[flyteplugins.union.io._base_volume.ActionRef]` | |
 
+## Properties
+
+| Property | Type | Description |
+|-|-|-|
+| `locator` | `Optional[str]` | The object-store address of *this* published version, or ``None`` if the volume has never been sealed (a fresh :meth:`new` / :meth:`empty`).  It's the path of this version's metadata object (``produced_by.locator`` — the JSON value :func:`_publish_metadata` writes), which carries the complete Volume: ``index``, ``bucket``, ``metadata_store_type``, stats, and lineage. Persist it anywhere (a task output, your own store, a config) and recover the exact version later with :meth:`from_locator` — that's the across-run handle that doesn't depend on name or live task context.  Available immediately off a :meth:`RWVolume.commit` / ``finalize`` / :meth:`fork` result, since each stamps ``produced_by`` on the version it publishes. ``None`` before the first seal — there's no version to point at yet.  Durability note: the address lives under the producing action's output path, so it stays resolvable as long as that action's artifacts are retained. |
+| `mount_path` | `Optional[Path]` | Where this handle is currently mounted, or ``None`` if not mounted.  Set by :meth:`mount` and cleared by the terminal seal (:meth:`RWVolume.finalize` / auto-finalize). Use it to locate files without re-deriving the path: ``(vol.mount_path / "data.bin")``. |
+
 ## Methods
 
 | Method | Description |
@@ -77,6 +84,7 @@ validated to form a valid model.
 | [`empty()`](#empty) | Declare a brand-new volume. |
 | [`finalize()`](#finalize) | Drain writeback, unmount, and publish as :class:`ROVolume`. |
 | [`fork()`](#fork) | Branch this writable into another volume. |
+| [`from_locator()`](#from_locator) | Load a previously published volume version by its :attr:`locator`. |
 | [`migrate_metadata_store_type()`](#migrate_metadata_store_type) | Re-host this Volume's metadata on ``new_metadata_store_type``. |
 | [`model_post_init()`](#model_post_init) | This function is meant to behave like a BaseModel method to initialize private attributes. |
 | [`mount()`](#mount) | Format (if fresh) and mount the volume at ``mount_path`` in this. |
@@ -88,8 +96,8 @@ validated to form a valid model.
 ```python
 def commit(
     message: Optional[str],
-    mount_path: str,
-    meta_dir: str,
+    mount_path: Optional[str],
+    meta_dir: Optional[str],
 ) -> ROVolume
 ```
 Drain writeback, then snapshot the current state as a new immutable
@@ -115,8 +123,8 @@ path automatically when you return an :class:`RWVolume`.
 | Parameter | Type | Description |
 |-|-|-|
 | `message` | `Optional[str]` | |
-| `mount_path` | `str` | |
-| `meta_dir` | `str` | |
+| `mount_path` | `Optional[str]` | |
+| `meta_dir` | `Optional[str]` | |
 
 ### empty()
 
@@ -138,18 +146,24 @@ task context as ``{raw_data_root}/{project}/{domain}/volumes`` —
 following Flyte's own layout for offloaded data. Must be called
 from inside a task in that case.
 
+Regardless of store type, *mounting* the returned Volume needs a
+FUSE-capable image and pod — the ``fuse3`` apt package and
+``flyte.PodTemplate().allow_fuse()`` — see :meth:`mount` for the full
+runtime requirements.
+
 ``metadata_store_type`` controls the in-pod metadata backend. When
 omitted it resolves from ``$UNION_VOLUME_METADATA_STORE`` and
 otherwise defaults to ``"sqlite"``.
 
 * ``"sqlite"`` (default) keeps the namespace in a local SQLite file —
-  runs in-process with no extra package in the task image, and supports
-  :meth:`fork`.
+  runs in-process and needs no *extra* package beyond ``fuse3``, and
+  supports :meth:`fork`.
 * ``"redis"`` runs an in-process ``redis-server`` and persists the
   namespace as an RDB snapshot — faster than the embedded stores for
-  metadata-heavy workloads, but requires ``redis-server`` in the image
-  (see :func:`with_high_throughput_volume_deps`, which also sets
-  ``$UNION_VOLUME_METADATA_STORE=redis`` so it is the default there).
+  metadata-heavy workloads, but additionally requires ``redis-server``
+  in the image. Use :func:`with_high_throughput_volume_deps`, which
+  installs ``fuse3`` + ``redis-server`` and sets
+  ``$UNION_VOLUME_METADATA_STORE=redis`` so Redis is the default there.
 
 The choice is baked into the Volume and travels with it through
 lineage; subsequent mounts of the same Volume must use the same
@@ -181,8 +195,6 @@ the consumer's env.
 ```python
 def finalize(
     message: Optional[str],
-    mount_path: str,
-    meta_dir: str,
     timeout: float,
 ) -> ROVolume
 ```
@@ -194,12 +206,14 @@ and attaches ``message``. The :class:`VolumeTransformer` calls this
 at task return when an :class:`RWVolume` is returned mounted —
 explicit user calls are rare.
 
+Operates on wherever this handle was mounted, recorded by
+:meth:`mount` — so it takes no ``mount_path`` / ``meta_dir``; those are
+already known. ``timeout`` bounds the unmount/client-exit wait.
+
 
 | Parameter | Type | Description |
 |-|-|-|
 | `message` | `Optional[str]` | |
-| `mount_path` | `str` | |
-| `meta_dir` | `str` | |
 | `timeout` | `float` | |
 
 ### fork()
@@ -208,8 +222,8 @@ explicit user calls are rare.
 def fork(
     name: str,
     as_: Literal['rw', 'ro'],
-    mount_path: str,
-    meta_dir: str,
+    mount_path: Optional[str],
+    meta_dir: Optional[str],
     timeout: float,
 ) -> Union['RWVolume', ROVolume]
 ```
@@ -230,16 +244,43 @@ Branch this writable into another volume.
 |-|-|-|
 | `name` | `str` | |
 | `as_` | `Literal['rw', 'ro']` | |
-| `mount_path` | `str` | |
-| `meta_dir` | `str` | |
+| `mount_path` | `Optional[str]` | |
+| `meta_dir` | `Optional[str]` | |
 | `timeout` | `float` | |
+
+### from_locator()
+
+```python
+def from_locator(
+    locator: str,
+) -> 'ROVolume'
+```
+Load a previously published volume version by its :attr:`locator`.
+
+The inverse of :attr:`locator`: download the metadata object at
+``locator`` (the full serialized Volume value) and reconstruct it as an
+immutable :class:`ROVolume` — ``index``, ``bucket``,
+``metadata_store_type``, stats and lineage all recovered, so the result
+is mountable read-only (or :meth:`fork`-able to branch + write) without
+any other arguments. This is how you reference a specific volume version
+across runs: stash ``vol.locator`` somewhere, then ``Volume.from_locator``
+it back later.
+
+Reads only the metadata object; the index and chunks are fetched lazily
+by :meth:`mount`. Needs object-store credentials for ``locator`` but no
+active task context. Raises :class:`VolumeError` if ``locator`` is empty.
+
+
+| Parameter | Type | Description |
+|-|-|-|
+| `locator` | `str` | |
 
 ### migrate_metadata_store_type()
 
 ```python
 def migrate_metadata_store_type(
     new_metadata_store_type: str,
-    meta_dir: str,
+    meta_dir: Optional[str],
     new_meta_dir: Optional[str],
 ) -> 'Volume'
 ```
@@ -272,7 +313,7 @@ one of the stores is ``"redis"``).
 | Parameter | Type | Description |
 |-|-|-|
 | `new_metadata_store_type` | `str` | |
-| `meta_dir` | `str` | |
+| `meta_dir` | `Optional[str]` | |
 | `new_meta_dir` | `Optional[str]` | |
 
 ### model_post_init()
@@ -296,9 +337,9 @@ It takes context as an argument since that's what pydantic-core passes when call
 
 ```python
 def mount(
-    mount_path: str,
-    meta_dir: str,
-    cache_dir: str,
+    mount_path: Optional[str],
+    meta_dir: Optional[str],
+    cache_dir: Optional[str],
     timeout: float,
     writeback: bool,
     upload_delay: Optional[str],
@@ -307,13 +348,33 @@ def mount(
     entry_cache: float,
     dir_entry_cache: float,
     read_only: bool,
-)
+) -> Path
 ```
 Format (if fresh) and mount the volume at ``mount_path`` in this
-process.
+process, and return the resolved mount point as a :class:`~pathlib.Path`
+(also available afterwards via the :attr:`mount_path` property).
 
 Call once near the top of a task body before reading or writing under
 ``mount_path``.
+
+**Runtime requirements** (both needed, or the mount fails):
+
+* **Image** — the ``fuse3`` apt package. JuiceFS execs the
+  ``fusermount3`` userspace helper to mount; the default minimal images
+  don't ship it, so the mount client exits immediately with
+  ``fuse: fuse is not installed``. Add it with
+  ``flyte.Image...with_apt_packages("fuse3")`` (or use
+  :func:`with_high_throughput_volume_deps`, which includes it). A
+  Redis-backed Volume additionally needs ``redis-server`` in the image —
+  that helper installs it too.
+* **Pod** — ``pod_template=flyte.PodTemplate().allow_fuse()`` on the
+  :class:`flyte.TaskEnvironment`, which grants the ``/dev/fuse`` device
+  and the capability an unprivileged mount needs (the cluster must run a
+  FUSE device plugin; the Union data plane ships one).
+
+The mount point, ``meta_dir`` and ``cache_dir`` must also be writable by
+the task user; the name-keyed defaults live under ``$HOME``, which the
+default image owns.
 
 When ``writeback=True`` (default), writes land in the local cache
 directory first and are uploaded asynchronously in the background.
@@ -351,9 +412,9 @@ any resume-from-checkpoint policy at the usage layer.
 
 | Parameter | Type | Description |
 |-|-|-|
-| `mount_path` | `str` | |
-| `meta_dir` | `str` | |
-| `cache_dir` | `str` | |
+| `mount_path` | `Optional[str]` | |
+| `meta_dir` | `Optional[str]` | |
+| `cache_dir` | `Optional[str]` | |
 | `timeout` | `float` | |
 | `writeback` | `bool` | |
 | `upload_delay` | `Optional[str]` | |
@@ -386,6 +447,10 @@ Equivalent in mechanics to :meth:`empty`, but:
 
 Prefer :meth:`new` in new code; :meth:`empty` is retained for
 existing callers that already declare ``-&gt; Volume``.
+
+Creating the handle does no I/O; the first :meth:`mount` formats the
+namespace and needs a FUSE-capable image + pod (``fuse3`` and
+``allow_fuse()`` — see :meth:`mount`).
 
 
 | Parameter | Type | Description |

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.io/volume.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.io/volume.md
@@ -1,6 +1,6 @@
 ---
 title: Volume
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---
@@ -64,6 +64,13 @@ validated to form a valid model.
 | `produced_by` | `typing.Optional[flyteplugins.union.io._base_volume.ActionRef]` | |
 | `parent_produced_by` | `typing.Optional[flyteplugins.union.io._base_volume.ActionRef]` | |
 
+## Properties
+
+| Property | Type | Description |
+|-|-|-|
+| `locator` | `Optional[str]` | The object-store address of *this* published version, or ``None`` if the volume has never been sealed (a fresh :meth:`new` / :meth:`empty`).  It's the path of this version's metadata object (``produced_by.locator`` — the JSON value :func:`_publish_metadata` writes), which carries the complete Volume: ``index``, ``bucket``, ``metadata_store_type``, stats, and lineage. Persist it anywhere (a task output, your own store, a config) and recover the exact version later with :meth:`from_locator` — that's the across-run handle that doesn't depend on name or live task context.  Available immediately off a :meth:`RWVolume.commit` / ``finalize`` / :meth:`fork` result, since each stamps ``produced_by`` on the version it publishes. ``None`` before the first seal — there's no version to point at yet.  Durability note: the address lives under the producing action's output path, so it stays resolvable as long as that action's artifacts are retained. |
+| `mount_path` | `Optional[Path]` | Where this handle is currently mounted, or ``None`` if not mounted.  Set by :meth:`mount` and cleared by the terminal seal (:meth:`RWVolume.finalize` / auto-finalize). Use it to locate files without re-deriving the path: ``(vol.mount_path / "data.bin")``. |
+
 ## Methods
 
 | Method | Description |
@@ -71,6 +78,7 @@ validated to form a valid model.
 | [`commit()`](#commit) | **Deprecated. |
 | [`empty()`](#empty) | Declare a brand-new volume. |
 | [`fork()`](#fork) | Snapshot the current metadata index and return a new ``Volume``. |
+| [`from_locator()`](#from_locator) | Load a previously published volume version by its :attr:`locator`. |
 | [`migrate_metadata_store_type()`](#migrate_metadata_store_type) | Re-host this Volume's metadata on ``new_metadata_store_type``. |
 | [`model_post_init()`](#model_post_init) | This function is meant to behave like a BaseModel method to initialize private attributes. |
 | [`mount()`](#mount) | Format (if fresh) and mount the volume at ``mount_path`` in this. |
@@ -81,8 +89,8 @@ validated to form a valid model.
 
 ```python
 def commit(
-    mount_path: str,
-    meta_dir: str,
+    mount_path: Optional[str],
+    meta_dir: Optional[str],
     timeout: float,
     message: Optional[str],
 ) -> 'Volume'
@@ -100,8 +108,8 @@ working; it emits :class:`DeprecationWarning`.
 
 | Parameter | Type | Description |
 |-|-|-|
-| `mount_path` | `str` | |
-| `meta_dir` | `str` | |
+| `mount_path` | `Optional[str]` | |
+| `meta_dir` | `Optional[str]` | |
 | `timeout` | `float` | |
 | `message` | `Optional[str]` | |
 
@@ -125,18 +133,24 @@ task context as ``{raw_data_root}/{project}/{domain}/volumes`` —
 following Flyte's own layout for offloaded data. Must be called
 from inside a task in that case.
 
+Regardless of store type, *mounting* the returned Volume needs a
+FUSE-capable image and pod — the ``fuse3`` apt package and
+``flyte.PodTemplate().allow_fuse()`` — see :meth:`mount` for the full
+runtime requirements.
+
 ``metadata_store_type`` controls the in-pod metadata backend. When
 omitted it resolves from ``$UNION_VOLUME_METADATA_STORE`` and
 otherwise defaults to ``"sqlite"``.
 
 * ``"sqlite"`` (default) keeps the namespace in a local SQLite file —
-  runs in-process with no extra package in the task image, and supports
-  :meth:`fork`.
+  runs in-process and needs no *extra* package beyond ``fuse3``, and
+  supports :meth:`fork`.
 * ``"redis"`` runs an in-process ``redis-server`` and persists the
   namespace as an RDB snapshot — faster than the embedded stores for
-  metadata-heavy workloads, but requires ``redis-server`` in the image
-  (see :func:`with_high_throughput_volume_deps`, which also sets
-  ``$UNION_VOLUME_METADATA_STORE=redis`` so it is the default there).
+  metadata-heavy workloads, but additionally requires ``redis-server``
+  in the image. Use :func:`with_high_throughput_volume_deps`, which
+  installs ``fuse3`` + ``redis-server`` and sets
+  ``$UNION_VOLUME_METADATA_STORE=redis`` so Redis is the default there.
 
 The choice is baked into the Volume and travels with it through
 lineage; subsequent mounts of the same Volume must use the same
@@ -168,8 +182,8 @@ the consumer's env.
 ```python
 def fork(
     name: str,
-    mount_path: str,
-    meta_dir: str,
+    mount_path: Optional[str],
+    meta_dir: Optional[str],
     timeout: float,
 ) -> 'Volume'
 ```
@@ -202,16 +216,43 @@ and was unsafe for the chunk-key reasons above.
 | Parameter | Type | Description |
 |-|-|-|
 | `name` | `str` | |
-| `mount_path` | `str` | |
-| `meta_dir` | `str` | |
+| `mount_path` | `Optional[str]` | |
+| `meta_dir` | `Optional[str]` | |
 | `timeout` | `float` | |
+
+### from_locator()
+
+```python
+def from_locator(
+    locator: str,
+) -> 'ROVolume'
+```
+Load a previously published volume version by its :attr:`locator`.
+
+The inverse of :attr:`locator`: download the metadata object at
+``locator`` (the full serialized Volume value) and reconstruct it as an
+immutable :class:`ROVolume` — ``index``, ``bucket``,
+``metadata_store_type``, stats and lineage all recovered, so the result
+is mountable read-only (or :meth:`fork`-able to branch + write) without
+any other arguments. This is how you reference a specific volume version
+across runs: stash ``vol.locator`` somewhere, then ``Volume.from_locator``
+it back later.
+
+Reads only the metadata object; the index and chunks are fetched lazily
+by :meth:`mount`. Needs object-store credentials for ``locator`` but no
+active task context. Raises :class:`VolumeError` if ``locator`` is empty.
+
+
+| Parameter | Type | Description |
+|-|-|-|
+| `locator` | `str` | |
 
 ### migrate_metadata_store_type()
 
 ```python
 def migrate_metadata_store_type(
     new_metadata_store_type: str,
-    meta_dir: str,
+    meta_dir: Optional[str],
     new_meta_dir: Optional[str],
 ) -> 'Volume'
 ```
@@ -244,7 +285,7 @@ one of the stores is ``"redis"``).
 | Parameter | Type | Description |
 |-|-|-|
 | `new_metadata_store_type` | `str` | |
-| `meta_dir` | `str` | |
+| `meta_dir` | `Optional[str]` | |
 | `new_meta_dir` | `Optional[str]` | |
 
 ### model_post_init()
@@ -268,9 +309,9 @@ It takes context as an argument since that's what pydantic-core passes when call
 
 ```python
 def mount(
-    mount_path: str,
-    meta_dir: str,
-    cache_dir: str,
+    mount_path: Optional[str],
+    meta_dir: Optional[str],
+    cache_dir: Optional[str],
     timeout: float,
     writeback: bool,
     upload_delay: Optional[str],
@@ -279,13 +320,33 @@ def mount(
     entry_cache: float,
     dir_entry_cache: float,
     read_only: bool,
-)
+) -> Path
 ```
 Format (if fresh) and mount the volume at ``mount_path`` in this
-process.
+process, and return the resolved mount point as a :class:`~pathlib.Path`
+(also available afterwards via the :attr:`mount_path` property).
 
 Call once near the top of a task body before reading or writing under
 ``mount_path``.
+
+**Runtime requirements** (both needed, or the mount fails):
+
+* **Image** — the ``fuse3`` apt package. JuiceFS execs the
+  ``fusermount3`` userspace helper to mount; the default minimal images
+  don't ship it, so the mount client exits immediately with
+  ``fuse: fuse is not installed``. Add it with
+  ``flyte.Image...with_apt_packages("fuse3")`` (or use
+  :func:`with_high_throughput_volume_deps`, which includes it). A
+  Redis-backed Volume additionally needs ``redis-server`` in the image —
+  that helper installs it too.
+* **Pod** — ``pod_template=flyte.PodTemplate().allow_fuse()`` on the
+  :class:`flyte.TaskEnvironment`, which grants the ``/dev/fuse`` device
+  and the capability an unprivileged mount needs (the cluster must run a
+  FUSE device plugin; the Union data plane ships one).
+
+The mount point, ``meta_dir`` and ``cache_dir`` must also be writable by
+the task user; the name-keyed defaults live under ``$HOME``, which the
+default image owns.
 
 When ``writeback=True`` (default), writes land in the local cache
 directory first and are uploaded asynchronously in the background.
@@ -323,9 +384,9 @@ any resume-from-checkpoint policy at the usage layer.
 
 | Parameter | Type | Description |
 |-|-|-|
-| `mount_path` | `str` | |
-| `meta_dir` | `str` | |
-| `cache_dir` | `str` | |
+| `mount_path` | `Optional[str]` | |
+| `meta_dir` | `Optional[str]` | |
+| `cache_dir` | `Optional[str]` | |
 | `timeout` | `float` | |
 | `writeback` | `bool` | |
 | `upload_delay` | `Optional[str]` | |
@@ -358,6 +419,10 @@ Equivalent in mechanics to :meth:`empty`, but:
 
 Prefer :meth:`new` in new code; :meth:`empty` is retained for
 existing callers that already declare ``-&gt; Volume``.
+
+Creating the handle does no I/O; the first :meth:`mount` formats the
+namespace and needs a FUSE-capable image + pod (``fuse3`` and
+``allow_fuse()`` — see :meth:`mount`).
 
 
 | Parameter | Type | Description |

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.remote/_index.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.remote/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.union.remote
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---
@@ -43,6 +43,7 @@ Example:
 | [`Policy`](../flyteplugins.union.remote/policy) | Represents a Union RBAC Policy. |
 | [`Queue`](../flyteplugins.union.remote/queue) | Represents a Union scheduling queue. |
 | [`Role`](../flyteplugins.union.remote/role) | Represents a Union RBAC Role. |
+| [`SSHDebug`](../flyteplugins.union.remote/sshdebug) | Resolved SSH-into-task connect info for a running debug action. |
 | [`User`](../flyteplugins.union.remote/user) | Represents a Union user. |
 | [`VolumeExplore`](../flyteplugins.union.remote/volumeexplore) | A resolved :class:`Volume` plus the IO to inspect and walk its lineage. |
 

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.remote/apikey.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.remote/apikey.md
@@ -1,6 +1,6 @@
 ---
 title: ApiKey
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.remote/assignment.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.remote/assignment.md
@@ -1,6 +1,6 @@
 ---
 title: Assignment
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.remote/cluster.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.remote/cluster.md
@@ -1,6 +1,6 @@
 ---
 title: Cluster
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.remote/clusterpool.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.remote/clusterpool.md
@@ -1,6 +1,6 @@
 ---
 title: ClusterPool
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.remote/member.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.remote/member.md
@@ -1,6 +1,6 @@
 ---
 title: Member
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.remote/policy.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.remote/policy.md
@@ -1,6 +1,6 @@
 ---
 title: Policy
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.remote/queue.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.remote/queue.md
@@ -1,6 +1,6 @@
 ---
 title: Queue
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.remote/role.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.remote/role.md
@@ -1,6 +1,6 @@
 ---
 title: Role
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.remote/sshdebug.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.remote/sshdebug.md
@@ -1,0 +1,147 @@
+---
+title: SSHDebug
+version: 0.4.3
+variants: +flyte +union
+layout: py_api
+---
+
+# SSHDebug
+
+**Package:** `flyteplugins.union.remote`
+
+Resolved SSH-into-task connect info for a running debug action.
+
+
+## Parameters
+
+```python
+class SSHDebug(
+    run_name: str,
+    action_name: str,
+    wss_url: str,
+    ssh_config: str,
+    host_alias: str,
+    headers_file: Optional[str],
+)
+```
+| Parameter | Type | Description |
+|-|-|-|
+| `run_name` | `str` | |
+| `action_name` | `str` | |
+| `wss_url` | `str` | |
+| `ssh_config` | `str` | |
+| `host_alias` | `str` | |
+| `headers_file` | `Optional[str]` | |
+
+## Methods
+
+| Method | Description |
+|-|-|
+| [`connect()`](#connect) | Resolve connect info for a running ssh-debug action. |
+| [`ensure_api_key()`](#ensure_api_key) | Ensure a dedicated, long-lived API key (client credentials) exists; return it encoded. |
+| [`ensure_keypair()`](#ensure_keypair) | Ensure the auto-managed debug keypair exists; return (private_key_path, public_key). |
+| [`launch_env()`](#launch_env) | Env vars to enable ssh-debug on a run, with the debug pubkey auto-injected. |
+
+
+### connect()
+
+
+> [!NOTE] This method can be called both synchronously or asynchronously.
+> Default invocation is sync and will block.
+> To call it asynchronously, use the function `.aio()` on the method name itself, e.g.,:
+> `result = await SSHDebug.connect.aio()`.
+```python
+def connect(
+    cls,
+    run_name: str,
+    action_name: str,
+    user: str,
+    identity_file: Optional[str],
+    host_alias: str,
+    use_api_key: bool,
+    refresh_token: bool,
+    headers_file: Optional[str],
+    timeout: float,
+    poll_interval: float,
+) -> 'SSHDebug'
+```
+Resolve connect info for a running ssh-debug action.
+
+Polls the action until its ``:6060`` IDE route is ready (or *timeout*),
+mints (or reuses a cached) Bearer token for the ingress, writes the
+headers file, and renders the ssh-config block. *identity_file* defaults
+to the auto-managed ``~/.flyte/ssh-debug/id_ed25519`` (created on launch).
+
+
+
+| Parameter | Type | Description |
+|-|-|-|
+| `cls` |  | |
+| `run_name` | `str` | |
+| `action_name` | `str` | |
+| `user` | `str` | |
+| `identity_file` | `Optional[str]` | |
+| `host_alias` | `str` | |
+| `use_api_key` | `bool` | |
+| `refresh_token` | `bool` | |
+| `headers_file` | `Optional[str]` | |
+| `timeout` | `float` | |
+| `poll_interval` | `float` | |
+
+**Raises**
+
+| Exception | Description |
+|-|-|
+| `TimeoutError` | if the debug route never becomes ready. |
+
+### ensure_api_key()
+
+```python
+def ensure_api_key(
+    name: str,
+) -> str
+```
+Ensure a dedicated, long-lived API key (client credentials) exists; return it encoded.
+
+Reuses the locally-stored key if it still exists server-side (verified with
+``ApiKey.get`` — the "api-key get to check for existence" path). Otherwise
+creates a fresh one and stores it 0600. Use this for headless, reusable auth
+that doesn't expire mid-session like an interactive user JWT.
+
+
+| Parameter | Type | Description |
+|-|-|-|
+| `name` | `str` | |
+
+### ensure_keypair()
+
+```python
+def ensure_keypair()
+```
+Ensure the auto-managed debug keypair exists; return (private_key_path, public_key).
+
+Generates an ed25519 keypair at ``~/.flyte/ssh-debug/id_ed25519`` the first
+time, then reuses it. The public key is what gets injected into the run
+(``_F_SSH_PK``); the private key is what ``flyte connect ssh`` authenticates
+with. Idempotent.
+
+
+### launch_env()
+
+```python
+def launch_env(
+    extra: Optional[dict],
+) -> dict
+```
+Env vars to enable ssh-debug on a run, with the debug pubkey auto-injected.
+
+Use with the run launcher so users don't manage keys or env vars::
+
+    run = flyte.with_runcontext(env_vars=SSHDebug.launch_env()).run(task)
+    info = SSHDebug.connect(run.name)   # uses the same auto-managed key
+
+
+| Parameter | Type | Description |
+|-|-|-|
+| `extra` | `Optional[dict]` | |
+

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.remote/user.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.remote/user.md
@@ -1,6 +1,6 @@
 ---
 title: User
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.remote/volumeexplore.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.remote/volumeexplore.md
@@ -1,6 +1,6 @@
 ---
 title: VolumeExplore
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.remote/volumeresolveerror.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.remote/volumeresolveerror.md
@@ -1,6 +1,6 @@
 ---
 title: VolumeResolveError
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.utils.auth/_index.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.utils.auth/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.union.utils.auth
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.utils.auth/appclientcredentials.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.utils.auth/appclientcredentials.md
@@ -1,6 +1,6 @@
 ---
 title: AppClientCredentials
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.utils.image/_index.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.utils.image/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.union.utils.image
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.utils/_index.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.utils/_index.md
@@ -1,6 +1,6 @@
 ---
 title: flyteplugins.union.utils
-version: 0.4.2
+version: 0.4.3
 variants: +flyte +union
 layout: py_api
 ---

--- a/content/api-reference/union-plugin/packages/flyteplugins.union.ws_proxy/_index.md
+++ b/content/api-reference/union-plugin/packages/flyteplugins.union.ws_proxy/_index.md
@@ -1,0 +1,36 @@
+---
+title: flyteplugins.union.ws_proxy
+version: 0.4.3
+variants: +flyte +union
+layout: py_api
+---
+
+# flyteplugins.union.ws_proxy
+
+Stdio <-> WebSocket proxy used as an ssh ``ProxyCommand`` for ssh-into-task.
+
+The pod terminates the WebSocket and bridges it to its local sshd; this client
+wraps the ssh stream in a standard WebSocket to the per-pod ``wss://`` route. We
+ship it (rather than depending on ``websocat``) so ``flyte connect ssh`` works
+with no extra install — it only needs ``aiohttp``, already a flyte dependency.
+
+Installed as the ``flyte-ws-proxy`` console script. Usage (normally emitted into
+~/.ssh/config by ``flyte connect ssh``):
+
+    ProxyCommand flyte-ws-proxy <wss-url> --http-headers-file <file-with-Authorization-Bearer>
+## Directory
+
+### Methods
+
+| Method | Description |
+|-|-|
+| [`main()`](#main) |  |
+
+
+## Methods
+
+#### main()
+
+```python
+def main()
+```

--- a/linkmap/flytesdk-linkmap.json
+++ b/linkmap/flytesdk-linkmap.json
@@ -426,6 +426,7 @@
     "flyte.latest_checkpoint": "/api-reference/flyte-sdk/packages/flyte/#latest_checkpoint",
     "flyte.map": "/api-reference/flyte-sdk/packages/flyte/#map",
     "flyte.new_condition": "/api-reference/flyte-sdk/packages/flyte/#new_condition",
+    "flyte.rerun": "/api-reference/flyte-sdk/packages/flyte/#rerun",
     "flyte.run": "/api-reference/flyte-sdk/packages/flyte/#run",
     "flyte.run_python_script": "/api-reference/flyte-sdk/packages/flyte/#run_python_script",
     "flyte.serve": "/api-reference/flyte-sdk/packages/flyte/#serve",

--- a/linkmap/union-plugin-linkmap.json
+++ b/linkmap/union-plugin-linkmap.json
@@ -10,8 +10,10 @@
     "flyteplugins.union.cli.policy": "/api-reference/union-plugin/packages/flyteplugins.union.cli.policy/",
     "flyteplugins.union.cli.queue": "/api-reference/union-plugin/packages/flyteplugins.union.cli.queue/",
     "flyteplugins.union.cli.role": "/api-reference/union-plugin/packages/flyteplugins.union.cli.role/",
+    "flyteplugins.union.cli.ssh": "/api-reference/union-plugin/packages/flyteplugins.union.cli.ssh/",
     "flyteplugins.union.cli.user": "/api-reference/union-plugin/packages/flyteplugins.union.cli.user/",
     "flyteplugins.union.cli.volume": "/api-reference/union-plugin/packages/flyteplugins.union.cli.volume/",
+    "flyteplugins.union.debug": "/api-reference/union-plugin/packages/flyteplugins.union.debug/",
     "flyteplugins.union.errors": "/api-reference/union-plugin/packages/flyteplugins.union.errors/",
     "flyteplugins.union.internal": "/api-reference/union-plugin/packages/flyteplugins.union.internal/",
     "flyteplugins.union.internal.validate": "/api-reference/union-plugin/packages/flyteplugins.union.internal.validate/",
@@ -21,9 +23,12 @@
     "flyteplugins.union.remote": "/api-reference/union-plugin/packages/flyteplugins.union.remote/",
     "flyteplugins.union.utils": "/api-reference/union-plugin/packages/flyteplugins.union.utils/",
     "flyteplugins.union.utils.auth": "/api-reference/union-plugin/packages/flyteplugins.union.utils.auth/",
-    "flyteplugins.union.utils.image": "/api-reference/union-plugin/packages/flyteplugins.union.utils.image/"
+    "flyteplugins.union.utils.image": "/api-reference/union-plugin/packages/flyteplugins.union.utils.image/",
+    "flyteplugins.union.ws_proxy": "/api-reference/union-plugin/packages/flyteplugins.union.ws_proxy/"
   },
   "identifiers": {
+    "flyteplugins.union.debug.SSHDebug": "/api-reference/union-plugin/packages/flyteplugins.union.debug/sshdebug/",
+    "SSHDebug": "/api-reference/union-plugin/packages/flyteplugins.union.debug/sshdebug/",
     "flyteplugins.union.errors.VolumeCommandError": "/api-reference/union-plugin/packages/flyteplugins.union.errors/volumecommanderror/",
     "VolumeCommandError": "/api-reference/union-plugin/packages/flyteplugins.union.errors/volumecommanderror/",
     "flyteplugins.union.errors.VolumeCommitError": "/api-reference/union-plugin/packages/flyteplugins.union.errors/volumecommiterror/",
@@ -46,6 +51,8 @@
     "VolumeStoreTypeNotSet": "/api-reference/union-plugin/packages/flyteplugins.union.errors/volumestoretypenotset/",
     "flyteplugins.union.errors.VolumeUnmountError": "/api-reference/union-plugin/packages/flyteplugins.union.errors/volumeunmounterror/",
     "VolumeUnmountError": "/api-reference/union-plugin/packages/flyteplugins.union.errors/volumeunmounterror/",
+    "flyteplugins.union.errors.VolumeUnmountUnsupportedError": "/api-reference/union-plugin/packages/flyteplugins.union.errors/volumeunmountunsupportederror/",
+    "VolumeUnmountUnsupportedError": "/api-reference/union-plugin/packages/flyteplugins.union.errors/volumeunmountunsupportederror/",
     "flyteplugins.union.errors.VolumeUsageError": "/api-reference/union-plugin/packages/flyteplugins.union.errors/volumeusageerror/",
     "VolumeUsageError": "/api-reference/union-plugin/packages/flyteplugins.union.errors/volumeusageerror/",
     "flyteplugins.union.io.ActionRef": "/api-reference/union-plugin/packages/flyteplugins.union.io/actionref/",
@@ -72,6 +79,7 @@
     "Queue": "/api-reference/union-plugin/packages/flyteplugins.union.remote/queue/",
     "flyteplugins.union.remote.Role": "/api-reference/union-plugin/packages/flyteplugins.union.remote/role/",
     "Role": "/api-reference/union-plugin/packages/flyteplugins.union.remote/role/",
+    "flyteplugins.union.remote.SSHDebug": "/api-reference/union-plugin/packages/flyteplugins.union.remote/sshdebug/",
     "flyteplugins.union.remote.User": "/api-reference/union-plugin/packages/flyteplugins.union.remote/user/",
     "User": "/api-reference/union-plugin/packages/flyteplugins.union.remote/user/",
     "flyteplugins.union.remote.VolumeExplore": "/api-reference/union-plugin/packages/flyteplugins.union.remote/volumeexplore/",
@@ -83,11 +91,13 @@
   },
   "methods": {
     "flyteplugins.union.cli.edit_with_retry": "/api-reference/union-plugin/packages/flyteplugins.union.cli/#edit_with_retry",
+    "flyteplugins.union.debug.with_debugcontext": "/api-reference/union-plugin/packages/flyteplugins.union.debug/#with_debugcontext",
     "flyteplugins.union.io.with_high_throughput_volume_deps": "/api-reference/union-plugin/packages/flyteplugins.union.io/#with_high_throughput_volume_deps",
     "flyteplugins.union.utils.with_local_flyteplugins_union": "/api-reference/union-plugin/packages/flyteplugins.union.utils/#with_local_flyteplugins_union",
     "flyteplugins.union.utils.auth.encode_app_client_credentials": "/api-reference/union-plugin/packages/flyteplugins.union.utils.auth/#encode_app_client_credentials",
     "flyteplugins.union.utils.auth.is_serverless_endpoint": "/api-reference/union-plugin/packages/flyteplugins.union.utils.auth/#is_serverless_endpoint",
     "flyteplugins.union.utils.image.local_dist_folder": "/api-reference/union-plugin/packages/flyteplugins.union.utils.image/#local_dist_folder",
-    "flyteplugins.union.utils.image.with_local_flyteplugins_union": "/api-reference/union-plugin/packages/flyteplugins.union.utils.image/#with_local_flyteplugins_union"
+    "flyteplugins.union.utils.image.with_local_flyteplugins_union": "/api-reference/union-plugin/packages/flyteplugins.union.utils.image/#with_local_flyteplugins_union",
+    "flyteplugins.union.ws_proxy.main": "/api-reference/union-plugin/packages/flyteplugins.union.ws_proxy/#main"
   }
 }


### PR DESCRIPTION
**Maintenance regen** (no Linear ticket — recurring housekeeping on a docsy-owned surface).

`make check-api-docs` reported all **24 packages** stale at **2.5.2** vs latest **2.5.6**. Ran `make update-api-docs` → regenerated the flyte SDK, flyte-cli, and all plugin API-reference pages from the 2.5.6 docstrings (**385 files**, +1038/−477).

Surfaced while reviewing the **External conditions** user-guide page (#1087, DOC-1190) — the condition API reference is **unchanged** between 2.5.2 and 2.5.6, so the review verdict on #1087 stands against current truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)