### PR TITLE
docsy(v2): SEO meta nits — flyte-context description + infra H1-mush fix (DOC-1247)

### DIFF
--- a/content/api-reference/flyte-context.md
+++ b/content/api-reference/flyte-context.md
@@ -1,5 +1,6 @@
 ---
 title: LLM-optimized documentation
+description: LLM-optimized documentation for Union.ai and Flyte, provided at four levels of granularity and following the llms.txt convention so AI coding agents and search engines can consume the docs.
 variants: +flyte +union
 weight: 1
 ---


### PR DESCRIPTION
Follow-up nits from [DOC-1234](https://linear.app/unionai/issue/DOC-1234), shipped together in one bump cycle.

1. **content** — `content/api-reference/flyte-context.md` (the "LLM-optimized documentation" explainer, not real API reference) got a misleading auto meta description; add an explicit accurate `description`.
2. **infra bump** — `unionai-docs-infra` → [infra#143](https://github.com/unionai/unionai-docs-infra/pull/143) (`bf1ef55`): fix the `.Plain` H1-into-first-sentence mush in `seo-meta.html`.

Draft — verify on the Cloudflare preview, then infra#143 merges first and this re-points to the squashed `infra/main` SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)