### PR TITLE
docsy(v2): rename run-mode page titles (Run locally in Python / Run locally on the devbox)

### DIFF
--- a/content/user-guide/run-modes/running-devbox.md
+++ b/content/user-guide/run-modes/running-devbox.md
@@ -1,5 +1,5 @@
 ---
-title: Run on the devbox
+title: Run locally on the devbox
 weight: 5
 variants: +flyte +union
 ---
@@ -13,7 +13,7 @@ variants: +flyte +union
 </sl-alert>
 
 {{< markdown >}}
-# Run on the devbox
+# Run locally on the devbox
 
 The devbox is a lightweight local cluster that runs on your machine with Docker. It includes a UI preview, scheduler, and object store, so you can test remote execution without deploying to a real cluster.
 {{< /markdown >}}
@@ -22,7 +22,7 @@ The devbox is a lightweight local cluster that runs on your machine with Docker.
 
 {{< variant flyte >}}
 {{< markdown >}}
-# Run on the devbox
+# Run locally on the devbox
 
 The Flyte devbox is a lightweight local cluster that runs on your machine with Docker. It gives you a full Flyte environment — including the UI, scheduler, and object store — so you can test remote execution without deploying to a real cluster.
 {{< /markdown >}}

--- a/content/user-guide/run-modes/running-locally.md
+++ b/content/user-guide/run-modes/running-locally.md
@@ -1,10 +1,10 @@
 ---
-title: Run locally
+title: Run locally in Python
 weight: 4
 variants: +flyte +union
 ---
 
-# Run locally
+# Run locally in Python
 
 Flyte runs locally with no cluster or Docker needed. Install the SDK, write tasks, and run them on your machine. When you're ready to scale, drop the `--local` flag and the same code runs on a remote cluster with GPUs.
 


### PR DESCRIPTION
Editorial rename of two run-mode page titles + their side-nav entries, on **both `union` and `flyte`** variants (v2). Requested in #team-docs; split off from the devbox-banner work (DOC-1252) as its own ticket + PR.

- **"Run locally" → "Run locally in Python"** (`content/user-guide/run-modes/running-locally.md`)
- **"Run on the devbox" → "Run locally on the devbox"** (`content/user-guide/run-modes/running-devbox.md`)

Both pages are variant-shared content (`variants: +flyte +union`), so each edit updates the page `<title>` and the sidebar nav label on **both** variants. H1 headings updated to match (the devbox page carries a per-variant H1 in each of its union/flyte blocks — both changed).

Left unchanged: the run-modes landing-page cards ("Local" / "Devbox" short labels) — the request was specifically the page titles + nav entries.

Linear: DOC-1253

🤖 Generated with [Claude Code](https://claude.com/claude-code)