### PR TITLE
docsy(v2): revert #1186 (registry config docs describe unshipped surfaces)

### DIFF
--- a/content/user-guide/run-modes/running-remote.md
+++ b/content/user-guide/run-modes/running-remote.md
@@ -59,8 +59,7 @@ flyte create config \
     --endpoint my-org.my-company.com \
     --domain development \
     --project my-project \
-    --builder local \
-    --registry ghcr.io/my-org
+    --builder local
 ```
 {{< /markdown >}}
 {{< /variant >}}
@@ -88,7 +87,6 @@ admin:
   endpoint: dns:///my-org.my-company.com
 image:
   builder: local
-  registry: ghcr.io/my-org
 task:
   org: my-org
   domain: development
@@ -109,7 +107,6 @@ flyte create config \
     --domain development \
     --project my-project \
     --builder remote \
-    --registry ghcr.io/my-org \
     --insecure \
     --output my-config.yaml \
     --force
@@ -126,7 +123,6 @@ flyte create config \
     --domain development \
     --project my-project \
     --builder local \
-    --registry ghcr.io/my-org \
     --insecure \
     --output my-config.yaml \
     --force
@@ -165,7 +161,6 @@ See the [CLI reference](../../api-reference/flyte-cli#flyte-create-config) for a
 - `builder`: How container images are built.
   - `remote` (Union): Images built on Union's infrastructure.
   - `local` (Flyte OSS): Images built on your machine. Requires Docker. See [Image building](../task-configuration/container-images#image-building).
-- `registry`: Optional registry prefix to use for image builds. This is helpful when you want the SDK to push or pull images from a custom registry without changing your code. You can also set it with the `FLYTE_IMAGE_REGISTRY` environment variable.
 
 **`task`** — Default settings for task execution.
 

--- a/content/user-guide/task-configuration/container-images.md
+++ b/content/user-guide/task-configuration/container-images.md
@@ -84,8 +84,6 @@ There are two ways that the image can be built:
 * If you are running a Flyte OSS instance then the image will be built locally on your machine and pushed to the container registry you specified in the `Image` definition.
 * If you are running a Union instance, the image can be built locally, as with Flyte OSS, or using the Union `ImageBuilder`, which runs remotely on Union's infrastructure.
 
-If you want the SDK to use a specific registry for image builds without changing your code, set `image.registry` in your config file or the `FLYTE_IMAGE_REGISTRY` environment variable. You can also add it when generating config with `flyte create config --registry <registry>`.
-
 ### Configuring the `builder`
 
 {{< variant flyte >}}


### PR DESCRIPTION
Reverts #1186 ("adding registry config setting and --registry flag").

**Why:** #1186 documented three ways to set an image registry, and none exist in the shipped SDK (verified against **flyte-sdk `main`**, HEAD `8f22ea78` 2026-07-08 — code-is-authoritative):

| PR #1186 documents | flyte-sdk `main` |
|---|---|
| `flyte create config --registry <reg>` | ❌ no such option on `create config` (`src/flyte/cli/_create.py` `def config`); the only `--registry` is on `create **secret**` (image-pull creds) |
| `image.registry:` config-file field | ❌ `create config` only writes `image.builder`; `src/flyte/config` has no `registry` field |
| `FLYTE_IMAGE_REGISTRY` env var | ❌ zero matches in the entire repo |

The only real registry surface is the **programmatic** `Image(registry=…)` attribute (e.g. `flyte.Image.from_debian_base(registry=…)`), which #1186 does not document.

A user following the merged docs hits `no such option: --registry`, and the env var / config field silently do nothing.

**Disposition:** revert now to remove the incorrect live-docs guidance. If/when the CLI flag + config field + env var actually ship, re-document against the shipped surface; if the intent was the programmatic `Image(registry=…)`, that's a separate, correct doc. docsy-authored draft.