### PR TITLE
docsy(v2): disable markdownlint MD004 (ul-style) in docs CI

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -63,6 +63,10 @@
     // MD029 ordered-list numbering: allow existing `1.`-repeated lists. Off.
     "MD029": false,
 
+    // MD004 unordered-list-style: content mixes `-` and `*` bullet markers across
+    // (and within) pages; enforcing one marker is churn, not correctness. Off.
+    "MD004": false,
+
     // MD036 emphasis-as-heading: docs use bold lead-ins that aren't headings. Off.
     "MD036": false,
 


### PR DESCRIPTION
Adds `"MD004": false` to `.markdownlint-cli2.jsonc`. The docs content mixes `-` and `*` unordered-list markers across (and within) pages; MD004/ul-style enforces one marker, which is churn rather than correctness. Consistent with the DOC-967 permissive-config posture (line-length, inline-HTML, table-spacing, etc. already off). Follow-up to DOC-967.