### PR TITLE
docsy(v2): remove legacy uctl references from V2 docs

### DIFF
--- a/content/security/data-protection/classification-and-residency.md
+++ b/content/security/data-protection/classification-and-residency.md
@@ -81,7 +81,7 @@ Then run a workflow with recognizable data (e.g., a known string or file), and v
 6. **Task definition**: confirm it contains the expected fields, stored in the control plane:
 
    ```bash
-   uctl get task <task-name> -o json
+   flyte get task <task-name>
    ```
 
    The response will contain resource requirements, typed interfaces, container image references, and potentially sensitive fields (environment variables, default values, etc.) as documented in [Control plane](../architecture/control-plane). Bulk data content should not appear inline.
@@ -89,7 +89,7 @@ Then run a workflow with recognizable data (e.g., a known string or file), and v
 7. **Run metadata**: confirm it contains metadata and URI references, stored in the control plane:
 
    ```bash
-   uctl get execution <execution-id> -o json
+   flyte get run <run-name>
    ```
 
    The response should contain phase, timestamps, URIs, error messages, and task definition fields. Bulk data content should not appear inline.
@@ -113,7 +113,7 @@ Then run a workflow with recognizable data (e.g., a known string or file), and v
 3. Confirm the cluster region via the Union.ai API:
 
    ```bash
-   uctl get cluster
+   flyte get cluster
    ```
 
    The cluster region should match the customer's chosen deployment region.

--- a/content/security/data-protection/logging-and-audit.md
+++ b/content/security/data-protection/logging-and-audit.md
@@ -54,7 +54,7 @@ This verification is fully self-service.
 
 Audit data is available from the following sources:
 
-- Control plane run and action lifecycle events: `flyte get run`, filtered by time window.
+- Control plane run and action lifecycle events: `flyte get run --created-after <ts> --created-before <ts>` for run-level events; for per-action lifecycle detail use `flyte get action <run-name>`.
 - Authentication events: the configured identity provider's audit log (e.g., Okta).
 - Cluster operations: the Kubernetes audit log on the data plane.
 - Cloud IAM activity: CloudTrail (AWS), Cloud Audit Logs (GCP), or Azure Monitor activity logs.

--- a/content/security/data-protection/logging-and-audit.md
+++ b/content/security/data-protection/logging-and-audit.md
@@ -54,7 +54,7 @@ This verification is fully self-service.
 
 Audit data is available from the following sources:
 
-- Control plane execution and lifecycle events: `uctl get execution --all -o json`, filtered by time window.
+- Control plane run and action lifecycle events: `flyte get run`, filtered by time window.
 - Authentication events: the configured identity provider's audit log (e.g., Okta).
 - Cluster operations: the Kubernetes audit log on the data plane.
 - Cloud IAM activity: CloudTrail (AWS), Cloud Audit Logs (GCP), or Azure Monitor activity logs.

--- a/content/security/data-protection/secrets.md
+++ b/content/security/data-protection/secrets.md
@@ -47,13 +47,13 @@ All four backends are available regardless of deployment model. The choice of ba
 1. Create a test secret:
 
    ```bash
-   uctl create secret --name test-secret --value "s3cr3t-value" --project myproject
+   flyte create secret --project myproject test-secret --value "s3cr3t-value"
    ```
 
 2. Attempt to read it back:
 
    ```bash
-   uctl get secret --name test-secret --project myproject
+   flyte get secret --project myproject test-secret
    ```
 
    The output should show name, scope, creation time, and cluster status. There should be **no value field** in the response.

--- a/content/security/identity-and-access/human-access.md
+++ b/content/security/identity-and-access/human-access.md
@@ -65,7 +65,7 @@ Customer-side support access:
 2. If support access has been granted, verify the RBAC binding:
 
    ```bash
-   uctl get policy
+   flyte get policy
    ```
 
    The Union.ai support user should appear with the scoped role and time limit configured by the customer.

--- a/content/security/identity-and-access/rbac.md
+++ b/content/security/identity-and-access/rbac.md
@@ -20,7 +20,7 @@ Additional internal system roles exist for platform operations but are not user-
 
 ## Custom policies
 
-Custom policies bind roles (built-in or custom) to resources scoped at org-wide, domain, or project+domain level using composable YAML bindings via `uctl`. This allows organizations to define fine-grained access policies that match their team structure and security requirements.
+Custom policies bind roles (built-in or custom) to resources scoped at org-wide, domain, or project+domain level using composable YAML bindings managed with the `flyte` CLI (`flyte create policy` / `flyte create role`). This allows organizations to define fine-grained access policies that match their team structure and security requirements.
 
 ## Enforcement
 
@@ -43,16 +43,16 @@ Union.ai enforces least privilege across all components. IAM roles on the data p
 2. Log in as Viewer and confirm restricted operations are denied:
 
    ```bash
-   uctl create run ...    # Expect denied
-   uctl create secret ... # Expect denied
-   uctl get executions    # Expect success
+   flyte run ...          # Expect denied
+   flyte create secret ... # Expect denied
+   flyte get run          # Expect success
    ```
 
 3. Log in as Contributor scoped to project A:
 
    ```bash
-   uctl create run --project B ... # Expect denied
-   uctl create run --project A ... # Expect success
+   flyte run --project B ... # Expect denied
+   flyte run --project A ... # Expect success
    ```
 
 4. Create a custom policy scoping a user to project X, development domain only. Attempt to access the production domain. Expect denied.
@@ -60,7 +60,7 @@ Union.ai enforces least privilege across all components. IAM roles on the data p
 5. Display all active policy bindings:
 
    ```bash
-   uctl get policy
+   flyte get policy
    ```
 
 6. For Union.ai employee access: the customer creates an RBAC policy for Union.ai support, scoped to viewer only and time-limited.

--- a/content/security/identity-and-access/rbac.md
+++ b/content/security/identity-and-access/rbac.md
@@ -20,7 +20,7 @@ Additional internal system roles exist for platform operations but are not user-
 
 ## Custom policies
 
-Custom policies bind roles (built-in or custom) to resources scoped at org-wide, domain, or project+domain level using composable YAML bindings managed with the `flyte` CLI (`flyte create policy` / `flyte create role`). This allows organizations to define fine-grained access policies that match their team structure and security requirements.
+Roles (built-in or custom) define sets of permitted **actions**; custom **policies** then bind those roles to resources — scoped org-wide, by domain, or by project+domain — using composable YAML **bindings**. Both are managed with the `flyte` CLI (`flyte create role` / `flyte create policy`). This allows organizations to define fine-grained access policies that match their team structure and security requirements.
 
 ## Enforcement
 


### PR DESCRIPTION
## DOC-1230 — Remove/migrate legacy `uctl` references in V2 docs

`uctl` is the legacy (Union 1.x) control-plane CLI. V2 uses the `flyte` CLI (core) + `flyteplugins-union` (union-specific verbs). Per the rescoped DOC-1230 inventory, `uctl` is **only partially superseded** — this PR migrates the cleanly-migratable occurrences and deliberately leaves the rest, each disposition grounded against shipped code.

### Verified against shipped code (verify-live, code-is-authoritative)
- **Core `flyte` CLI** (installed `flyte`, live api-ref): `flyte run`, `flyte get run|task|secret|cluster`, `flyte create secret|policy|role`. **`flyte get run`/`get task` have no `-o json` flag** → dropped it; `execution` → `run`; `flyte create secret NAME --value …` (name is positional, no `--name`).
- **`flyteplugins-union` v0.5.1** entry points (`flyte.plugins.cli.commands`): confirms `flyte get/create/delete/update policy`, `cluster`, `cluster-pool`, `queue`, `role`, `user`, `assignment`, `api-key`. **No** `secret`, `service-account`, `cluster-resource-attribute`, or `cluster-pool-attributes` command.
- **`UCTL_CONFIG`** is still read by the v2 SDK (`flyte/config/_reader.py`, `_initialize.py`) — a real V2 env var, not a stray.

### Migrated (5 files, this PR)
| File | uctl → flyte |
|---|---|
| `security/identity-and-access/rbac.md` | prose "via `uctl`" → "via the `flyte` CLI (`flyte create policy`/`role`)"; `uctl create run`→`flyte run`; `uctl create secret`→`flyte create secret`; `uctl get executions`→`flyte get run`; `uctl get policy`→`flyte get policy` |
| `security/identity-and-access/human-access.md` | `uctl get policy` → `flyte get policy` |
| `security/data-protection/secrets.md` | `uctl create/get secret --name …` → `flyte create/get secret … <name>` (positional name) |
| `security/data-protection/logging-and-audit.md` | `uctl get execution --all -o json` → `flyte get run` |
| `security/data-protection/classification-and-residency.md` | `uctl get task -o json`→`flyte get task`; `uctl get execution`→`flyte get run`; `uctl get cluster`→`flyte get cluster` |

### Deliberately KEPT as `uctl` (no V2 equivalent — would break onboarding)
- **8 self-managed `deployment/selfmanaged/*/deploy-dataplane.md`** — `uctl config init` + `uctl selfserve provision-dataplane-resources` (+ in-flow `get cluster`/`create apikey`): the self-managed data-plane onboarding flow, `uctl`-only. Kept end-to-end for flow consistency.
- **Matchable-attribute pages** — `deployment/byoc/enabling-aws-resources/_index.md`, `deployment/selfmanaged/configuration/multi-cluster.md`, `user-guide/project-patterns/resource-management.md`: `uctl update/get cluster-resource-attribute` / `cluster-pool-attributes` — no `flyte` equivalent (the plugin's `cluster-pool`/`queue` are different resources).
- **`user-guide/run-modes/running-remote.md`** — `UCTL_CONFIG` in the config-precedence list: a genuine V2 SDK env var.

### Left for a human / other owner (not in this PR)
- **~88-page generated `content/api-reference/uctl-cli/` section** — generated from the CLI, not hand-editable; **eng/owner call** (retire vs. keep while `uctl` is still partially supported). Cross-repo finding.
- **`api-reference/flyte-sdk/packages/flyte.config/_index.md`** (`UCTL_CONFIG` mention) — regenerated from SDK docstrings; upstream/regen change, not content.
- **`deployment/selfmanaged/configuration/authentication.md`** ("standard `uctl` or Union config") + **`community/contributing-docs/shortcodes.md`** (`{{< key ctl >}}` shortcode doc) — incidental/minor wording in `uctl`-legit contexts; left as-is.

Refs DOC-1230. Draft — held pending human review.
