### PR TITLE
docsy(v2): document task overrides (incl. secret overrides)

### DIFF
--- a/content/user-guide/task-configuration/_index.md
+++ b/content/user-guide/task-configuration/_index.md
@@ -37,7 +37,7 @@ Task configuration is done at three levels. From most general to most specific, 
 
 * The `TaskEnvironment` level: setting parameters when defining the `TaskEnvironment` object.
 * The `@env.task` decorator level: Setting parameters in the `@env.task` decorator when defining a task function.
-* The task invocation level: Using the `task.override()` method when invoking task execution.
+* The task invocation level: Using the [`task.override()`](./overrides) method when invoking task execution.
 
 Each level has its own set of parameters, and some parameters are shared across levels.
 For shared parameters, the more specific level will override the more general one.
@@ -78,4 +78,3 @@ For the complete parameter interaction matrix showing which parameters can be se
 | **docs** | `@env.task` only | [Additional task settings](./additional-task-settings#docs) |
 
 \*When `reusable` is set, `resources`, `env_vars`, and `secrets` can only be overridden via `task.override()` with `reusable="off"` in the same call.
-

--- a/content/user-guide/task-configuration/_index.md
+++ b/content/user-guide/task-configuration/_index.md
@@ -53,6 +53,35 @@ Here is an example of how these levels work together, showing each level with al
 Each parameter is documented in detail on its dedicated page in this section.
 For the complete parameter interaction matrix showing which parameters can be set at which level, and for full type signatures and constraints, see the [`TaskEnvironment` API reference](../../api-reference/flyte-sdk/packages/flyte/taskenvironment).
 
+{{< variant flyte >}}
+{{< markdown >}}
+| Parameter | Set at | Details |
+|-----------|--------|---------|
+| **name** | `TaskEnvironment` only | [Additional task settings](./additional-task-settings) &bull; [`TaskEnvironment` API ref](../../api-reference/flyte-sdk/packages/flyte/taskenvironment) |
+| **image** | `TaskEnvironment` only | [Container images](./container-images) &bull; [`Image` API ref](../../api-reference/flyte-sdk/packages/flyte/image) |
+| **depends_on** | `TaskEnvironment` only | [Multiple environments](./multiple-environments) |
+| **description** | `TaskEnvironment` only | [Additional task settings](./additional-task-settings) |
+| **plugin_config** | `TaskEnvironment` only | [Task plugins](./task-plugins) |
+| **resources** | `TaskEnvironment`, `override`\* | [Resources](./resources) &bull; [`Resources` API ref](../../api-reference/flyte-sdk/packages/flyte/resources) |
+| **env_vars** | `TaskEnvironment`, `override`\* | [Additional task settings](./additional-task-settings#environment-variables) |
+| **secrets** | `TaskEnvironment`, `override`\* | [Secrets](./secrets) &bull; [`Secret` API ref](../../api-reference/flyte-sdk/packages/flyte/secret) |
+| **cache** | All three levels | [Caching](./caching) &bull; [`Cache` API ref](../../api-reference/flyte-sdk/packages/flyte/cache) |
+| **pod_template** | All three levels | [Pod templates](./pod-templates) &bull; [`PodTemplate` API ref](../../api-reference/flyte-sdk/packages/flyte/podtemplate) |
+| **reusable** | `TaskEnvironment`, `override` | [Reusable containers](./reusable-containers) &bull; [`ReusePolicy` API ref](../../api-reference/flyte-sdk/packages/flyte/reusepolicy) |
+| **interruptible** | All three levels | [Interruptible tasks](./interruptible-tasks-and-queues) |
+| **short_name** | `@env.task`, `override` | [Additional task settings](./additional-task-settings) |
+| **retries** | `@env.task`, `override` | [Retries and timeouts](./retries-and-timeouts) &bull; [`RetryStrategy` API ref](../../api-reference/flyte-sdk/packages/flyte/retrystrategy) |
+| **timeout** | `@env.task`, `override` | [Retries and timeouts](./retries-and-timeouts) &bull; [`Timeout` API ref](../../api-reference/flyte-sdk/packages/flyte/timeout) |
+| **max_inline_io_bytes** | `@env.task`, `override` | [Additional task settings](./additional-task-settings#inline-io-threshold) |
+| **links** | `@env.task`, `override` | [Additional task settings](./additional-task-settings#links) |
+| **report** | `@env.task` only | [Additional task settings](./additional-task-settings#report) |
+| **triggers** | `@env.task` only | [Triggers](./triggers) &bull; [`Trigger` API ref](../../api-reference/flyte-sdk/packages/flyte/trigger) |
+| **docs** | `@env.task` only | [Additional task settings](./additional-task-settings#docs) |
+{{< /markdown >}}
+{{< /variant >}}
+
+{{< variant union >}}
+{{< markdown >}}
 | Parameter | Set at | Details |
 |-----------|--------|---------|
 | **name** | `TaskEnvironment` only | [Additional task settings](./additional-task-settings) &bull; [`TaskEnvironment` API ref](../../api-reference/flyte-sdk/packages/flyte/taskenvironment) |
@@ -76,5 +105,7 @@ For the complete parameter interaction matrix showing which parameters can be se
 | **report** | `@env.task` only | [Additional task settings](./additional-task-settings#report) |
 | **triggers** | `@env.task` only | [Triggers](./triggers) &bull; [`Trigger` API ref](../../api-reference/flyte-sdk/packages/flyte/trigger) |
 | **docs** | `@env.task` only | [Additional task settings](./additional-task-settings#docs) |
+{{< /markdown >}}
+{{< /variant >}}
 
 \*When `reusable` is set, `resources`, `env_vars`, and `secrets` can only be overridden via `task.override()` with `reusable="off"` in the same call.

--- a/content/user-guide/task-configuration/overrides.md
+++ b/content/user-guide/task-configuration/overrides.md
@@ -55,9 +55,15 @@ The key idiom is `task.override(...)(args)`: `override()` returns a callable tas
 | **secrets** | [Overriding secrets](#overriding-secrets) &bull; [Secrets](./secrets) &bull; [`Secret` API ref](../../api-reference/flyte-sdk/packages/flyte/secret) |
 | **max_inline_io_bytes** | [Additional task settings](./additional-task-settings#inline-io-threshold) |
 | **pod_template** | [Pod templates](./pod-templates) &bull; [`PodTemplate` API ref](../../api-reference/flyte-sdk/packages/flyte/podtemplate) |
-| **queue** | {{< variant union >}}<a href="../queues/">Queues</a>{{< /variant >}}{{< variant flyte >}}Queues{{< /variant >}} |
 | **interruptible** | [Interruptible tasks](./interruptible-tasks-and-queues) |
 | **links** | [Additional task settings](./additional-task-settings#links) |
+
+{{< variant union >}}
+{{< markdown >}}
+> [!NOTE] Queue routing (Union)
+> `override(queue=…)` also routes the task to a specific [queue](./queues) to control concurrency, priority, and fairness. See [Queues](./queues).
+{{< /markdown >}}
+{{< /variant >}}
 
 For the full parameter interaction matrix showing which parameters can be set at which level, see [Task configuration levels](_index#task-configuration-levels).
 

--- a/content/user-guide/task-configuration/overrides.md
+++ b/content/user-guide/task-configuration/overrides.md
@@ -111,7 +111,7 @@ result = await my_task.override(
 Just as you can override resources per invocation, you can override the [secrets](./secrets) injected into a task for a single call.
 This is useful when the same task needs different credentials depending on how it's invoked &mdash; for example, calling an external API with a different key per tenant, or supplying a secret that the task's environment doesn't declare.
 
-Pass `secrets` to `override()` exactly as you would to the `TaskEnvironment` or `@env.task` decorator: a secret key, a `Secret` object, or a list of either.
+Pass `secrets` to `override()` exactly as you would to the `TaskEnvironment`: a secret key, a `Secret` object, or a list of either.
 
 ```python
 import flyte

--- a/content/user-guide/task-configuration/overrides.md
+++ b/content/user-guide/task-configuration/overrides.md
@@ -43,6 +43,8 @@ The key idiom is `task.override(...)(args)`: `override()` returns a callable tas
 
 `override()` accepts the parameters that are settable at the task-invocation level:
 
+{{< variant flyte >}}
+{{< markdown >}}
 | Parameter | Details |
 |-----------|---------|
 | **short_name** | [Additional task settings](./additional-task-settings) |
@@ -57,11 +59,26 @@ The key idiom is `task.override(...)(args)`: `override()` returns a callable tas
 | **pod_template** | [Pod templates](./pod-templates) &bull; [`PodTemplate` API ref](../../api-reference/flyte-sdk/packages/flyte/podtemplate) |
 | **interruptible** | [Interruptible tasks](./interruptible-tasks-and-queues) |
 | **links** | [Additional task settings](./additional-task-settings#links) |
+{{< /markdown >}}
+{{< /variant >}}
 
 {{< variant union >}}
 {{< markdown >}}
-> [!NOTE] Queue routing (Union)
-> `override(queue=…)` also routes the task to a specific [queue](./queues) to control concurrency, priority, and fairness. See [Queues](./queues).
+| Parameter | Details |
+|-----------|---------|
+| **short_name** | [Additional task settings](./additional-task-settings) |
+| **resources** | [Resources](./resources) &bull; [`Resources` API ref](../../api-reference/flyte-sdk/packages/flyte/resources) |
+| **cache** | [Caching](./caching) &bull; [`Cache` API ref](../../api-reference/flyte-sdk/packages/flyte/cache) |
+| **retries** | [Retries and timeouts](./retries-and-timeouts) &bull; [`RetryStrategy` API ref](../../api-reference/flyte-sdk/packages/flyte/retrystrategy) |
+| **timeout** | [Retries and timeouts](./retries-and-timeouts) &bull; [`Timeout` API ref](../../api-reference/flyte-sdk/packages/flyte/timeout) |
+| **reusable** | [Reusable containers](./reusable-containers) &bull; [`ReusePolicy` API ref](../../api-reference/flyte-sdk/packages/flyte/reusepolicy) |
+| **env_vars** | [Additional task settings](./additional-task-settings#environment-variables) |
+| **secrets** | [Overriding secrets](#overriding-secrets) &bull; [Secrets](./secrets) &bull; [`Secret` API ref](../../api-reference/flyte-sdk/packages/flyte/secret) |
+| **max_inline_io_bytes** | [Additional task settings](./additional-task-settings#inline-io-threshold) |
+| **pod_template** | [Pod templates](./pod-templates) &bull; [`PodTemplate` API ref](../../api-reference/flyte-sdk/packages/flyte/podtemplate) |
+| **queue** | [Queues](./queues) |
+| **interruptible** | [Interruptible tasks](./interruptible-tasks-and-queues) |
+| **links** | [Additional task settings](./additional-task-settings#links) |
 {{< /markdown >}}
 {{< /variant >}}
 

--- a/content/user-guide/task-configuration/overrides.md
+++ b/content/user-guide/task-configuration/overrides.md
@@ -143,6 +143,9 @@ async def main() -> str:
     return alternate
 ```
 
+> [!NOTE]
+> If the task's environment uses **reusable containers** (`reusable` is set), overriding `secrets` &mdash; like `resources` and `env_vars` &mdash; requires passing `reusable="off"` in the **same** `override()` call. Otherwise the override is rejected.
+
 As with the environment-level `secrets` parameter, the secret is injected at runtime and accessed inside the task &mdash; typically as an environment variable via `os.environ` (or mounted as a file).
 See [Secrets](./secrets) for how to create secrets and how they are injected, and remember that the overriding `secrets` value **replaces** the environment's secrets for that invocation rather than adding to them.
 

--- a/content/user-guide/task-configuration/overrides.md
+++ b/content/user-guide/task-configuration/overrides.md
@@ -59,7 +59,7 @@ The key idiom is `task.override(...)(args)`: `override()` returns a callable tas
 | **interruptible** | [Interruptible tasks](./interruptible-tasks-and-queues) |
 | **links** | [Additional task settings](./additional-task-settings#links) |
 
-For the full parameter interaction matrix showing which parameters can be set at which level, see [Task configuration levels](./#task-configuration-levels).
+For the full parameter interaction matrix showing which parameters can be set at which level, see [Task configuration levels](_index#task-configuration-levels).
 
 > [!NOTE] Overrides replace, they don't merge
 > When you override a collection-valued parameter such as `resources`, `env_vars`, or `secrets`, the value you pass **replaces** the environment's value for that invocation &mdash; it is not merged with it.

--- a/content/user-guide/task-configuration/overrides.md
+++ b/content/user-guide/task-configuration/overrides.md
@@ -55,7 +55,7 @@ The key idiom is `task.override(...)(args)`: `override()` returns a callable tas
 | **secrets** | [Overriding secrets](#overriding-secrets) &bull; [Secrets](./secrets) &bull; [`Secret` API ref](../../api-reference/flyte-sdk/packages/flyte/secret) |
 | **max_inline_io_bytes** | [Additional task settings](./additional-task-settings#inline-io-threshold) |
 | **pod_template** | [Pod templates](./pod-templates) &bull; [`PodTemplate` API ref](../../api-reference/flyte-sdk/packages/flyte/podtemplate) |
-| **queue** | [Queues](./queues) |
+| **queue** | {{< variant union >}}<a href="../queues/">Queues</a>{{< /variant >}}{{< variant flyte >}}Queues{{< /variant >}} |
 | **interruptible** | [Interruptible tasks](./interruptible-tasks-and-queues) |
 | **links** | [Additional task settings](./additional-task-settings#links) |
 

--- a/content/user-guide/task-configuration/overrides.md
+++ b/content/user-guide/task-configuration/overrides.md
@@ -6,7 +6,7 @@ variants: +flyte +union
 
 # Overrides
 
-Most task configuration is set when you define a task &mdash; on the `TaskEnvironment` or in the `@env.task` decorator.
+Most task configuration is set when you define a task: on the `TaskEnvironment` or in the `@env.task` decorator.
 But you often need to change some of that configuration for a **single invocation** of a task: give one call more memory, point it at a different secret, or bump its retries.
 
 The `task.override()` method does exactly this.
@@ -37,7 +37,7 @@ async def main() -> str:
     return heavy
 ```
 
-The key idiom is `task.override(...)(args)`: `override()` returns a callable task, which you then invoke with the task's arguments &mdash; note the two sets of parentheses.
+The key idiom is `task.override(...)(args)`: `override()` returns a callable task, which you then invoke with the task's arguments. Note the two sets of parentheses.
 
 ## What you can override
 
@@ -85,17 +85,17 @@ The key idiom is `task.override(...)(args)`: `override()` returns a callable tas
 For the full parameter interaction matrix showing which parameters can be set at which level, see [Task configuration levels](_index#task-configuration-levels).
 
 > [!NOTE] Overrides replace, they don't merge
-> When you override a collection-valued parameter such as `resources`, `env_vars`, or `secrets`, the value you pass **replaces** the environment's value for that invocation &mdash; it is not merged with it.
+> When you override a collection-valued parameter such as `resources`, `env_vars`, or `secrets`, the value you pass **replaces** the environment's value for that invocation. It is not merged with it.
 > To keep some of the original entries, include them in the override.
 
 ## What you cannot override
 
-`name`, `image`, `docs`, and the task's interface (its input and output types) **cannot** be overridden &mdash; attempting to override them raises an error.
+`name`, `image`, `docs`, and the task's interface (its input and output types) **cannot** be overridden. Attempting to override them raises an error.
 To run a task with a different image, define it in a separate `TaskEnvironment` (see [Container images](./container-images) and [Multiple environments](./multiple-environments)).
 
 ## Overriding when a task is reusable
 
-When a task uses a [reusable container](./reusable-containers) (`reusable` is set), its `resources`, `env_vars`, and `secrets` come from the parent environment and **cannot** be overridden while reuse is active &mdash; the container is already running.
+When a task uses a [reusable container](./reusable-containers) (`reusable` is set), its `resources`, `env_vars`, and `secrets` come from the parent environment and **cannot** be overridden while reuse is active. The container is already running.
 
 To override any of these on a reusable task, turn reuse off in the same `override()` call by passing `reusable="off"`:
 
@@ -109,7 +109,7 @@ result = await my_task.override(
 ## Overriding secrets
 
 Just as you can override resources per invocation, you can override the [secrets](./secrets) injected into a task for a single call.
-This is useful when the same task needs different credentials depending on how it's invoked &mdash; for example, calling an external API with a different key per tenant, or supplying a secret that the task's environment doesn't declare.
+This is useful when the same task needs different credentials depending on how it's invoked: for example, calling an external API with a different key per tenant, or supplying a secret that the task's environment doesn't declare.
 
 Pass `secrets` to `override()` exactly as you would to the `TaskEnvironment`: a secret key, a `Secret` object, or a list of either.
 
@@ -144,9 +144,9 @@ async def main() -> str:
 ```
 
 > [!NOTE]
-> If the task's environment uses **reusable containers** (`reusable` is set), overriding `secrets` &mdash; like `resources` and `env_vars` &mdash; requires passing `reusable="off"` in the **same** `override()` call. Otherwise the override is rejected.
+> If the task's environment uses **reusable containers** (`reusable` is set), overriding `secrets`, like `resources` and `env_vars`, requires passing `reusable="off"` in the **same** `override()` call. Otherwise the override is rejected.
 
-As with the environment-level `secrets` parameter, the secret is injected at runtime and accessed inside the task &mdash; typically as an environment variable via `os.environ` (or mounted as a file).
+As with the environment-level `secrets` parameter, the secret is injected at runtime and accessed inside the task: typically as an environment variable via `os.environ` (or mounted as a file).
 See [Secrets](./secrets) for how to create secrets and how they are injected, and remember that the overriding `secrets` value **replaces** the environment's secrets for that invocation rather than adding to them.
 
 > [!NOTE]

--- a/content/user-guide/task-configuration/overrides.md
+++ b/content/user-guide/task-configuration/overrides.md
@@ -1,0 +1,130 @@
+---
+title: Overrides
+weight: 15
+variants: +flyte +union
+---
+
+# Overrides
+
+Most task configuration is set when you define a task &mdash; on the `TaskEnvironment` or in the `@env.task` decorator.
+But you often need to change some of that configuration for a **single invocation** of a task: give one call more memory, point it at a different secret, or bump its retries.
+
+The `task.override()` method does exactly this.
+It returns a **new task** with the specified parameters changed, leaving the original task definition untouched, so you can invoke the overridden task in place of the original:
+
+```python
+import flyte
+
+env = flyte.TaskEnvironment(
+    name="training",
+    resources=flyte.Resources(cpu=1, memory="512Mi"),
+)
+
+@env.task
+async def train(data: str) -> str:
+    return f"trained on {data}"
+
+@env.task
+async def main() -> str:
+    # Invoke train with its environment-level resources.
+    baseline = await train("small.csv")
+
+    # Invoke train with overridden resources for this call only.
+    heavy = await train.override(
+        resources=flyte.Resources(cpu="4", memory="24Gi"),
+    )("large.csv")
+
+    return heavy
+```
+
+The key idiom is `task.override(...)(args)`: `override()` returns a callable task, which you then invoke with the task's arguments &mdash; note the two sets of parentheses.
+
+## What you can override
+
+`override()` accepts the parameters that are settable at the task-invocation level:
+
+| Parameter | Details |
+|-----------|---------|
+| **short_name** | [Additional task settings](./additional-task-settings) |
+| **resources** | [Resources](./resources) &bull; [`Resources` API ref](../../api-reference/flyte-sdk/packages/flyte/resources) |
+| **cache** | [Caching](./caching) &bull; [`Cache` API ref](../../api-reference/flyte-sdk/packages/flyte/cache) |
+| **retries** | [Retries and timeouts](./retries-and-timeouts) &bull; [`RetryStrategy` API ref](../../api-reference/flyte-sdk/packages/flyte/retrystrategy) |
+| **timeout** | [Retries and timeouts](./retries-and-timeouts) &bull; [`Timeout` API ref](../../api-reference/flyte-sdk/packages/flyte/timeout) |
+| **reusable** | [Reusable containers](./reusable-containers) &bull; [`ReusePolicy` API ref](../../api-reference/flyte-sdk/packages/flyte/reusepolicy) |
+| **env_vars** | [Additional task settings](./additional-task-settings#environment-variables) |
+| **secrets** | [Overriding secrets](#overriding-secrets) &bull; [Secrets](./secrets) &bull; [`Secret` API ref](../../api-reference/flyte-sdk/packages/flyte/secret) |
+| **max_inline_io_bytes** | [Additional task settings](./additional-task-settings#inline-io-threshold) |
+| **pod_template** | [Pod templates](./pod-templates) &bull; [`PodTemplate` API ref](../../api-reference/flyte-sdk/packages/flyte/podtemplate) |
+| **queue** | [Queues](./queues) |
+| **interruptible** | [Interruptible tasks](./interruptible-tasks-and-queues) |
+| **links** | [Additional task settings](./additional-task-settings#links) |
+
+For the full parameter interaction matrix showing which parameters can be set at which level, see [Task configuration levels](./#task-configuration-levels).
+
+> [!NOTE] Overrides replace, they don't merge
+> When you override a collection-valued parameter such as `resources`, `env_vars`, or `secrets`, the value you pass **replaces** the environment's value for that invocation &mdash; it is not merged with it.
+> To keep some of the original entries, include them in the override.
+
+## What you cannot override
+
+`name`, `image`, `docs`, and the task's interface (its input and output types) **cannot** be overridden &mdash; attempting to override them raises an error.
+To run a task with a different image, define it in a separate `TaskEnvironment` (see [Container images](./container-images) and [Multiple environments](./multiple-environments)).
+
+## Overriding when a task is reusable
+
+When a task uses a [reusable container](./reusable-containers) (`reusable` is set), its `resources`, `env_vars`, and `secrets` come from the parent environment and **cannot** be overridden while reuse is active &mdash; the container is already running.
+
+To override any of these on a reusable task, turn reuse off in the same `override()` call by passing `reusable="off"`:
+
+```python
+result = await my_task.override(
+    reusable="off",
+    resources=flyte.Resources(cpu="4", memory="8Gi"),
+)(data)
+```
+
+## Overriding secrets
+
+Just as you can override resources per invocation, you can override the [secrets](./secrets) injected into a task for a single call.
+This is useful when the same task needs different credentials depending on how it's invoked &mdash; for example, calling an external API with a different key per tenant, or supplying a secret that the task's environment doesn't declare.
+
+Pass `secrets` to `override()` exactly as you would to the `TaskEnvironment` or `@env.task` decorator: a secret key, a `Secret` object, or a list of either.
+
+```python
+import flyte
+from flyte import Secret
+
+env = flyte.TaskEnvironment(
+    name="model_calls",
+    secrets=Secret("openai-key", as_env_var="LLM_API_KEY"),
+)
+
+@env.task
+async def call_model(prompt: str) -> str:
+    import os
+    api_key = os.environ["LLM_API_KEY"]
+    ...  # call the model using api_key
+    return "response"
+
+@env.task
+async def main() -> str:
+    # Use the environment's default secret.
+    default = await call_model("hello")
+
+    # Override the secret for this invocation, mounting a different
+    # store key into the same LLM_API_KEY environment variable.
+    alternate = await call_model.override(
+        secrets=Secret("anthropic-key", as_env_var="LLM_API_KEY"),
+    )("hello")
+
+    return alternate
+```
+
+As with the environment-level `secrets` parameter, the secret is injected at runtime and accessed inside the task &mdash; typically as an environment variable via `os.environ` (or mounted as a file).
+See [Secrets](./secrets) for how to create secrets and how they are injected, and remember that the overriding `secrets` value **replaces** the environment's secrets for that invocation rather than adding to them.
+
+> [!NOTE]
+> A task can only access a secret if the secret's scope includes the project and domain where the task's `TaskEnvironment` is deployed. Overriding the secret at invocation time does not change this.
+
+> [!WARNING]
+> Do not return secret values from tasks. Returned values are stored in plaintext in your data plane's object store and shown in the UI and to downstream tasks, defeating the secret store's protections.

--- a/content/user-guide/task-configuration/secrets.md
+++ b/content/user-guide/task-configuration/secrets.md
@@ -102,7 +102,7 @@ For example:
 
 ## Overriding secrets at invocation time
 
-The secrets above are declared when the task is defined, on the `TaskEnvironment` or in the `@env.task` decorator.
+The secrets above are declared when the task is defined, on the `TaskEnvironment`.
 You can also override which secrets are injected for a **single invocation** of a task using `task.override(secrets=...)` &mdash; useful when the same task needs different credentials depending on how it's called.
 See [Overriding secrets](./overrides#overriding-secrets) for details and an example.
 

--- a/content/user-guide/task-configuration/secrets.md
+++ b/content/user-guide/task-configuration/secrets.md
@@ -25,7 +25,6 @@ It will be available across all projects and domains in your organization.
 See the [scoping secrets](#scoping-secrets) section below for more details.
 See [Using a literal string secret](#using-a-literal-string-secret) for how to access the secret in your task code.
 
-
 ## Creating a file secret
 
 You can also create a secret by specifying a local file:
@@ -42,6 +41,7 @@ When you create a secret without specifying a project or domain, as we did above
 This means that the secret will be available across all projects and domains in the organization.
 
 You can optionally specify either or both of the `--project` and `--domain` flags to restrict the scope of the secret to:
+
 * A specific project (across all domains)
 * A specific domain (across all project)
 * A specific project and a specific domain.
@@ -99,6 +99,12 @@ For example:
 > Currently, to access a file secret you must specify a `mount` parameter value of `"/etc/flyte/secrets"`.
 > This fixed path is the directory in which the secret file will be placed.
 > The name of the secret file will be equal to the key of the secret.
+
+## Overriding secrets at invocation time
+
+The secrets above are declared when the task is defined, on the `TaskEnvironment` or in the `@env.task` decorator.
+You can also override which secrets are injected for a **single invocation** of a task using `task.override(secrets=...)` &mdash; useful when the same task needs different credentials depending on how it's called.
+See [Overriding secrets](./overrides#overriding-secrets) for details and an example.
 
 > [!NOTE]
 > A `TaskEnvironment` can only access a secret if the scope of the secret includes the project and domain where the `TaskEnvironment` is deployed.


### PR DESCRIPTION
## What

Adds a dedicated **Overrides** page under **User Guide → Configure tasks** documenting the `task.override()` invocation-level mechanism, and documents **secret overrides** specifically.

- **New** `content/user-guide/task-configuration/overrides.md` — the `task.override()` mechanism (returns a new task; invoked as `task.override(...)(args)`), the full overridable-parameter surface with cross-links to each parameter's page, replace-not-merge semantics, the reusable-container constraint (`reusable="off"`), what **cannot** be overridden (`name`/`image`/`docs`/interface), and an **Overriding secrets** section with a grounded example.
- `secrets.md` — adds an "Overriding secrets at invocation time" subsection pointing to the new page (closes the secret-override discoverability gap for users landing on the Secrets page).
- `_index.md` — links `task.override()` in the config-levels list to the new page (plus two trivial pre-existing markdownlint fixes on files touched).

## Why

`task.override()` is a shipped, useful v2 capability whose coverage was diffuse (per-parameter mentions on Resources/Retries/Additional settings, no grouping) and whose **secret** override was entirely undocumented. This groups the common patterns and fills the secret-override gap.

Closes:
- DOC-1082 — new overrides section: https://linear.app/unionai/issue/DOC-1082/new-overrides-section
- DOC-1083 — secret overrides: https://linear.app/unionai/issue/DOC-1083/secret-overrides

## Verify-live evidence (code is authoritative)

Grounded against installed **flyte SDK 2.0.0b56**:
- `flyte/_task.py` `TaskTemplate.override(*, short_name, resources, cache, retries, timeout, reusable, env_vars, secrets, max_inline_io_bytes, pod_template, queue, interruptible, links, **kwargs)` → returns a new `TaskTemplate`.
- **`name`, `image`, `docs`, and interface cannot be overridden** — the SDK raises `ValueError` for each. (Note: this contradicts an initial assumption that image is overridable; the docs follow the code.)
- `reusable`-set tasks reject `resources`/`env_vars`/`secrets` overrides unless `reusable="off"` is passed in the same call.
- Override values **replace** (not merge with) the environment's values (`x = x or self.x`).
- `secrets` accepts `SecretRequest = str | Secret | list[str|Secret]` (`flyte/_secret.py`); `Secret(key, group, mount, as_env_var)`.
- Call idiom `await task.override(...)(args)` confirmed against the live Resources and Task-configuration-levels pages.

markdownlint-cli2: 0 errors on all changed files. Content-only; no submodule pointer bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)