### PR TITLE
docsy(v2): add 'Why use reusable containers' section

### DIFF
--- a/content/user-guide/task-configuration/reusable-containers.md
+++ b/content/user-guide/task-configuration/reusable-containers.md
@@ -25,6 +25,19 @@ This approach reduces start up overhead and improves resource efficiency.
 > [!NOTE]
 > The reusable container feature is only available when running your Flyte code on a Union backend.
 
+## Why use reusable containers
+
+The default fresh-container-per-execution model gives every task strong isolation, but it pays a cold-start cost on every execution: the container has to be created, the image pulled, and the Python process initialized before your code runs.
+When that startup cost is large relative to how long the task actually runs, the overhead dominates.
+Reusable containers address this by keeping a pool of warm containers ready to accept work.
+Reach for them when you have:
+
+- **Many short tasks with high per-execution startup cost.** Fan-out and map-style workloads — where the same small task runs hundreds or thousands of times — benefit most, because the startup overhead is paid once per container instead of once per execution.
+- **Expensive in-memory state to keep warm.** Because the same container (and its Python process) is reused across executions, you can load a model, dataset, or connection once and reuse it on subsequent invocations — for example by caching it in a global variable or with an in-memory cache — instead of reloading it every time.
+- **A need for higher throughput and better resource utilization.** A reusable environment can process multiple `async` tasks concurrently within each container. Total capacity is `replicas × concurrency`, so you can drive up utilization without provisioning a fresh container per task. See [Scale your workflows](../run-scaling/scale-your-workflows) for how this fits into a broader scaling strategy.
+
+Stick with the default (non-reusable) model when tasks are long-running, run infrequently, or need strong isolation between executions — in those cases the startup cost is negligible and container reuse adds no benefit.
+
 ## How it works
 
 With reusable containers, the system maintains a pool of persistent containers that can handle multiple task executions.

--- a/content/user-guide/task-configuration/reusable-containers.md
+++ b/content/user-guide/task-configuration/reusable-containers.md
@@ -27,14 +27,14 @@ This approach reduces start up overhead and improves resource efficiency.
 
 ## Why use reusable containers
 
-The default fresh-container-per-execution model gives every task strong isolation, but it pays a cold-start cost on every execution: the container has to be created, the image pulled, and the Python process initialized before your code runs.
+The default fresh-container-per-execution model gives every execution strong isolation, but it pays a cold-start cost on every execution: the container has to be created, the image pulled, and the Python process initialized before your code runs.
 When that startup cost is large relative to how long the task actually runs, the overhead dominates.
 Reusable containers address this by keeping a pool of warm containers ready to accept work.
 Reach for them when you have:
 
 - **Many short tasks with high per-execution startup cost.** Fan-out and map-style workloads — where the same small task runs hundreds or thousands of times — benefit most, because the startup overhead is paid once per container instead of once per execution.
-- **Expensive in-memory state to keep warm.** Because the same container (and its Python process) is reused across executions, you can load a model, dataset, or connection once and reuse it on subsequent invocations — for example by caching it in a global variable or with an in-memory cache — instead of reloading it every time.
-- **A need for higher throughput and better resource utilization.** A reusable environment can process multiple `async` tasks concurrently within each container. Total capacity is `replicas × concurrency`, so you can drive up utilization without provisioning a fresh container per task. See [Scale your workflows](../run-scaling/scale-your-workflows) for how this fits into a broader scaling strategy.
+- **Expensive in-memory state to keep warm.** Because the same container (and its Python process) is reused across executions, you can load a model or dataset once and reuse it on subsequent invocations — for example by caching it in a global variable or with an in-memory cache — instead of reloading it every time. Prefer in-memory artifacts for this; a long-lived connection can go stale (credential rotation, idle timeouts), so if you cache one, guard it with a health check and reconnect when needed.
+- **A need for higher throughput and better resource utilization.** A reusable environment can process multiple async task executions concurrently within each container. Total capacity is `max_replicas × concurrency`, so you can drive up utilization without provisioning a fresh container per task. See [Scale your workflows](../run-scaling/scale-your-workflows) for how this fits into a broader scaling strategy.
 
 Stick with the default (non-reusable) model when tasks are long-running, run infrequently, or need strong isolation between executions — in those cases the startup cost is negligible and container reuse adds no benefit.
 


### PR DESCRIPTION
## What

Adds a **"Why use reusable containers"** section to the reusable containers page (`content/user-guide/task-configuration/reusable-containers.md`), giving the concise motivational when/why-to-use framing requested in **[DOC-693](https://linear.app/unionai/issue/DOC-693/add-why-use-actors-section)** ("Add 'Why use actors' section").

## Retarget note (code-is-authoritative)

The ticket originated from an Oct-2024 Slack thread framed around **Flyte 1.x "actors"** (`@actor.task`). In **Flyte/Union 2.0.x this capability ships as reusable containers / `flyte.ReusePolicy`** — the term "actor" no longer appears in the V2 SDK or docs (verified against `flyte-sdk` `main` and the live V2 docs). So the section is written for reusable containers, not "actors". This matches the DOC-693 backlog-triage decision to retarget the V1 "actors" ask to the V2 reusable-containers page.

## Why here

The page previously had only a one-line motivation ("reduces start up overhead and improves resource efficiency") followed by "How it works" — it explained *how* but not *why/when*. The new section sits right after the intro, before "How it works".

## Content grounding (verify-live)

Grounded in the shipped SDK, not the 1.x source thread:
- `flyte.ReusePolicy` docstring (flyte-sdk `main`, API ref v2.5.8): *"When environment creation is expensive relative to task runtime, reusable containers keep a pool of warm containers ready, avoiding cold-start overhead. The Python process may be reused by subsequent task invocations."*
- `TaskEnvironment(reusable=flyte.ReusePolicy(...))` — canonical param verified against the API reference.
- Total capacity = `replicas × concurrency` (from the docstring + existing page's "Understanding parameter relationships").

The section covers: warm-pool / cold-start avoidance, stateful reuse of the Python process, throughput via `replicas × concurrency`, and when to *stay* with the default fresh-container model.

## Notes for reviewer

- Cross-links to the existing **Scale your workflows** page (`../run-scaling/scale-your-workflows`), which already frames reusable containers for throughput.
- **Incidental finding (not fixed here, out of scope):** `content/user-guide/run-scaling/scale-your-workflows.md` uses `reuse_policy=flyte.ReusePolicy(...)` in its examples, but the current SDK param on `TaskEnvironment` is `reusable=`. Worth a follow-up correction.

Draft PR — held pending review. DOC-693.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
