### PR TITLE
docsy(v2): add custom type-renderer example to decks page

### DIFF
--- a/content/user-guide/task-programming/dataframes.md
+++ b/content/user-guide/task-programming/dataframes.md
@@ -108,3 +108,7 @@ The `collect()` call in `aggregate_by_department` is what triggers execution of 
 ### Run the example
 
 {{< code file="/unionai-examples/v2/user-guide/task-programming/dataframes/polars_dataframes.py" fragment="main" lang="python" >}}
+
+## See also
+
+To display a DataFrame as an HTML table in a task report, define a `flyte.types.Renderable` for it — see [Rendering a custom type](./reports#rendering-a-custom-type) on the Reports page.

--- a/content/user-guide/task-programming/handling-custom-types.md
+++ b/content/user-guide/task-programming/handling-custom-types.md
@@ -223,3 +223,7 @@ DataFrame extensions use encoders and decoders from `flyte.io.extend`. Documenta
 3. **Add validation**: Validate data in your transformer to catch errors early
 4. **Use meaningful tags**: The `TypeStructure.tag` helps identify your type in the Flyte UI
 5. **Be judicious with plugins**: Only install the plugins you need to minimize initialization overhead
+
+## See also
+
+To render a custom type as HTML in a task report, define a `flyte.types.Renderable` for it — see [Rendering a custom type](./reports#rendering-a-custom-type) on the Reports page.

--- a/content/user-guide/task-programming/reports.md
+++ b/content/user-guide/task-programming/reports.md
@@ -186,4 +186,4 @@ if __name__ == "__main__":
 > [!NOTE]
 > The report contains only what you explicitly `log()` or `replace()`. Returning a value whose type has a renderer attached does **not** by itself add it to the report — render the value and log the HTML, as shown above.
 
-Flyte also ships several ready-made renderers you can use as reference implementations for your own, including ones that render a pandas or PyArrow DataFrame as an HTML table and one that renders a Markdown string.
+Flyte's SDK also implements a few renderers of this kind internally — for pandas and PyArrow DataFrames and for Markdown strings. These aren't exposed as public API (only the `flyte.types.Renderable` protocol is), so treat them as examples of the same pattern rather than importable helpers.

--- a/content/user-guide/task-programming/reports.md
+++ b/content/user-guide/task-programming/reports.md
@@ -144,7 +144,7 @@ class Molecule:
         self.name = name
         self.smiles = smiles
 
-class MoleculeRenderer:
+class MoleculeRenderer(Renderable):
     """A Renderable for the Molecule type."""
 
     def to_html(self, mol: Molecule) -> str:

--- a/content/user-guide/task-programming/reports.md
+++ b/content/user-guide/task-programming/reports.md
@@ -129,3 +129,61 @@ The key to the live update ability is the `while` loop that appends Javascript t
 When the workflow runs, you can see the report updating in real-time in the UI:
 
 ![Data Processing Dashboard](../../_static/images/user-guide/data_processing_dashboard.png)
+
+## Rendering a custom type
+
+The examples above build report HTML by hand. When you have a **custom type** — or a DataFrame, or a `StructuredDataset` — that you render the same way in many places, you can define a reusable **renderer** for the type and attach it to the type, instead of repeating the HTML-building logic at every call site.
+
+A renderer is any class that satisfies the `flyte.types.Renderable` protocol: it implements a single `to_html(self, value) -> str` method that returns an HTML fragment for a value of your type.
+
+```python
+from flyte.types import Renderable
+
+class Molecule:
+    def __init__(self, name: str, smiles: str):
+        self.name = name
+        self.smiles = smiles
+
+class MoleculeRenderer:
+    """A Renderable for the Molecule type."""
+
+    def to_html(self, mol: Molecule) -> str:
+        return f"<h2>{mol.name}</h2><pre>{mol.smiles}</pre>"
+```
+
+You attach the renderer to the type with `typing.Annotated`, then dispatch a value through its attached renderer with `flyte.types.TypeEngine.to_html()`. Log the resulting HTML to the report just like any other content:
+
+```python
+from typing import Annotated
+
+import flyte
+import flyte.report
+from flyte.types import TypeEngine
+
+env = flyte.TaskEnvironment(name="custom_renderer")
+
+# Attaching the renderer to the type is the "registration".
+RenderedMolecule = Annotated[Molecule, MoleculeRenderer()]
+
+@env.task(report=True)
+async def show_molecule() -> Molecule:
+    mol = Molecule("caffeine", "CN1C=NC2=C1C(=O)N(C(=O)N2C)C")
+
+    # Dispatch the value through the renderer attached to RenderedMolecule.
+    html = TypeEngine.to_html(mol, RenderedMolecule)
+    await flyte.report.log.aio(html)
+    await flyte.report.flush.aio()
+
+    return mol
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    print(flyte.run(show_molecule).url)
+```
+
+`TypeEngine.to_html()` finds the `Renderable` attached to the type via `Annotated`, calls its `to_html()`, and returns the HTML string — which you then send to the report with `flyte.report.log()` (or `replace()`). The same pattern works for a DataFrame or `StructuredDataset`: annotate the type with a renderer that turns the frame into an HTML table.
+
+> [!NOTE]
+> The report contains only what you explicitly `log()` or `replace()`. Returning a value whose type has a renderer attached does **not** by itself add it to the report — render the value and log the HTML, as shown above.
+
+Flyte also ships several ready-made renderers you can use as reference implementations for your own, including ones that render a pandas or PyArrow DataFrame as an HTML table and one that renders a Markdown string.


### PR DESCRIPTION
## What

Adds a worked example to the **Reports** page (`user-guide/task-programming/reports`) showing how to render a **custom type** as HTML in a task report, plus "See also" cross-links from the **Custom types** and **DataFrames** pages.

Resolves the docs gap in [DOC-1121](https://linear.app/unionai/issue/DOC-1121) — originated from Slack feedback (Daniel Sola, Oct 2025) about confusion connecting types / DataFrames / StructuredDatasets to report rendering. ("Decks" is the Flyte 1 term; the Flyte 2 equivalent is **Reports**, so the example lives on the Reports page.)

## Grounding (code-is-authoritative, verified live against the shipped SDK)

- **`flyte.types.Renderable`** — public `@runtime_checkable` protocol (`src/flyte/types/_renderer.py`), a class implementing `to_html(self, value) -> str`. Exported in `flyte.types.__all__` and documented in the API reference.
- **Attach + dispatch** — `typing.Annotated[MyType, MyRenderer()]` binds the renderer to the type; **`flyte.types.TypeEngine.to_html(value, Annotated[...])`** (`_type_engine.py:1876`) finds the attached `Renderable` and calls it. Both symbols are public + in the linkmap.
- **Verified runnable** — the example code was executed live against the installed `flyte` SDK: `isinstance(renderer, Renderable)` → `True`, and `TypeEngine.to_html(mol, Annotated[Molecule, MoleculeRenderer()])` returns the expected HTML.
- **Honest behavior note in the doc** — the report is populated **only** by explicit `flyte.report.log()`/`replace()` calls (`_internal/runtime/taskrunner.py:192-196` just flushes existing content). There is **no** automatic rendering of task outputs through registered renderers in Flyte 2, so the example renders then logs the HTML explicitly — and the doc says so.

The DataFrame-specific `DataFrameTransformerEngine.register_renderer()` path also works but lives in a **private** module (`flyte.io._dataframe.dataframe`, not in `flyte.io.__all__`), so the example leads with the public `Renderable` + `TypeEngine.to_html` path and notes it applies equally to DataFrames/StructuredDatasets.

## Status

**Held draft** — feature is shipped, so this is publishable on review. Draft per docsy contract (agent proposes, human disposes).
