### PR TITLE
docsy(v2): CLI parameter customization example

### DIFF
--- a/content/user-guide/task-deployment/custom-cli.md
+++ b/content/user-guide/task-deployment/custom-cli.md
@@ -69,8 +69,8 @@ if __name__ == "__main__":
     config = tyro.cli(Config)
 
     flyte.init_from_config()
-    r = flyte.run(main, config)
-    print(r.url)
+    run = flyte.run(main, config)
+    print(run.url)
 ```
 
 Run it like any script — `tyro` exposes `foo` and `bar` as CLI options and prints
@@ -84,8 +84,7 @@ Here `tyro.cli(Config)` does the parsing, `flyte.init_from_config()` loads your
 `config.yaml` (endpoint, project, domain, and so on), and
 `flyte.run(main, config)` deploys and runs the task with the parsed config as its
 input. The `config` object is passed **positionally** to `main`, mapping to its
-`config` parameter — the same positional form documented in
-[Run command options](./run-command-options).
+`config` parameter — these are ordinary Python positional arguments.
 
 ## Using a different parser
 
@@ -112,8 +111,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     flyte.init_from_config()
-    r = flyte.run(main, foo=args.foo, bar=args.bar)
-    print(r.url)
+    run = flyte.run(main, foo=args.foo, bar=args.bar)
+    print(run.url)
 ```
 
 Swap `argparse` for `click` or `hydra` the same way: parse however you like, then

--- a/content/user-guide/task-deployment/custom-cli.md
+++ b/content/user-guide/task-deployment/custom-cli.md
@@ -1,0 +1,134 @@
+---
+title: Build a custom CLI
+weight: 5
+variants: +flyte +union
+---
+
+# Build a custom CLI
+
+The built-in `flyte run` command (see [Run command options](./run-command-options))
+turns your task's parameters into `--<input_name>` options automatically. That's
+the fastest way to run a task from the command line, but it gives you the CLI
+that Flyte generates.
+
+When you want your **own** command-line interface — custom argument names, grouped
+options, subcommands, config files, `--help` text you control — build it with an
+argument-parsing library of your choice and hand the parsed values to
+`flyte.run()`. Because `flyte.run()` is an ordinary Python function, any parser
+works: [`tyro`](https://brentyi.github.io/tyro/), `argparse`, `click`, or `hydra`.
+
+## The pattern
+
+A custom CLI wrapper is three steps:
+
+1. **Parse the command line** into a config object (a dataclass, a Pydantic model,
+   or plain arguments) with the parser of your choice.
+2. **Initialize Flyte** with `flyte.init_from_config()`.
+3. **Run the task** with `flyte.run()`, passing the parsed config as the task's
+   input.
+
+## Example: a typed CLI with `tyro`
+
+[`tyro`](https://brentyi.github.io/tyro/) generates a fully-typed CLI directly
+from a dataclass, so you describe your parameters once and get parsing,
+validation, and `--help` for free.
+
+```python
+# /// script
+# dependencies = [
+#    "tyro",
+#    "flyte",
+# ]
+# ///
+
+from dataclasses import dataclass
+
+import tyro
+
+import flyte
+
+env = flyte.TaskEnvironment(
+    name="custom_cli",
+    image=flyte.Image.from_uv_script(__file__, name="flyte"),
+)
+
+
+@dataclass
+class Config:
+    foo: int
+    bar: str = "default"
+
+
+@env.task
+async def main(config: Config):
+    print(f"foo: {config.foo}, bar: {config.bar}")
+
+
+if __name__ == "__main__":
+    # Generate a CLI and instantiate `Config` with its two arguments: `foo` and `bar`.
+    config = tyro.cli(Config)
+
+    flyte.init_from_config()
+    r = flyte.run(main, config)
+    print(r.url)
+```
+
+Run it like any script — `tyro` exposes `foo` and `bar` as CLI options and prints
+`--help` for you:
+
+```bash
+$ uv run custom_cli.py --foo 42 --bar hello
+```
+
+Here `tyro.cli(Config)` does the parsing, `flyte.init_from_config()` loads your
+`config.yaml` (endpoint, project, domain, and so on), and
+`flyte.run(main, config)` deploys and runs the task with the parsed config as its
+input. The `config` object is passed **positionally** to `main`, mapping to its
+`config` parameter — the same positional form documented in
+[Run command options](./run-command-options).
+
+## Using a different parser
+
+The pattern is identical whichever library you reach for — only step 1 changes.
+With the standard library's `argparse`:
+
+```python
+import argparse
+
+import flyte
+
+env = flyte.TaskEnvironment(name="custom_cli")
+
+
+@env.task
+async def main(foo: int, bar: str = "default"):
+    print(f"foo: {foo}, bar: {bar}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--foo", type=int, required=True)
+    parser.add_argument("--bar", default="default")
+    args = parser.parse_args()
+
+    flyte.init_from_config()
+    r = flyte.run(main, foo=args.foo, bar=args.bar)
+    print(r.url)
+```
+
+Swap `argparse` for `click` or `hydra` the same way: parse however you like, then
+call `flyte.run()` with the resulting values (positionally or by keyword). This is
+also the entry point for richer CLIs — subcommands that each run a different task,
+`hydra` config composition, environment-driven defaults, and so on.
+
+## When to use which
+
+- **Reach for the built-in `flyte run`** when you just need to run a task from the
+  command line and Flyte's generated `--<input_name>` options are enough. See
+  [Run command options](./run-command-options).
+- **Build a custom CLI** when you need control over the interface itself — your own
+  option names, subcommands, config-file loading, or help text — or when the CLI is
+  a first-class part of a tool you're shipping.
+
+For configuring the run itself (storage, caching, identity, logging) rather than the
+task's inputs, see [Run context](./run-context).

--- a/content/user-guide/task-deployment/custom-cli.md
+++ b/content/user-guide/task-deployment/custom-cli.md
@@ -11,8 +11,8 @@ turns your task's parameters into `--<input_name>` options automatically. That's
 the fastest way to run a task from the command line, but it gives you the CLI
 that Flyte generates.
 
-When you want your **own** command-line interface — custom argument names, grouped
-options, subcommands, config files, `--help` text you control — build it with an
+When you want your **own** command-line interface (custom argument names, grouped
+options, subcommands, config files, `--help` text you control), build it with an
 argument-parsing library of your choice and hand the parsed values to
 `flyte.run()`. Because `flyte.run()` is an ordinary Python function, any parser
 works: [`tyro`](https://brentyi.github.io/tyro/), `argparse`, `click`, or `hydra`.
@@ -73,22 +73,22 @@ if __name__ == "__main__":
     print(run.url)
 ```
 
-Run it like any script — `tyro` exposes `foo` and `bar` as CLI options and prints
+Run it like any script, and `tyro` exposes `foo` and `bar` as CLI options and prints
 `--help` for you:
 
 ```bash
-$ uv run custom_cli.py --foo 42 --bar hello
+uv run custom_cli.py --foo 42 --bar hello
 ```
 
 Here `tyro.cli(Config)` does the parsing, `flyte.init_from_config()` loads your
 `config.yaml` (endpoint, project, domain, and so on), and
 `flyte.run(main, config)` deploys and runs the task with the parsed config as its
 input. The `config` object is passed **positionally** to `main`, mapping to its
-`config` parameter — these are ordinary Python positional arguments.
+`config` parameter. These are ordinary Python positional arguments.
 
 ## Using a different parser
 
-The pattern is identical whichever library you reach for — only step 1 changes.
+The pattern is identical whichever library you reach for: only step 1 changes.
 With the standard library's `argparse`:
 
 ```python
@@ -117,7 +117,7 @@ if __name__ == "__main__":
 
 Swap `argparse` for `click` or `hydra` the same way: parse however you like, then
 call `flyte.run()` with the resulting values (positionally or by keyword). This is
-also the entry point for richer CLIs — subcommands that each run a different task,
+also the entry point for richer CLIs: subcommands that each run a different task,
 `hydra` config composition, environment-driven defaults, and so on.
 
 ## When to use which
@@ -125,8 +125,8 @@ also the entry point for richer CLIs — subcommands that each run a different t
 - **Reach for the built-in `flyte run`** when you just need to run a task from the
   command line and Flyte's generated `--<input_name>` options are enough. See
   [Run command options](./run-command-options).
-- **Build a custom CLI** when you need control over the interface itself — your own
-  option names, subcommands, config-file loading, or help text — or when the CLI is
+- **Build a custom CLI** when you need control over the interface itself (your own
+  option names, subcommands, config-file loading, or help text), or when the CLI is
   a first-class part of a tool you're shipping.
 
 For configuring the run itself (storage, caching, identity, logging) rather than the


### PR DESCRIPTION
## What

Adds a new how-to page **`user-guide/task-deployment/custom-cli.md`** ("Build a custom CLI") showing how to wrap a Flyte 2.0.x task in your **own** command-line interface — parse args with `tyro` / `argparse` / `click` / `hydra`, then `flyte.init_from_config()` + `flyte.run()`.

Resolves **DOC-1066** — "Example for customizing CLI with different parameters" (Ketan's ask to show how you can customize the CLI for different parameters using click/argparse/tyro/hydra).

## Grounding (verify-live)

- Grounded in **flyte-sdk PR [#175](https://github.com/flyteorg/flyte-sdk/pull/175)** — the shipped example `examples/customize/custom_cli.py` (tyro → `flyte.init_from_config()` → `flyte.run(main, config)`). The tyro example is reproduced verbatim from that file.
- Verified `flyte.init_from_config()` signature and the positional `flyte.run(main, config)` form against the live flyte-sdk `main` (`src/flyte/_initialize.py`).

## Relationship to #1180 (coordinated, not overlapping)

PR **#1180** (DOC-436/663, `docsy/v2-cli-input-passing`) documents the **built-in** `flyte run` CLI — typed input passing via `--<input_name>`, positional args, per-type syntax — by editing `run-command-options.md` and `_index.md`.

This PR is the **distinct** topic the DOC-1066 triage flagged: building your **own** CLI wrapper around `flyte.run()`. To avoid colliding with #1180's heavy edits, this PR:
- **touches neither file #1180 edits** — it only adds a new page (Hugo auto-lists it in the section sidebar by `weight`);
- cross-links **to** `run-command-options` (the built-in CLI) and `run-context`, using page-level links (no dependency on anchors #1180 introduces), so it merges cleanly in either order.

## Status

**Held draft** — DOC-1066's feature (flyte-sdk #175) has already shipped, so this is publish-ready on review; kept draft pending human disposition per docsy posture.

Linear: DOC-1066