### PR TITLE
docsy(v2): set GPU limits in cluster resource config

### DIFF
--- a/content/user-guide/project-patterns/resource-management.md
+++ b/content/user-guide/project-patterns/resource-management.md
@@ -58,8 +58,8 @@ uctl get cluster-resource-attribute -p <project> -d <domain>
 
 The `projectQuota*` attributes above set namespace CPU and memory quotas; there is no equivalent standard GPU quota key. GPU limits are enforced instead through the [settings](../core-concepts/settings) system, which resolves through the org → domain → project hierarchy:
 
-- **`task_resource.max.gpu`** — the maximum GPU per task pod, enforced as a hard limit that a per-task `flyte.Resources` request cannot exceed. This is how you cap (or raise) the GPU ceiling for a domain or project.
-- **`task_resource.min.gpu`** — the default GPU request applied when a task doesn't specify one.
+- **`task_resource.max.gpu`**: the maximum GPU per task pod, enforced as a hard ceiling: a per-task `flyte.Resources` GPU request above it is **capped to the maximum rather than rejected**. This is how you cap (or raise) the GPU ceiling for a domain or project.
+- **`task_resource.min.gpu`**: the default GPU request applied when a task doesn't specify one.
 
 Set them at the scope you want with `flyte edit settings`, then uncomment and edit the relevant key:
 

--- a/content/user-guide/project-patterns/resource-management.md
+++ b/content/user-guide/project-patterns/resource-management.md
@@ -54,6 +54,21 @@ Verify with:
 uctl get cluster-resource-attribute -p <project> -d <domain>
 ```
 
+### GPU limits
+
+The `projectQuota*` attributes above set namespace CPU and memory quotas; there is no equivalent standard GPU quota key. GPU limits are enforced instead through the [settings](../core-concepts/settings) system, which resolves through the org → domain → project hierarchy:
+
+- **`task_resource.max.gpu`** — the maximum GPU per task pod, enforced as a hard limit that a per-task `flyte.Resources` request cannot exceed. This is how you cap (or raise) the GPU ceiling for a domain or project.
+- **`task_resource.min.gpu`** — the default GPU request applied when a task doesn't specify one.
+
+Set them at the scope you want with `flyte edit settings`, then uncomment and edit the relevant key:
+
+```bash
+flyte edit settings --domain production
+```
+
+Unlike the CPU and memory quotas above, these are per-task limits rather than a namespace-wide aggregate. See [Settings](../core-concepts/settings) for the full key list and how inheritance and overrides work.
+
 ### Why quotas matter
 
 Without quotas, projects can starve each other for shared resources. Runs that exceed available capacity are still dispatched to the cluster, and pods sit pending while the execution shows as "running." Quotas turn that silent contention into an explicit, fail-fast signal teams can act on.


### PR DESCRIPTION
## What

Adds a **GPU limits** subsection to the Resource management guide (`user-guide/project-patterns/resource-management`), answering **[DOC-306](https://linear.app/unionai/issue/DOC-306/update-cluster-resource-config-with-how-to-set-gpu-limits)** — "how does an admin set GPU limits in the cluster resource config?"

## Why / grounding (code-is-authoritative)

The page documented project-domain quotas for **CPU and memory only** (`projectQuotaCpu` / `projectQuotaMemory` via `uctl update cluster-resource-attribute`), with GPU absent. DOC-306 (and its Jira original, DOCS-362) asked specifically how to raise the GPU limit, guessing at a `projectQuotaNvidiaGpu` key.

**Verified against live docs + repo content + source:**

- **There is no standard project-level GPU quota key.** The `projectQuota*` attributes are *free-form ResourceQuota template variables* — the shipped/standard template wires only `limits.cpu` / `limits.memory` (`deployment/flyte-plugins/kubernetes-plugins.md` template; `deployment/flyte-configuration/customizable_resources.md` — "free-form strings"). So `projectQuotaNvidiaGpu` is not a real, fixed key.
- **The confirmed v2/Union GPU limit mechanism is the settings system:**
  - **`task_resource.max.gpu`** — maximum GPU per task pod, enforced as a hard limit that a per-task `flyte.Resources` request cannot exceed.
  - **`task_resource.min.gpu`** — default GPU request when a task omits one.
  - Set via `flyte edit settings --domain <d>` (or `--project`). Documented on `user-guide/core-concepts/settings` and confirmed against the live docs (`.../core-concepts/settings/page.md`).

The new subsection states the confirmed keys, notes these are per-task limits rather than a namespace aggregate, and cross-links Settings. Scope is deliberately narrow (the platform/domain/project GPU cap) — distinct from the per-task `Resources(gpu=)` API (DOC-1102 / #1197).

## Hold status

**Held draft** — the mechanism ships today (already live in the Settings docs), so this is publish-ready on human review/merge, not blocked on an unshipped feature.

Refs: DOC-306