### PR TITLE
docsy(v2): authenticating flyte.init with an API key

### DIFF
--- a/content/user-guide/authenticating.md
+++ b/content/user-guide/authenticating.md
@@ -293,7 +293,7 @@ tasks = remote.Task.listall(project="flytesnacks", domain="development")
 Both methods work identically. The `init_from_api_key()` method is a convenience function specifically designed for API key authentication. If no `api_key` parameter is provided, it automatically reads from the `FLYTE_API_KEY` environment variable.
 
 > [!NOTE]
-> Use `flyte.init_from_api_key()` or `flyte.init(api_key=...)` for API key authentication — **not** `flyte.init_from_config()`. `init_from_config()` reads its auth settings from a `config.yaml` file, which has no API key field, so it cannot authenticate with an API key.
+> Use `flyte.init_from_api_key()` or `flyte.init(api_key=...)` for API key authentication, **not** `flyte.init_from_config()`. `init_from_config()` reads its auth settings from a `config.yaml` file, which has no API key field, so it cannot authenticate with an API key.
 
 > [!NOTE]
 > The API key is a base64-encoded string containing endpoint, client_id, client_secret, and org information. The SDK automatically decodes this and uses OAuth2 client credentials flow for authentication.

--- a/content/user-guide/authenticating.md
+++ b/content/user-guide/authenticating.md
@@ -293,6 +293,9 @@ tasks = remote.Task.listall(project="flytesnacks", domain="development")
 Both methods work identically. The `init_from_api_key()` method is a convenience function specifically designed for API key authentication. If no `api_key` parameter is provided, it automatically reads from the `FLYTE_API_KEY` environment variable.
 
 > [!NOTE]
+> Use `flyte.init_from_api_key()` or `flyte.init(api_key=...)` for API key authentication — **not** `flyte.init_from_config()`. `init_from_config()` reads its auth settings from a `config.yaml` file, which has no API key field, so it cannot authenticate with an API key.
+
+> [!NOTE]
 > The API key is a base64-encoded string containing endpoint, client_id, client_secret, and org information. The SDK automatically decodes this and uses OAuth2 client credentials flow for authentication.
 
 **Example: Automated deployment script**


### PR DESCRIPTION
## What

Adds a short clarification to the **Authenticating** page (`content/user-guide/authenticating.md`, API key section) that API-key authentication must use `flyte.init_from_api_key()` or `flyte.init(api_key=...)` — **not** `flyte.init_from_config()`, which reads auth from a `config.yaml` that has no API-key field.

Ticket: [DOC-1123](https://linear.app/unionai/issue/DOC-1123) (help request from a user trying to kick off a Flyte v2 run from CI with an API key).

## Why

In the DOC-1123 thread the user reached for `flyte.init_from_config()` and was confused that it wouldn't accept an `api_key` ("I've been using `flyte.init_from_config` which doesn't allow passing `api_key`"); Niels (eng) explicitly asked to "improve/test/**document** the `flyte.init(api_key=...)` story." The page already documents `init_from_api_key()` / `init(api_key=...)` / `FLYTE_API_KEY` / `flyte create api-key` well, but never disambiguates them from `init_from_config()` — which is the exact stumbling block. This note closes that gap.

## Grounding — code is authoritative (verified against flyte SDK `2.0.0b56`)

- `flyte.init(api_key=...)` — **ships** (`_initialize.py`, `init()` accepts `api_key`).
- `flyte.init_from_api_key(api_key=...)` — **ships**; reads `FLYTE_API_KEY` when `api_key` is `None`, decodes the encoded key to endpoint/client_id/secret/org, uses `ClientSecret` auth.
- `flyte.init_from_config()` — **does not accept `api_key`** (confirmed from its signature).
- `PlatformConfig` (the `config.yaml` schema) has `client_id` / `client_credentials_secret` / `client_credentials_secret_env_var` / `auth_mode` / `endpoint` but **no `api_key` / `api_key_env_var`** field.

## Scope — shipped docs part only

This PR documents **only what ships today** (the correct init entry points for API-key auth). Two related items from the ticket are deliberately **out of scope**:

1. **`api_key` / `api_key_env_var` support in `config.yaml`** — the second ask in the ticket. This **did not ship** (`PlatformConfig` has no such field); it is an **SDK feature request for eng**, not a docs gap. Documenting it would describe non-existent behavior. Surfaced as a cross-surface finding on the ticket.
2. **A concrete `flyte run`-from-CI-with-API-key example** (the user's broader workflow) — the CI/CD page (`project-patterns/cicd.md`) currently covers `flyte deploy` from CI only. That page is **already being edited in-review by #1183 (DOC-944)**; per the 2026-07-08 triage note, the residual run-from-CI example should fold into #1183 rather than spawn a conflicting parallel edit to the same file. This PR therefore touches only `authenticating.md`, which #1183 does not.

## Verification

Content-only, 3-line addition (a `> [!NOTE]` callout); no shortcode/template changes. No submodule pointers bumped.

**Held draft** — do not merge as part of routine review; this is a docsy-authored draft pending human disposition per the DOC-1123 pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)