### PR TITLE
docsy(v2): reconcile self-managed cloud list + link orphaned Crusoe/Nebius guides

### DIFF
--- a/content/deployment/_index.md
+++ b/content/deployment/_index.md
@@ -31,7 +31,7 @@ The BYOC deployment offers a fully "serverless in your cloud", turnkey solution 
 
 The Self-managed deployment allows you to manage the data plane yourself on cloud infrastructure that you control and maintain:
 
-* The **data plane** resides in your cloud provider account and is managed by you. Your team will handle deployment, monitoring, Kubernetes upgrades, and all other operational aspects of the platform. You do not need to provide any permissions to the Union.ai system to create a data plane. Self-managed deployment supports data planes on Amazon Web Services (AWS), Google Cloud Platform (GCP), Microsoft Azure and Oracle Compute Infrastructure (OCI).
+* The **data plane** resides in your cloud provider account and is managed by you. Your team will handle deployment, monitoring, Kubernetes upgrades, and all other operational aspects of the platform. You do not need to provide any permissions to the Union.ai system to create a data plane. Self-managed deployment supports data planes on Amazon Web Services (AWS), Google Cloud Platform (GCP), Microsoft Azure, and Oracle Cloud Infrastructure (OCI); on neocloud providers including CoreWeave, Crusoe, and Nebius; and on any generic Kubernetes environment. See [Set up your data plane](./selfmanaged/_index) for the full list of supported providers.
 
 * The **control plane**, as with all Union.ai deployment options, resides in the Union.ai Amazon Web Services (AWS) account and is administered by Union.ai. However, as mentioned, data separation is maintained between the data plane and the control plane, with no control plane access to the code, input/output, images or logs in the data plane.
 

--- a/content/deployment/selfmanaged/_index.md
+++ b/content/deployment/selfmanaged/_index.md
@@ -24,6 +24,8 @@ Union.ai has no access to your cluster, providing the highest level of data isol
    - [Azure](./selfmanaged-azure/_index)
    - [OCI](./selfmanaged-oci/_index)
    - [CoreWeave](./selfmanaged-coreweave/_index)
+   - [Crusoe](./selfmanaged-crusoe/_index)
+   - [Nebius](./selfmanaged-nebius/_index)
 
 ## Configuration
 


### PR DESCRIPTION
## What

Fixes an inconsistency in how the self-managed supported clouds are documented, and links two orphaned deployment guides.

Closes **[DOC-1261](https://linear.app/unionai/issue/DOC-1261)**.

## The problem

Three sources disagreed on which clouds self-managed supports:

| Source | Listed | Gap |
|---|---|---|
| On disk (`selfmanaged/selfmanaged-*/`) | AWS, GCP, Azure, OCI, Generic, **CoreWeave, Crusoe, Nebius** | ground truth |
| `deployment/_index.md` prose | AWS, GCP, Azure, OCI | omits Generic + all 3 neoclouds |
| `selfmanaged/_index.md` nav | Generic, AWS, GCP, Azure, OCI, CoreWeave | **omits Crusoe + Nebius** |

**Crusoe and Nebius have complete guides (`_index` + `prepare-infra` + `deploy-dataplane`) but were not linked from the self-managed index — orphaned in nav.**

## Changes

- `selfmanaged/_index.md` — add **Crusoe** and **Nebius** to the provider list (fixes the orphaned guides).
- `deployment/_index.md` — extend the self-managed cloud sentence to include the neoclouds + generic Kubernetes, and link to the self-managed index as the canonical list. Also corrected "Oracle Compute Infrastructure" → "Oracle Cloud Infrastructure".

BYOC's list (AWS/GCP/Azure) and the cloud-specific setup pages are unchanged.

Surfaced during the DOC-358 cleanup (genericizing stale "AWS or GCP" data-plane references).

🤖 Generated with [Claude Code](https://claude.com/claude-code)