### PR TITLE
docsy(v2): fix Terraform API-key bootstrap command

### DIFF
--- a/content/deployment/terraform/management.md
+++ b/content/deployment/terraform/management.md
@@ -59,10 +59,10 @@ export UNIONAI_API_KEY="your-api-key"
 
 ### Generating an API key
 
-Create an API key using the Union CLI:
+Create an API key using the `flyte` CLI:
 
 ```bash
-union create api-key admin --name "terraform-api-key"
+flyte create api-key --name "terraform-api-key"
 ```
 
 For more information on creating API keys, see the [Flyte CLI documentation](../../api-reference/flyte-cli#flyte-create-api-key).
@@ -421,7 +421,7 @@ resource "unionai_api_key" "ci_cd" {
 ## Requirements
 
 - **Terraform**: >= 1.0
-- **Union API key**: Generated via the Union CLI
+- **Union API key**: Generated via the `flyte` CLI
 - **Go**: >= 1.24 (for development only)
 
 ## Support and contributions


### PR DESCRIPTION
## What

Corrects the API-key bootstrap command on the Terraform provider page (`content/deployment/terraform/management.md`), a follow-up to #1213.

**Before:** `union create api-key admin --name "terraform-api-key"`
**After:** `flyte create api-key --name "terraform-api-key"`

## Why (verified against the shipped CLI)

The command was wrong on two counts:
1. **No `union` binary exists** in v2 — `flyte-sdk`'s `project.scripts` defines only `flyte` (plus internal `a0`/`fserve`/etc.); there is no `union` console script. `flyteplugins-union` v0.2.2 registers its commands as **`flyte` subcommands** via `[flyte.plugins.cli.commands]` (`create.api-key = flyteplugins.union.cli.api_key:create_api_key`).
2. **No `admin` positional exists.** `create_api_key` is `@click.command("api-key")` with a single required `--name` option and no arguments; its own docstring shows `flyte create api-key --name ci-pipeline`.

The stale `union create api-key admin …` form came from the provider repo's `docs/index.md`; the shipped CLI (and the docs-site CLI reference at `#flyte-create-api-key`, which this line links to) both use `flyte create api-key --name`.

Also updated two prose "Union CLI" mentions → "`flyte` CLI" for consistency with the command shown.

Closes the eng-confirm caveat noted on DOC-1133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)