### PR TITLE
docsy(v2): make shortcodes.md _static sample link relative (DOC-966)

### DIFF
--- a/content/community/contributing-docs/shortcodes.md
+++ b/content/community/contributing-docs/shortcodes.md
@@ -240,7 +240,7 @@ Parameters:
 The examples in this section uses this file as base:
 
 {{< code file="/_static/__docs_builder__/sample.py" show_fragments=true lang=python >}}
-Link to [/_static/__docs_builder__/sample.py](/_static/__docs_builder__/sample.py)
+Link to [/_static/__docs_builder__/sample.py](../../_static/__docs_builder__/sample.py)
 
 #### Including a section of a file: `{{docs-fragment}}`
 


### PR DESCRIPTION
## What

Fixes the one remaining root-absolute `/_static/` reference in docs content — a now-broken link at `content/community/contributing-docs/shortcodes.md:243`.

```diff
-Link to [/_static/__docs_builder__/sample.py](/_static/__docs_builder__/sample.py)
+Link to [/_static/__docs_builder__/sample.py](../../_static/__docs_builder__/sample.py)
```

## Why

The Terraform-managed CloudFront `/_static/*` back-compat cache behavior was retired ([unionai/cloud#16921](https://github.com/unionai/cloud/pull/16921), [DOC-966](https://linear.app/unionai/issue/DOC-966)). Bare-root `/_static/…` URLs now **404**:

| URL | Before | Now |
|---|---|---|
| `/_static/__docs_builder__/sample.py` | 200 | **404** |
| `/docs/v2/union/_static/__docs_builder__/sample.py` | 200 | 200 |

`render-link.html`/`rel-link.html` emits a root-absolute `/_static/…` path **as-is**, so this link rendered `href="/_static/…"` → broken. A **relative** path is rewritten against `page.RelPermalink` → version-scoped.

The visible link text is left as the canonical build path (matching the `{{< code file="/_static/…" >}}` convention on the line above, which is a build-time `readFile` path — correctly root-absolute and unaffected); only the **href** is made relative.

## Verification

Full `union` variant build (`make variant VARIANT=union`, clean). Rendered href:

```
/docs/v2/union/community/contributing-docs/shortcodes/../../../_static/__docs_builder__/sample.py
```

→ normalizes to `/docs/v2/union/_static/__docs_builder__/sample.py` (live **200**). No bare-root `/_static` hrefs remain in the built page. This was the last such content reference — completing DOC-966's goal ("remove all references to the root `/_static`").

🤖 Generated with [Claude Code](https://claude.com/claude-code)