### PR TITLE
docsy(v2): bump infra for link-checker .py skip + drop band-aid

### DIFF
--- a/.link-checker-exclude
+++ b/.link-checker-exclude
@@ -6,12 +6,6 @@
 contributing-docs/shortcodes\.md:DEVELOPER\.md
 contributing-docs/authoring\.md:SHORTCODES\.md
 
-# Illustrative link to the docs-builder sample .py (a /_static asset, not a Hugo
-# page). The checker's static-asset skip list (non_page_exts) omits `.py`, so a
-# relative link to a .py static file is mis-validated as a page reference. The
-# link is version-scoped + serves 200 (DOC-966). Systemic fix: add `.py` to
-# non_page_exts in check_internal_links.py (infra follow-up).
-contributing-docs/shortcodes\.md:\.\./\.\./_static/__docs_builder__/sample\.py
 
 # API reference auto-generated cross-references (case mismatch in generated content)
 # api-reference/flyte-sdk/


### PR DESCRIPTION
## What

- Bumps the `unionai-docs-infra` submodule `79221312` → `4736b09b` ([infra#155](https://github.com/unionai/unionai-docs-infra/pull/155): add `.py` to the link checker's `non_page_exts`).
- Removes the now-redundant `.link-checker-exclude` `sample.py` band-aid (added in #1230).

## Why

Deploys the systemic fix for the DOC-966 check-links regression: with `.py` skipped like other static-asset extensions, the relative `shortcodes.md:243` link to `sample.py` validates correctly on its own, so the exclude band-aid is no longer needed.

## Verification

The bumped `check_internal_links.py` passes **both variants with the band-aid removed** (run locally against this branch's content). CI's "Check Internal Links" here exercises the same, using the bumped submodule.

Signed off (DCO). Merge deploys the fix to `main`'s CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)