### PR TITLE
docsy(v2): link vLLM/SGLang app pages to their API reference

### DIFF
--- a/content/user-guide/native-app-integrations/sglang-app.md
+++ b/content/user-guide/native-app-integrations/sglang-app.md
@@ -181,3 +181,7 @@ SGLang is particularly well-suited for structured generation tasks. The deployed
 - Enable `stream_model=True` for faster loading
 - Prefetch models before deployment
 - Use faster storage backends
+
+## API reference
+
+See the [SGLang API reference](../../api-reference/integrations/sglang/_index) for full details.

--- a/content/user-guide/native-app-integrations/vllm-app.md
+++ b/content/user-guide/native-app-integrations/vllm-app.md
@@ -177,3 +177,7 @@ vllm_app = VLLMAppEnvironment(
 - Enable `stream_model=True` for faster loading
 - Prefetch models before deployment
 - Use faster storage backends
+
+## API reference
+
+See the [vLLM API reference](../../api-reference/integrations/vllm/_index) for full details.


### PR DESCRIPTION
## What

Adds a short **API reference** cross-link to the two model-serving native-app pages, which previously had no link to their auto-generated API reference:

- `content/user-guide/native-app-integrations/vllm-app.md` → [vLLM API reference](../../api-reference/integrations/vllm/_index)
- `content/user-guide/native-app-integrations/sglang-app.md` → [SGLang API reference](../../api-reference/integrations/sglang/_index)

## Why

Surfaced during DOC-1166 / DOC-1013 assessment: the vLLM and SGLang app pages document `VLLMAppEnvironment` / `SGLangAppEnvironment` but never point readers to the generated API reference for the plugins.

## Convention

Mirrors exactly the existing pattern on the integration index pages (`content/integrations/{dask,ray,pytorch,openai,...}/_index.md`), each of which ends with:

```markdown
## API reference

See the [<Name> API reference](../../api-reference/integrations/<name>/_index) for full details.
```

## Verification

- `make check-links` — flyte + union both report "all links OK"; the new links resolve.
- `make dist` — full build clean for both variants; rendered links resolve to `/api-reference/integrations/vllm/` and `/api-reference/integrations/sglang/`.
- Both API-reference targets exist (`content/api-reference/integrations/{vllm,sglang}/_index.md`, `+flyte +union`), matching the source pages' variants.

Minimal, additive: two prose lines, nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)