### PR TITLE
docsy: DCO-sign-off the automated API-regen commits (regen-api-docs.yml)

### DIFF
--- a/.github/workflows/regen-api-docs.yml
+++ b/.github/workflows/regen-api-docs.yml
@@ -136,6 +136,13 @@ jobs:
             content/api-reference/**
             linkmap/*-linkmap.json
           commit-message: "docs(api-reference): regenerate API docs (automated)"
+          # DCO: "Check DCO" is a required status check on main (DOC-1244), so the
+          # automated regen commit must carry a Signed-off-by trailer or the PR
+          # can never merge. Pin the bot as author+committer and let the action
+          # append the sign-off from that identity (peter-evans signoff option).
+          author: "unionai-docsy-bot[bot] <295918299+unionai-docsy-bot[bot]@users.noreply.github.com>"
+          committer: "unionai-docsy-bot[bot] <295918299+unionai-docsy-bot[bot]@users.noreply.github.com>"
+          signoff: true
           title: "docs(api-reference): regenerate API docs (automated)"
           body-path: /tmp/pr-body.md
           labels: api-docs-regen


### PR DESCRIPTION
## What

The automated API-reference regen workflow (`.github/workflows/regen-api-docs.yml`, the CI complement to `/docsy --refresh-api` — DOC-1044) opens draft PRs (e.g. #1245) via `peter-evans/create-pull-request`. Its commit carried **no `Signed-off-by` trailer**, so the now-**mandatory** `Check DCO` required status check (DOC-1244) fails and those regen PRs can never merge.

## Fix

On the `create-pull-request` step:
- Pin the docsy bot as `author` + `committer` (attributable, deterministic).
- Enable `signoff: true` so the action appends a DCO `Signed-off-by:` trailer from that identity to every automated regen commit.

`check-dco.yml` only requires that a well-formed `Signed-off-by: <name> <email>` trailer exists on each commit, so this is sufficient to pass.

## Effect

- **Future** regen PRs are born DCO-compliant and mergeable.
- **PR #1245** (already open) still has its pre-fix unsigned commit — once this merges, re-triggering the regen (`repository_dispatch`) updates #1245's branch with a signed commit; or its commit can be `git rebase --signoff`'d directly.

Owned-surface docs-CI hygiene (no Linear ticket; relates to DOC-1244 DCO mandate + DOC-1044 regen automation). Draft — human merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)