### PR TITLE
Self Managed setup doc updates

### DIFF
--- a/content/deployment/selfmanaged/configuration/authentication.md
+++ b/content/deployment/selfmanaged/configuration/authentication.md
@@ -307,7 +307,7 @@ config:
 
 ### In-pod control plane authentication (EAGER_API_KEY)
 
-Flyte task pods may need to call back into the Union.ai control plane during execution -- to launch sub-tasks, fetch remote references, run apps that make programmatic API calls, and similar. The `EAGER_API_KEY` secret holds the OAuth2 client credentials used to authenticate those calls. (The "eager" prefix is a Flyte 1.x holdover -- the key is needed for every task pod that may reach the control plane, not just eager workflows. There is no separate eager-mode toggle in Flyte 2.x.)
+Flyte task pods may need to call back into the Union.ai control plane during execution: to launch sub-tasks, fetch remote references, run apps that make programmatic API calls, and similar. The `EAGER_API_KEY` secret holds the OAuth2 client credentials used to authenticate those calls. (The "eager" prefix is a Flyte 1.x holdover; the key is needed for every task pod that may reach the control plane, not just eager workflows. There is no separate eager-mode toggle in Flyte 2.x.)
 
 The executor injects the secret into task pods via:
 
@@ -321,7 +321,7 @@ executor:
 
 #### Provisioning
 
-The {{< key product_name >}} operator provisions this key for you -- no manual step and no support request are needed. On each reconciliation tick the operator checks whether the key already exists; if it does not, the operator mints one on the control plane and writes it into the cluster through the local operator proxy. Once the key is in place the check is a no-op, so the loop is safe to run continuously and re-provisions the key automatically if it is ever removed.
+The {{< key product_name >}} operator provisions this key for you: no manual step and no support request are needed. On each reconciliation tick the operator checks whether the key already exists; if it does not, the operator mints one on the control plane and writes it into the cluster through the local operator proxy. Once the key is in place the check is a no-op, so the loop is safe to run continuously and re-provisions the key automatically if it is ever removed.
 
 Self-provisioning is active when secret management is enabled, which is the chart default:
 

--- a/content/deployment/selfmanaged/configuration/authentication.md
+++ b/content/deployment/selfmanaged/configuration/authentication.md
@@ -319,8 +319,19 @@ executor:
       secretName: EAGER_API_KEY
 ```
 
-> [!NOTE] Provisioning the EAGER_API_KEY
-> The `EAGER_API_KEY` secret must be provisioned for the organization before any task pod can call the control plane. The key value is issued by Union.ai; contact your Union.ai Support representative to have it provisioned for your tenant. Once you have the value, deliver it to the `EAGER_API_KEY` Kubernetes secret in the executor's namespace via External Secrets Operator (or another out-of-band secret delivery mechanism). The provisioning workflow is being moved to a self-serve flow on the Union.ai console; until then, the contact-Support path is the canonical one.
+#### Provisioning
+
+The {{< key product_name >}} operator provisions this key for you -- no manual step and no support request are needed. On each reconciliation tick the operator checks whether the key already exists; if it does not, the operator mints one on the control plane and writes it into the cluster through the local operator proxy. Once the key is in place the check is a no-op, so the loop is safe to run continuously and re-provisions the key automatically if it is ever removed.
+
+Self-provisioning is active when secret management is enabled, which is the chart default:
+
+```yaml
+proxy:
+  secretManager:
+    enabled: true
+```
+
+If you disable secret management, the operator cannot store the key and you must deliver the `EAGER_API_KEY` secret yourself, following the same [External Secrets Operator](#option-a-external-secrets-operator-recommended) pattern used for the client secrets below.
 
 ### Data plane secrets
 

--- a/content/deployment/selfmanaged/selfmanaged-aws/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-aws/deploy-dataplane.md
@@ -9,7 +9,7 @@ variants: -flyte +union
 If you have not yet set up the required AWS resources (EKS cluster, S3, ECR, IAM), see [Prepare infrastructure](../selfmanaged-aws/prepare-infra) first.
 
 > [!NOTE] Planning more than one cluster?
-> This page covers the single-cluster path: one cluster in the `default` cluster pool, as created by the `flyte create cluster ... --pool default` command below. If you plan to connect several clusters to the same control plane, read [Multiple clusters](../configuration/multi-cluster) first. Pool membership governs metadata sharing -- clusters in the same pool share one metadata bucket, and clusters in different pools must use different ones -- so it affects the metadata bucket you configure below.
+> This page covers the single-cluster path: one cluster in the `default` cluster pool, as created by the `flyte create cluster ... --pool default` command below. If you plan to connect several clusters to the same control plane, read [Multiple clusters](../configuration/multi-cluster) first. Pool membership governs metadata sharing: clusters in the same pool share one metadata bucket, and clusters in different pools must use different ones, so it affects the metadata bucket you configure below.
 
 ## Assumptions
 
@@ -44,7 +44,7 @@ If you have not yet set up the required AWS resources (EKS cluster, S3, ECR, IAM
 
    `flyte create config` writes `.flyte/config.yaml`. The first command that contacts the control plane opens a browser to authenticate you.
 
-   Register the cluster before you install the chart -- the data plane binds to this record when it starts. Every organization is provisioned with a `default` pool, so `--pool default` needs no extra setup.
+   Register the cluster before you install the chart: the data plane binds to this record when it starts. Every organization is provisioned with a `default` pool, so `--pool default` needs no extra setup.
 
 3. Use the `uctl selfserve provision-dataplane-resources` command to generate a new client and client secret for communicating with your Union control plane, provision authorization permissions for the app to operate on the union cluster name you have selected, and provide follow-up instructions:
 

--- a/content/deployment/selfmanaged/selfmanaged-aws/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-aws/deploy-dataplane.md
@@ -35,7 +35,7 @@ If you have not yet set up the required AWS resources (EKS cluster, S3, ECR, IAM
 2. Configure the `flyte` CLI to talk to your control plane, then register the cluster name:
 
    ```bash
-   flyte create config --endpoint dns:///<YOUR_UNION_CONTROL_PLANE_URL> --org <YOUR_ORG_NAME>
+   flyte create config --endpoint <YOUR_UNION_CONTROL_PLANE_URL> --org <YOUR_ORG_NAME>
    flyte create cluster <YOUR_SELECTED_CLUSTERNAME> --pool default
    ```
 

--- a/content/deployment/selfmanaged/selfmanaged-aws/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-aws/deploy-dataplane.md
@@ -83,7 +83,7 @@ If you have not yet set up the required AWS resources (EKS cluster, S3, ECR, IAM
      --set-string secrets.admin.clientId=<CLIENT_ID> \
      --set secrets.admin.clientSecret=<CLIENT_SECRET> \
      --namespace union \
-     --create-namespace \
+     --create-namespace 
    ```
 
 6. Once deployed you can check to see if the cluster has been successfully registered to the control plane:

--- a/content/deployment/selfmanaged/selfmanaged-aws/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-aws/deploy-dataplane.md
@@ -20,6 +20,8 @@ If you have not yet set up the required AWS resources (EKS cluster, S3, ECR, IAM
 
 * Install [Helm 3](https://helm.sh/docs/intro/install/).
 * Install [uctl](../../../api-reference/uctl-cli/_index).
+* Install the [`flyte` CLI](../../../api-reference/flyte-cli).
+* Install the [`flyteplugins-union` plugin](../../../api-reference/flyte-cli#plugin-commands), which provides the `flyte get cluster` command: `pip install flyteplugins-union`.
 
 ## Deploy the {{< key product_name >}} operator
 
@@ -30,7 +32,18 @@ If you have not yet set up the required AWS resources (EKS cluster, S3, ECR, IAM
    helm repo update
    ```
 
-2. Use the `uctl selfserve provision-dataplane-resources` command to generate a new client and client secret for communicating with your Union control plane, provision authorization permissions for the app to operate on the union cluster name you have selected, generate values file to install dataplane in your Kubernetes cluster and provide follow-up instructions:
+2. Configure the `flyte` CLI to talk to your control plane, then register the cluster name:
+
+   ```bash
+   flyte create config --endpoint dns:///<YOUR_UNION_CONTROL_PLANE_URL> --org <YOUR_ORG_NAME>
+   flyte create cluster <YOUR_SELECTED_CLUSTERNAME> --pool default
+   ```
+
+   `flyte create config` writes `.flyte/config.yaml`. The first command that contacts the control plane opens a browser to authenticate you.
+
+   Register the cluster before you install the chart -- the data plane binds to this record when it starts. Every organization is provisioned with a `default` pool, so `--pool default` needs no extra setup.
+
+3. Use the `uctl selfserve provision-dataplane-resources` command to generate a new client and client secret for communicating with your Union control plane, provision authorization permissions for the app to operate on the union cluster name you have selected, and provide follow-up instructions:
 
    ```bash
    uctl config init --host=<YOUR_UNION_CONTROL_PLANE_URL>
@@ -38,51 +51,53 @@ If you have not yet set up the required AWS resources (EKS cluster, S3, ECR, IAM
    ```
 
    * The command will output the ID, name, and a secret that will be used by the Union services to communicate with your control plane.
-     It will also generate a YAML file `<org>-values.yaml` specific to the provider that you specify, in this case `aws`.
+     You will pass the client ID and client secret to the Helm chart in step 5.
 
-   * Save the secret that is displayed. Union does not store the credentials; rerunning the same command can be used to retrieve the secret later.
+   * Save the secret that is displayed. Union does not store it, and it cannot be retrieved later.
 
-3. Update the generated values file with your infrastructure details:
+4. Download the AWS values file for the data plane chart and fill in your infrastructure details:
 
-   Using the [environment variables](../selfmanaged-aws/prepare-infra#environment-variables) from the prepare infrastructure step:
+   ```bash
+   curl -O https://raw.githubusercontent.com/unionai/helm-charts/main/charts/dataplane/values.aws.yaml
+   ```
 
+   Using the [environment variables](../selfmanaged-aws/prepare-infra#environment-variables) from the prepare infrastructure step, set the following keys under `global`. The rest of the file (storage, service account annotations, IRSA) is templated from these values, so you do not need to edit it:
+
+   - Set `global.UNION_CONTROL_PLANE_HOST` and `global.CONTROLPLANE_HOST` to your control plane hostname (no scheme, no port).
+   - Set `global.CLUSTER_NAME` to the cluster name you registered in step 2.
+   - Set `global.ORG_NAME` to your organization name.
    - Set `global.AWS_ACCOUNT_ID` to your AWS account ID. You can retrieve it with `aws sts get-caller-identity --query Account --output text`.
+   - Set `global.AWS_REGION` to `${AWS_REGION}`.
    - Set `global.METADATA_BUCKET` to `${BUCKET_PREFIX}-metadata`.
    - Set `global.FAST_REGISTRATION_BUCKET` to `${BUCKET_PREFIX}-fast-reg`.
    - Set `global.BACKEND_IAM_ROLE_ARN` to `arn:aws:iam::${AWS_ACCOUNT_ID}:role/${IAM_ROLE_NAME}` (where `AWS_ACCOUNT_ID` is your 12-digit account ID).
    - Set `global.WORKER_IAM_ROLE_ARN` to the same value (or a separate role if you use distinct worker permissions).
-   - Set `storage.bucketName` to `${BUCKET_PREFIX}-metadata`.
-   - Set `storage.fastRegistrationBucketName` to `${BUCKET_PREFIX}-fast-reg`.
-   - Set `storage.region` to `${AWS_REGION}`.
-   - Set `commonServiceAccount.annotations."eks.amazonaws.com/role-arn"` to `arn:aws:iam::${AWS_ACCOUNT_ID}:role/${IAM_ROLE_NAME}`.
-   - Set `imageBuilder.registryName` to `${ECR_REPO_NAME}` (defaults to `union-dataplane`; the chart auto-generates the full ECR URL from the account ID and region).
+   - Optionally set `imageBuilder.registryName` to `${ECR_REPO_NAME}` (defaults to `union-dataplane`; the chart auto-generates the full ECR URL from the account ID and region).
 
-4. Install the data plane Helm chart:
+5. Install the data plane Helm chart, passing the client ID and client secret from step 3:
 
    ```bash
    helm upgrade --install union unionai/dataplane \
-     -f <GENERATED_VALUES_FILE> \
+     -f values.aws.yaml \
+     --set global.AUTH_CLIENT_ID=<CLIENT_ID> \
+     --set-string secrets.admin.clientId=<CLIENT_ID> \
+     --set secrets.admin.clientSecret=<CLIENT_SECRET> \
      --namespace union \
      --create-namespace \
-     --force-conflicts
-   ```
-
-5. **Required for helm charts on a version <= 2026.5.8.** Create an API key for your organization. This is required for v2 workflow executions on the data plane. If you have already created one, rerun the same command to propagate the key to the new cluster:
-
-   ```bash
-   uctl create apikey --keyName EAGER_API_KEY --org <YOUR_ORG_NAME>
    ```
 
 6. Once deployed you can check to see if the cluster has been successfully registered to the control plane:
 
    ```bash
-   uctl get cluster
-    ----------- ------- --------------- -----------
-   | NAME      | ORG   | STATE         | HEALTH    |
-    ----------- ------- --------------- -----------
-   | <cluster> | <org> | STATE_ENABLED | HEALTHY   |
-    ----------- ------- --------------- -----------
-   1 rows
+   flyte get cluster
+   ```
+
+   The command groups clusters by state. A successfully registered cluster appears under **Enabled Clusters**:
+
+   ```text
+   Enabled Clusters
+   NAME        ORG     STATE     HEALTH
+   <cluster>   <org>   enabled   healthy
    ```
 
 7. Follow the [Quickstart](../../../user-guide/quickstart) to run your first workflow and verify your cluster is working correctly.

--- a/content/deployment/selfmanaged/selfmanaged-aws/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-aws/deploy-dataplane.md
@@ -8,6 +8,9 @@ variants: -flyte +union
 
 If you have not yet set up the required AWS resources (EKS cluster, S3, ECR, IAM), see [Prepare infrastructure](../selfmanaged-aws/prepare-infra) first.
 
+> [!NOTE] Planning more than one cluster?
+> This page covers the single-cluster path: one cluster in the `default` cluster pool, as created by the `flyte create cluster ... --pool default` command below. If you plan to connect several clusters to the same control plane, read [Multiple clusters](../configuration/multi-cluster) first. Pool membership governs metadata sharing -- clusters in the same pool share one metadata bucket, and clusters in different pools must use different ones -- so it affects the metadata bucket you configure below.
+
 ## Assumptions
 
 * You have a {{< key product_name >}} organization, and you know the control plane URL for your organization.

--- a/content/deployment/selfmanaged/selfmanaged-azure/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-azure/deploy-dataplane.md
@@ -8,6 +8,9 @@ variants: -flyte +union
 
 If you have not yet set up the required Azure resources (AKS cluster, Storage Account, Managed Identities, Workload Identity), see [Prepare infrastructure](../selfmanaged-azure/prepare-infra) first.
 
+> [!NOTE] Planning more than one cluster?
+> This page covers the single-cluster path: one cluster in the `default` cluster pool, as created by the `flyte create cluster ... --pool default` command below. If you plan to connect several clusters to the same control plane, read [Multiple clusters](../configuration/multi-cluster) first. Pool membership governs metadata sharing -- clusters in the same pool share one metadata bucket, and clusters in different pools must use different ones -- so it affects the metadata bucket you configure below.
+
 ## Assumptions
 
 * You have a {{< key product_name >}} organization, and you know the control plane URL for your organization.

--- a/content/deployment/selfmanaged/selfmanaged-azure/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-azure/deploy-dataplane.md
@@ -35,7 +35,7 @@ If you have not yet set up the required Azure resources (AKS cluster, Storage Ac
 2. Configure the `flyte` CLI to talk to your control plane, then register the cluster name:
 
    ```bash
-   flyte create config --endpoint dns:///<YOUR_UNION_CONTROL_PLANE_URL> --org <YOUR_ORG_NAME>
+   flyte create config --endpoint <YOUR_UNION_CONTROL_PLANE_URL> --org <YOUR_ORG_NAME>
    flyte create cluster <YOUR_SELECTED_CLUSTERNAME> --pool default
    ```
 

--- a/content/deployment/selfmanaged/selfmanaged-azure/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-azure/deploy-dataplane.md
@@ -9,7 +9,7 @@ variants: -flyte +union
 If you have not yet set up the required Azure resources (AKS cluster, Storage Account, Managed Identities, Workload Identity), see [Prepare infrastructure](../selfmanaged-azure/prepare-infra) first.
 
 > [!NOTE] Planning more than one cluster?
-> This page covers the single-cluster path: one cluster in the `default` cluster pool, as created by the `flyte create cluster ... --pool default` command below. If you plan to connect several clusters to the same control plane, read [Multiple clusters](../configuration/multi-cluster) first. Pool membership governs metadata sharing -- clusters in the same pool share one metadata bucket, and clusters in different pools must use different ones -- so it affects the metadata bucket you configure below.
+> This page covers the single-cluster path: one cluster in the `default` cluster pool, as created by the `flyte create cluster ... --pool default` command below. If you plan to connect several clusters to the same control plane, read [Multiple clusters](../configuration/multi-cluster) first. Pool membership governs metadata sharing: clusters in the same pool share one metadata bucket, and clusters in different pools must use different ones, so it affects the metadata bucket you configure below.
 
 ## Assumptions
 
@@ -44,7 +44,7 @@ If you have not yet set up the required Azure resources (AKS cluster, Storage Ac
 
    `flyte create config` writes `.flyte/config.yaml`. The first command that contacts the control plane opens a browser to authenticate you.
 
-   Register the cluster before you install the chart -- the data plane binds to this record when it starts. Every organization is provisioned with a `default` pool, so `--pool default` needs no extra setup.
+   Register the cluster before you install the chart: the data plane binds to this record when it starts. Every organization is provisioned with a `default` pool, so `--pool default` needs no extra setup.
 
 3. Use the `uctl selfserve provision-dataplane-resources` command to generate a new client and client secret for communicating with your Union control plane, provision authorization permissions for the app to operate on the Union cluster name you have selected, and provide follow-up instructions:
 

--- a/content/deployment/selfmanaged/selfmanaged-azure/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-azure/deploy-dataplane.md
@@ -20,6 +20,8 @@ If you have not yet set up the required Azure resources (AKS cluster, Storage Ac
 
 * Install [Helm 3](https://helm.sh/docs/intro/install/).
 * Install [uctl](../../../api-reference/uctl-cli/_index).
+* Install the [`flyte` CLI](../../../api-reference/flyte-cli).
+* Install the [`flyteplugins-union` plugin](../../../api-reference/flyte-cli#plugin-commands), which provides the `flyte get cluster` command: `pip install flyteplugins-union`.
 
 ## Deploy the {{< key product_name >}} operator
 
@@ -30,7 +32,18 @@ If you have not yet set up the required Azure resources (AKS cluster, Storage Ac
    helm repo update
    ```
 
-2. Use the `uctl selfserve provision-dataplane-resources` command to generate a new client and client secret for communicating with your Union control plane, provision authorization permissions for the app to operate on the Union cluster name you have selected, generate values file to install dataplane in your Kubernetes cluster and provide follow-up instructions:
+2. Configure the `flyte` CLI to talk to your control plane, then register the cluster name:
+
+   ```bash
+   flyte create config --endpoint dns:///<YOUR_UNION_CONTROL_PLANE_URL> --org <YOUR_ORG_NAME>
+   flyte create cluster <YOUR_SELECTED_CLUSTERNAME> --pool default
+   ```
+
+   `flyte create config` writes `.flyte/config.yaml`. The first command that contacts the control plane opens a browser to authenticate you.
+
+   Register the cluster before you install the chart -- the data plane binds to this record when it starts. Every organization is provisioned with a `default` pool, so `--pool default` needs no extra setup.
+
+3. Use the `uctl selfserve provision-dataplane-resources` command to generate a new client and client secret for communicating with your Union control plane, provision authorization permissions for the app to operate on the Union cluster name you have selected, and provide follow-up instructions:
 
    ```bash
    uctl config init --host=<YOUR_UNION_CONTROL_PLANE_URL>
@@ -38,20 +51,26 @@ If you have not yet set up the required Azure resources (AKS cluster, Storage Ac
    ```
 
    * The command will output the ID, name, and a secret that will be used by the Union services to communicate with your control plane.
-     It will also generate a YAML file `<org>-values.yaml` specific to the provider that you specify, in this case `azure`.
+     You will pass the client ID and client secret to the Helm chart in step 5.
 
-   * Save the secret that is displayed. Union does not store the credentials; rerunning the same command can be used to retrieve the secret later.
+   * Save the secret that is displayed. Union does not store it, and it cannot be retrieved later.
 
-3. Update the generated values file with your infrastructure details:
+4. Download the Azure values file for the data plane chart and fill in your infrastructure details:
 
-   Using the [environment variables](../selfmanaged-azure/prepare-infra#environment-variables) from the prepare infrastructure step:
+   ```bash
+   curl -O https://raw.githubusercontent.com/unionai/helm-charts/main/charts/dataplane/values.azure.yaml
+   ```
 
-   - Set `global.BACKEND_IAM_ROLE_ARN` to `${BACKEND_CLIENT_ID}` (the backend managed identity client ID).
-   - Set `global.WORKER_IAM_ROLE_ARN` to `${WORKER_CLIENT_ID}` (the worker managed identity client ID).
-   - Set `global.METADATA_BUCKET` to `${METADATA_CONTAINER}`.
-   - Set `storage.custom.stow.config.account` to `${STORAGE_ACCOUNT}`.
-   - Set `storage.region` to `${LOCATION}`.
-   - Set `commonServiceAccount.annotations."azure.workload.identity/client-id"` to `${BACKEND_CLIENT_ID}`.
+   Using the [environment variables](../selfmanaged-azure/prepare-infra#environment-variables) from the prepare infrastructure step, set the following keys under `global`. The rest of the file (Blob storage, service account annotations, Workload Identity) is templated from these values, so you do not need to edit it:
+
+   - Set `global.UNION_CONTROL_PLANE_HOST` and `global.CONTROLPLANE_HOST` to your control plane hostname (no scheme, no port).
+   - Set `global.CLUSTER_NAME` to the cluster name you registered in step 2.
+   - Set `global.ORG_NAME` to your organization name.
+   - Set `global.METADATA_CONTAINER` to `${METADATA_CONTAINER}`.
+   - Set `global.AZURE_STORAGE_ACCOUNT` to `${STORAGE_ACCOUNT}`.
+   - Set `global.AZURE_SUBSCRIPTION_ID`, `global.AZURE_TENANT_ID`, and `global.AZURE_RESOURCE_GROUP` to the subscription, tenant, and resource group holding your Union resources.
+   - Set `global.AZURE_BACKEND_CLIENT_ID` to `${BACKEND_CLIENT_ID}` (the backend managed identity client ID).
+   - Set `global.AZURE_WORKER_CLIENT_ID` to `${WORKER_CLIENT_ID}` (the worker managed identity client ID).
    - For persisted task logs, wire FluentBit to the `${FLUENTBIT_SECRET_NAME}` secret you created in
      [Prepare infrastructure](../selfmanaged-azure/prepare-infra#8-persisted-logs-storage-key-fluentbit).
      FluentBit's `azure_blob` output cannot use Workload Identity, so it reads the storage key from
@@ -62,41 +81,39 @@ If you have not yet set up the required Azure resources (AKS cluster, Storage Ac
        azureBlobSharedKey: "${AZURE_STORAGE_SHARED_KEY}"
        env:
          - name: AZURE_STORAGE_SHARED_KEY
-            valueFrom:
-              secretKeyRef:
-                name: ${FLUENTBIT_SECRET_NAME}
-                key: shared_key
+           valueFrom:
+             secretKeyRef:
+               name: ${FLUENTBIT_SECRET_NAME}
+               key: shared_key
      ```
 
    If using Azure Key Vault (optional):
-   - Set `AZURE_KEY_VAULT_URI` to `https://${KEY_VAULT_NAME}.vault.azure.net/`.
+   - Set `global.AZURE_KEY_VAULT_URI` to `https://${KEY_VAULT_NAME}.vault.azure.net/`.
 
-4. Install the data plane Helm chart:
+5. Install the data plane Helm chart, passing the client ID and client secret from step 3:
 
    ```bash
    helm upgrade --install union unionai/dataplane \
-     -f <GENERATED_VALUES_FILE> \
+     -f values.azure.yaml \
+     --set global.AUTH_CLIENT_ID=<CLIENT_ID> \
+     --set-string secrets.admin.clientId=<CLIENT_ID> \
+     --set secrets.admin.clientSecret=<CLIENT_SECRET> \
      --namespace union \
      --create-namespace \
-     --force-conflicts
-   ```
-
-5. **Required for helm charts on a version <= 2026.5.8.** Create an API key for your organization. This is required for v2 workflow executions on the data plane. If you have already created one, rerun the same command to propagate the key to the new cluster:
-
-   ```bash
-   uctl create apikey --keyName EAGER_API_KEY --org <YOUR_ORG_NAME>
    ```
 
 6. Once deployed you can check to see if the cluster has been successfully registered to the control plane:
 
    ```bash
-   uctl get cluster
-    ----------- ------- --------------- -----------
-   | NAME      | ORG   | STATE         | HEALTH    |
-    ----------- ------- --------------- -----------
-   | <cluster> | <org> | STATE_ENABLED | HEALTHY   |
-    ----------- ------- --------------- -----------
-   1 rows
+   flyte get cluster
+   ```
+
+   The command groups clusters by state. A successfully registered cluster appears under **Enabled Clusters**:
+
+   ```text
+   Enabled Clusters
+   NAME        ORG     STATE     HEALTH
+   <cluster>   <org>   enabled   healthy
    ```
 
 7. Follow the [Quickstart](../../../user-guide/quickstart) to run your first workflow and verify your cluster is working correctly.

--- a/content/deployment/selfmanaged/selfmanaged-azure/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-azure/deploy-dataplane.md
@@ -99,7 +99,7 @@ If you have not yet set up the required Azure resources (AKS cluster, Storage Ac
      --set-string secrets.admin.clientId=<CLIENT_ID> \
      --set secrets.admin.clientSecret=<CLIENT_SECRET> \
      --namespace union \
-     --create-namespace \
+     --create-namespace
    ```
 
 6. Once deployed you can check to see if the cluster has been successfully registered to the control plane:

--- a/content/deployment/selfmanaged/selfmanaged-coreweave/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-coreweave/deploy-dataplane.md
@@ -93,7 +93,7 @@ If you have not yet set up the required CoreWeave resources (CKS cluster, AI Obj
            auth_type: accesskey
            endpoint: https://cwobject.com
            disable_ssl: false
-           disable_force_path_style: "true"
+           disable_force_path_style: true
 
    fluentbit:
      enabled: true

--- a/content/deployment/selfmanaged/selfmanaged-coreweave/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-coreweave/deploy-dataplane.md
@@ -9,7 +9,7 @@ variants: -flyte +union
 If you have not yet set up the required CoreWeave resources (CKS cluster, AI Object Storage bucket, access keys, access policy), see [Prepare infrastructure](../selfmanaged-coreweave/prepare-infra) first.
 
 > [!NOTE] Planning more than one cluster?
-> This page covers the single-cluster path: one cluster in the `default` cluster pool, as created by the `flyte create cluster ... --pool default` command below. If you plan to connect several clusters to the same control plane, read [Multiple clusters](../configuration/multi-cluster) first. Pool membership governs metadata sharing -- clusters in the same pool share one metadata bucket, and clusters in different pools must use different ones -- so it affects the metadata bucket you configure below.
+> This page covers the single-cluster path: one cluster in the `default` cluster pool, as created by the `flyte create cluster ... --pool default` command below. If you plan to connect several clusters to the same control plane, read [Multiple clusters](../configuration/multi-cluster) first. Pool membership governs metadata sharing: clusters in the same pool share one metadata bucket, and clusters in different pools must use different ones, so it affects the metadata bucket you configure below.
 
 ## Assumptions
 
@@ -42,7 +42,7 @@ If you have not yet set up the required CoreWeave resources (CKS cluster, AI Obj
 
    `flyte create config` writes `.flyte/config.yaml`. The first command that contacts the control plane opens a browser to authenticate you.
 
-   Register the cluster before you install the chart -- the data plane binds to this record when it starts. Every organization is provisioned with a `default` pool, so `--pool default` needs no extra setup.
+   Register the cluster before you install the chart: the data plane binds to this record when it starts. Every organization is provisioned with a `default` pool, so `--pool default` needs no extra setup.
 
 3. Configure the Union CLI and provision data plane resources:
 
@@ -62,7 +62,7 @@ If you have not yet set up the required CoreWeave resources (CKS cluster, AI Obj
    curl -O https://raw.githubusercontent.com/unionai/helm-charts/main/charts/dataplane/values.yaml
    ```
 
-   Rather than putting your access keys in the values file, store them in a Kubernetes Secret and reference it from the chart. Create the namespace and the secret first -- the chart reads the secret while rendering, so it must exist before you install:
+   Rather than putting your access keys in the values file, store them in a Kubernetes Secret and reference it from the chart. Create the namespace and the secret first; the chart reads the secret while rendering, so it must exist before you install:
 
    ```bash
    kubectl create namespace union
@@ -116,13 +116,13 @@ If you have not yet set up the required CoreWeave resources (CKS cluster, AI Obj
    Two separate mechanisms read that secret:
 
    - `storage.credentialsSecretRef` makes the chart inject `FLYTE_AWS_ACCESS_KEY_ID` and `FLYTE_AWS_SECRET_ACCESS_KEY` into task pods. This path is independent of `storage.provider`, so it works with `custom`, and it is why no per-executor environment variables are needed.
-   - The `storage.custom` block is rendered as a Helm template, so the `lookup` expressions above resolve the same secret into the stow configuration the control plane components use.
+   - The chart renders the `storage.custom` block as a Helm template. When `credentialsSecretRef` is set, the chart looks up that secret and merges its `access_key_id` and `secret_key` into the stow configuration the control plane components use, so you do not add credentials to the `custom` block yourself.
 
    > [!NOTE]
    > The `uctl selfserve provision-dataplane-resources` command in step 3 generates the `<CLIENT_ID>` and `<CLIENT_SECRET>` values. Use the values from that command's output.
 
    > [!NOTE]
-   > The chart resolves the secret with a Helm `lookup`, which returns nothing during `helm template` or `--dry-run`. Those commands render the storage config without credentials; only a real install picks them up. If your secret uses different field names, set `credentialsSecretRef.accessKeyIdKey` and `credentialsSecretRef.secretKeyKey` to match, and adjust the `lookup` expressions accordingly.
+   > The chart resolves the secret with a Helm `lookup`, which returns nothing during `helm template` or `--dry-run`. Those commands render the storage config without credentials; only a real install picks them up. If your secret uses different field names, set `credentialsSecretRef.accessKeyIdKey` and `credentialsSecretRef.secretKeyKey` to match.
    >
    > This page keeps `storage.provider: custom` because CoreWeave AI Object Storage requires virtual-hosted style URLs, and `disable_force_path_style` is only reachable through a `custom` stow block.
 

--- a/content/deployment/selfmanaged/selfmanaged-coreweave/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-coreweave/deploy-dataplane.md
@@ -20,6 +20,7 @@ If you have not yet set up the required CoreWeave resources (CKS cluster, AI Obj
 * Install [Helm 3](https://helm.sh/docs/intro/install/).
 * Install [uctl](../../../api-reference/uctl-cli/_index).
 * Install the [`flyte` CLI](../../../api-reference/flyte-cli) (used later to run a sample workflow).
+* Install the [`flyteplugins-union` plugin](../../../api-reference/flyte-cli#plugin-commands), which provides the `flyte get cluster` command: `pip install flyteplugins-union`.
 
 ## Deploy the {{< key product_name >}} operator
 
@@ -29,7 +30,18 @@ If you have not yet set up the required CoreWeave resources (CKS cluster, AI Obj
    export KUBECONFIG=<PATH_TO_KUBECONFIG>
    ```
 
-2. Configure the Union CLI and provision data plane resources:
+2. Configure the `flyte` CLI to talk to your control plane, then register the cluster name:
+
+   ```bash
+   flyte create config --endpoint dns:///<ORG_NAME>.union.ai --org <ORG_NAME>
+   flyte create cluster <CLUSTER_NAME> --pool default
+   ```
+
+   `flyte create config` writes `.flyte/config.yaml`. The first command that contacts the control plane opens a browser to authenticate you.
+
+   Register the cluster before you install the chart -- the data plane binds to this record when it starts. Every organization is provisioned with a `default` pool, so `--pool default` needs no extra setup.
+
+3. Configure the Union CLI and provision data plane resources:
 
    ```bash
    uctl config init --host=<ORG_NAME>.union.ai
@@ -37,11 +49,26 @@ If you have not yet set up the required CoreWeave resources (CKS cluster, AI Obj
    ```
 
    * The command will output the ID, name, and a secret that will be used by the Union services to communicate with your control plane.
-     It will also generate a YAML values file specific to the `custom` provider.
+     You will pass the client ID and client secret to the Helm chart in step 7.
 
-   * Save the secret that is displayed. Union does not store the credentials; rerunning the same command can be used to retrieve the secret later.
+   * Save the secret that is displayed. Union does not store it, and it cannot be retrieved later.
 
-3. Update the generated values file with your CoreWeave-specific storage configuration. AI Object Storage requires virtual-hosted style S3 URLs, so you must override the default storage configuration. Replace the placeholders with your actual credentials and settings.
+4. Create a values file for the data plane chart. Start from the base values file and layer your CoreWeave-specific storage configuration on top. AI Object Storage requires virtual-hosted style S3 URLs, so you must override the default storage configuration. Replace the placeholders with your actual credentials and settings.
+
+   ```bash
+   curl -O https://raw.githubusercontent.com/unionai/helm-charts/main/charts/dataplane/values.yaml
+   ```
+
+   Rather than putting your access keys in the values file, store them in a Kubernetes Secret and reference it from the chart. Create the namespace and the secret first -- the chart reads the secret while rendering, so it must exist before you install:
+
+   ```bash
+   kubectl create namespace union
+   kubectl create secret generic storage-credentials -n union \
+     --from-literal=access_key_id=<ACCESS_KEY_ID> \
+     --from-literal=secret_key=<SECRET_ACCESS_KEY>
+   ```
+
+   Then write the values file:
 
    ```yaml
    host: <ORG_NAME>.union.ai
@@ -51,8 +78,11 @@ If you have not yet set up the required CoreWeave resources (CKS cluster, AI Obj
 
    storage:
      provider: custom
+     authType: accesskey
      bucketName: <BUCKET_NAME>
      fastRegistrationBucketName: <BUCKET_NAME>
+     credentialsSecretRef:
+       name: storage-credentials
      custom:
        type: stow
        container: <BUCKET_NAME>
@@ -61,56 +91,37 @@ If you have not yet set up the required CoreWeave resources (CKS cluster, AI Obj
          config:
            region: <AVAILABILITY_ZONE>
            auth_type: accesskey
-           access_key_id: <ACCESS_KEY_ID>
-           secret_key: <SECRET_ACCESS_KEY>
            endpoint: https://cwobject.com
            disable_ssl: false
-           disable_force_path_style: true
-
-   executor:
-     extraEnvVars:
-       - name: FLYTE_AWS_S3_ADDRESSING_STYLE
-         value: "virtual"
-       - name: FLYTE_AWS_ENDPOINT
-         value: "https://cwobject.com"
-       - name: AWS_ACCESS_KEY_ID
-         value: <ACCESS_KEY_ID>
-       - name: AWS_SECRET_ACCESS_KEY
-         value: <SECRET_ACCESS_KEY>
-       - name: AWS_DEFAULT_REGION
-         value: <AVAILABILITY_ZONE>
-
-   config:
-     k8s:
-       plugins:
-         k8s:
-           default-env-vars:
-             - FLYTE_AWS_ENDPOINT: https://<BUCKET_NAME>.cwobject.com
-             - FLYTE_AWS_S3_ADDRESSING_STYLE: "virtual"
-             - AWS_ACCESS_KEY_ID: <ACCESS_KEY_ID>
-             - AWS_SECRET_ACCESS_KEY: <SECRET_ACCESS_KEY>
-             - AWS_DEFAULT_REGION: <AVAILABILITY_ZONE>
-
-   operator:
-     enableTunnelService: true
-
-   secrets:
-     admin:
-       create: true
-       clientId: <CLIENT_ID>
-       clientSecret: <CLIENT_SECRET>
+           disable_force_path_style: "true"
 
    fluentbit:
      enabled: true
      env:
        - name: AWS_ACCESS_KEY_ID
-         value: <ACCESS_KEY_ID>
+         valueFrom:
+           secretKeyRef:
+             name: storage-credentials
+             key: access_key_id
        - name: AWS_SECRET_ACCESS_KEY
-         value: <SECRET_ACCESS_KEY>
+         valueFrom:
+           secretKeyRef:
+             name: storage-credentials
+             key: secret_key
    ```
 
+   Two separate mechanisms read that secret:
+
+   - `storage.credentialsSecretRef` makes the chart inject `FLYTE_AWS_ACCESS_KEY_ID` and `FLYTE_AWS_SECRET_ACCESS_KEY` into task pods. This path is independent of `storage.provider`, so it works with `custom`, and it is why no per-executor environment variables are needed.
+   - The `storage.custom` block is rendered as a Helm template, so the `lookup` expressions above resolve the same secret into the stow configuration the control plane components use.
+
    > [!NOTE]
-   > The `uctl selfserve provision-dataplane-resources` command in step 2 generates the `<CLIENT_ID>` and `<CLIENT_SECRET>` values. Use the values from that command's output.
+   > The `uctl selfserve provision-dataplane-resources` command in step 3 generates the `<CLIENT_ID>` and `<CLIENT_SECRET>` values. Use the values from that command's output.
+
+   > [!NOTE]
+   > The chart resolves the secret with a Helm `lookup`, which returns nothing during `helm template` or `--dry-run`. Those commands render the storage config without credentials; only a real install picks them up. If your secret uses different field names, set `credentialsSecretRef.accessKeyIdKey` and `credentialsSecretRef.secretKeyKey` to match, and adjust the `lookup` expressions accordingly.
+   >
+   > This page keeps `storage.provider: custom` because CoreWeave AI Object Storage requires virtual-hosted style URLs, and `disable_force_path_style` is only reachable through a `custom` stow block.
 
    The settings below are required for AI Object Storage compatibility:
 
@@ -118,32 +129,33 @@ If you have not yet set up the required CoreWeave resources (CKS cluster, AI Obj
    | ----------------------------------------------------------------------- | ------------------------------------ | --------------------------------------------------------------- |
    | `storage.custom.stow.config.disable_force_path_style`                   | `true`                               | Enables virtual-hosted style S3 URLs.                           |
    | `storage.custom.stow.config.endpoint`                                   | `https://cwobject.com`               | AI Object Storage endpoint for the control plane.               |
-   | `config.k8s.plugins.k8s.default-env-vars` (entry: `FLYTE_AWS_ENDPOINT`) | `https://<BUCKET_NAME>.cwobject.com` | Bucket-specific endpoint injected into task pods.               |
-   | `executor.extraEnvVars.FLYTE_AWS_S3_ADDRESSING_STYLE`                   | `virtual`                            | Configures the executor to use virtual-hosted style addressing. |
-
-4. Add the {{< key product_name >}} Helm repo:
+  
+5. Add the {{< key product_name >}} Helm repo:
 
    ```bash
    helm repo add unionai https://unionai.github.io/helm-charts/
    helm repo update
    ```
 
-5. Install the Custom Resource Definitions (CRDs):
+6. Install the Custom Resource Definitions (CRDs):
 
    ```bash
    helm upgrade --install unionai-dataplane-crds unionai/dataplane-crds
    ```
 
-6. Install the data plane. Replace `<PATH_TO_VALUES_FILE>` with the path to the Helm values file you customized in step 3.
+7. Install the data plane. Replace `<PATH_TO_VALUES_FILE>` with the path to the Helm values file you customized in step 4, and `<CLIENT_ID>` / `<CLIENT_SECRET>` with the credentials printed in step 3.
 
    ```bash
    helm upgrade --install unionai-dataplane unionai/dataplane \
      --namespace union --create-namespace \
      --values <PATH_TO_VALUES_FILE> \
+     --set-string global.AUTH_CLIENT_ID=<CLIENT_ID> \
+     --set secrets.admin.clientId=<CLIENT_ID> \
+     --set secrets.admin.clientSecret=<CLIENT_SECRET> \
      --timeout 10m
    ```
 
-7. Verify the pods are running:
+8. Verify the pods are running:
 
    ```bash
    kubectl get pods -n union
@@ -151,27 +163,19 @@ If you have not yet set up the required CoreWeave resources (CKS cluster, AI Obj
 
    When the deployment succeeds, all pods show a `Running` status, including `union-operator-proxy`, `union-operator-buildkit`, `flytepropeller`, and `executor`.
 
-8. Verify the cluster is registered with the control plane:
+9. Verify the cluster is registered with the control plane:
 
    ```bash
-   uctl get cluster
+   flyte get cluster
    ```
 
    The output is similar to the following:
 
    ```text
-   NAME               ORG          STATE          HEALTH
-   union-coreweave    my-org       STATE_ENABLED  HEALTHY
+   Enabled Clusters
+   NAME            ORG       STATE     HEALTH
+   union-coreweave my-org    enabled   healthy
    ```
-
-9. **Required for helm charts on a version <= 2026.5.8.** Create an API key for your organization. This is required for v2 workflow executions on the data plane. If you have already created one, rerun the same command to propagate the key to the new cluster:
-
-   ```bash
-   uctl create apikey --keyName EAGER_API_KEY --org <ORG_NAME>
-   ```
-
-   > [!NOTE]
-   > If you receive a `PermissionDenied` error, contact [Union.ai support](https://www.union.ai/) to have the permission enabled for your organization.
 
 ## Test a workflow
 

--- a/content/deployment/selfmanaged/selfmanaged-coreweave/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-coreweave/deploy-dataplane.md
@@ -8,6 +8,9 @@ variants: -flyte +union
 
 If you have not yet set up the required CoreWeave resources (CKS cluster, AI Object Storage bucket, access keys, access policy), see [Prepare infrastructure](../selfmanaged-coreweave/prepare-infra) first.
 
+> [!NOTE] Planning more than one cluster?
+> This page covers the single-cluster path: one cluster in the `default` cluster pool, as created by the `flyte create cluster ... --pool default` command below. If you plan to connect several clusters to the same control plane, read [Multiple clusters](../configuration/multi-cluster) first. Pool membership governs metadata sharing -- clusters in the same pool share one metadata bucket, and clusters in different pools must use different ones -- so it affects the metadata bucket you configure below.
+
 ## Assumptions
 
 * You have a {{< key product_name >}} organization, and you know the control plane URL for your organization.

--- a/content/deployment/selfmanaged/selfmanaged-coreweave/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-coreweave/deploy-dataplane.md
@@ -33,7 +33,7 @@ If you have not yet set up the required CoreWeave resources (CKS cluster, AI Obj
 2. Configure the `flyte` CLI to talk to your control plane, then register the cluster name:
 
    ```bash
-   flyte create config --endpoint dns:///<ORG_NAME>.union.ai --org <ORG_NAME>
+   flyte create config --endpoint <ORG_NAME>.union.ai --org <ORG_NAME>
    flyte create cluster <CLUSTER_NAME> --pool default
    ```
 

--- a/content/deployment/selfmanaged/selfmanaged-crusoe/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-crusoe/deploy-dataplane.md
@@ -8,6 +8,9 @@ variants: -flyte +union
 
 If you have not yet set up the required Crusoe resources (CMK cluster, Cloud Storage bucket, access keys, access policy), see [Prepare infrastructure](../selfmanaged-crusoe/prepare-infra) first.
 
+> [!NOTE] Planning more than one cluster?
+> This page covers the single-cluster path: one cluster in the `default` cluster pool, as created by the `flyte create cluster ... --pool default` command below. If you plan to connect several clusters to the same control plane, read [Multiple clusters](../configuration/multi-cluster) first. Pool membership governs metadata sharing -- clusters in the same pool share one metadata bucket, and clusters in different pools must use different ones -- so it affects the metadata bucket you configure below.
+
 ## Assumptions
 
 * You have a {{< key product_name >}} organization, and you know the control plane URL for your organization.

--- a/content/deployment/selfmanaged/selfmanaged-crusoe/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-crusoe/deploy-dataplane.md
@@ -83,7 +83,7 @@ If you have not yet set up the required Crusoe resources (CMK cluster, Cloud Sto
      authType: accesskey
      bucketName: <BUCKET_NAME>
      fastRegistrationBucketName: <BUCKET_NAME>
-     endpoint: https://object.crusoecloud.com    # [VERIFY endpoint]
+     endpoint: <YOUR_STORAGE_ENDPOINT>
      region: <CRUSOE_REGION>
      disableSSL: false
      credentialsSecretRef:
@@ -243,18 +243,3 @@ For more information, see the following resources:
 - [Crusoe Managed Kubernetes overview](https://docs.crusoecloud.com/kubernetes/overview/)
 - [Crusoe Cloud Storage overview](https://docs.crusoecloud.com/storage/object-storage/overview)
 
-<!--
-Open items to confirm before publishing (carried over from draft):
-1. S3 endpoint URL: object.crusoecloud.com, storage.crusoecloud.com, region-scoped, or other?
-2. Addressing style: does Crusoe require virtual-hosted style or support path-style?
-3. Region naming: canonical region/AZ format (e.g., us-northcentral1-a)?
-4. IAM policy schema: AWS-style JSON or custom?
-5. Console navigation paths: exact menu paths for buckets, keys, policies.
-6. Kubernetes service name: CMK, CKE, or other branding?
-7. GPU node pool labels & taints: canonical labels (e.g., crusoe.ai/gpu-type=h100)?
-8. Supported Kubernetes versions: confirm the "most recent three minor" claim.
-9. Networking / egress: RESOLVED — outbound-only; TCP 443 to the control plane tenant endpoint and TCP 7844 for the Cloudflare Tunnel (default tier). Documented at content/security/architecture/network.md#egress-requirements.
-10. Default StorageClass on CMK for PVCs (BuildKit cache, fluent-bit)?
-11. Image registry pull-through cache to reduce GHCR pull latency?
-12. Logging sink: back to the same bucket, or a managed logging service?
--->

--- a/content/deployment/selfmanaged/selfmanaged-crusoe/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-crusoe/deploy-dataplane.md
@@ -9,7 +9,7 @@ variants: -flyte +union
 If you have not yet set up the required Crusoe resources (CMK cluster, Cloud Storage bucket, access keys, access policy), see [Prepare infrastructure](../selfmanaged-crusoe/prepare-infra) first.
 
 > [!NOTE] Planning more than one cluster?
-> This page covers the single-cluster path: one cluster in the `default` cluster pool, as created by the `flyte create cluster ... --pool default` command below. If you plan to connect several clusters to the same control plane, read [Multiple clusters](../configuration/multi-cluster) first. Pool membership governs metadata sharing -- clusters in the same pool share one metadata bucket, and clusters in different pools must use different ones -- so it affects the metadata bucket you configure below.
+> This page covers the single-cluster path: one cluster in the `default` cluster pool, as created by the `flyte create cluster ... --pool default` command below. If you plan to connect several clusters to the same control plane, read [Multiple clusters](../configuration/multi-cluster) first. Pool membership governs metadata sharing: clusters in the same pool share one metadata bucket, and clusters in different pools must use different ones, so it affects the metadata bucket you configure below.
 
 ## Assumptions
 
@@ -42,7 +42,7 @@ If you have not yet set up the required Crusoe resources (CMK cluster, Cloud Sto
 
    `flyte create config` writes `.flyte/config.yaml`. The first command that contacts the control plane opens a browser to authenticate you.
 
-   Register the cluster before you install the chart -- the data plane binds to this record when it starts. Every organization is provisioned with a `default` pool, so `--pool default` needs no extra setup.
+   Register the cluster before you install the chart: the data plane binds to this record when it starts. Every organization is provisioned with a `default` pool, so `--pool default` needs no extra setup.
 
 3. Configure the Union CLI and provision data plane resources:
 
@@ -64,7 +64,7 @@ If you have not yet set up the required Crusoe resources (CMK cluster, Cloud Sto
    curl -O https://raw.githubusercontent.com/unionai/helm-charts/main/charts/dataplane/values.yaml
    ```
 
-   Rather than putting your access keys in the values file, store them in a Kubernetes Secret and reference it from the chart. Create the namespace and the secret first -- the chart reads the secret while rendering, so it must exist before you install:
+   Rather than putting your access keys in the values file, store them in a Kubernetes Secret and reference it from the chart. Create the namespace and the secret first; the chart reads the secret while rendering, so it must exist before you install:
 
    ```bash
    kubectl create namespace union
@@ -209,13 +209,12 @@ To run a sample workflow, complete the following steps:
 
 > [!NOTE] Crusoe-specific tip
 > To land tasks on Crusoe GPU nodes, add a task-level resource request and a node selector matching Crusoe's GPU node pool labels.
-> <!-- [VERIFY label keys — e.g., crusoe.ai/gpu-type=h100] -->
 
 ## Troubleshooting
 
 | Symptom                                      | Cause                                                  | Fix                                                                                                                       |
 | -------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
-| `PathStyleRequestNotAllowed 400`             | Control plane generates path-style URLs but Crusoe requires virtual-hosted. | `compat` cannot express this setting. Switch `storage` to `provider: custom` with an explicit `stow` block setting `disable_force_path_style: true`. Keep `credentialsSecretRef` (it still injects the task-pod variables) and resolve the stow credentials with a `lookup` expression, as the [CoreWeave page](../selfmanaged-coreweave/deploy-dataplane) shows. |
+| `PathStyleRequestNotAllowed 400`             | Control plane generates path-style URLs but Crusoe requires virtual-hosted. | `compat` cannot express this setting. Switch `storage` to `provider: custom` with an explicit `stow` block setting `disable_force_path_style: true`. Keep `credentialsSecretRef`: the chart still injects the task-pod variables and also merges the stow credentials into the `custom` stow config automatically, as the [CoreWeave page](../selfmanaged-coreweave/deploy-dataplane) shows. |
 | `403 Forbidden` on S3 operations             | No access policy attached to the storage key.          | Create/attach an object storage access policy in the Crusoe Cloud Console.                                                |
 | Task pods reach `s3.us-east-1.amazonaws.com` | Task pods missing the Crusoe endpoint.                 | The chart injects `FLYTE_AWS_ENDPOINT` from `storage.endpoint` when `injectPodEnvVars` is enabled (the default); confirm that value is set.                     |
 | "All enabled clusters are unhealthy"         | Control plane can't reach the data plane.              | Verify the tunnel service: `kubectl get pods -n union \| grep proxy`.                                                     |

--- a/content/deployment/selfmanaged/selfmanaged-crusoe/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-crusoe/deploy-dataplane.md
@@ -20,6 +20,7 @@ If you have not yet set up the required Crusoe resources (CMK cluster, Cloud Sto
 * Install [Helm 3](https://helm.sh/docs/intro/install/).
 * Install [uctl](../../../api-reference/uctl-cli/_index).
 * Install the [`flyte` CLI](../../../api-reference/flyte-cli) (used later to run a sample workflow).
+* Install the [`flyteplugins-union` plugin](../../../api-reference/flyte-cli#plugin-commands), which provides the `flyte get cluster` command: `pip install flyteplugins-union`.
 
 ## Deploy the {{< key product_name >}} operator
 
@@ -29,7 +30,18 @@ If you have not yet set up the required Crusoe resources (CMK cluster, Cloud Sto
    export KUBECONFIG=<PATH_TO_KUBECONFIG>
    ```
 
-2. Configure the Union CLI and provision data plane resources:
+2. Configure the `flyte` CLI to talk to your control plane, then register the cluster name:
+
+   ```bash
+   flyte create config --endpoint dns:///<ORG_NAME>.union.ai --org <ORG_NAME>
+   flyte create cluster <CLUSTER_NAME> --pool default
+   ```
+
+   `flyte create config` writes `.flyte/config.yaml`. The first command that contacts the control plane opens a browser to authenticate you.
+
+   Register the cluster before you install the chart -- the data plane binds to this record when it starts. Every organization is provisioned with a `default` pool, so `--pool default` needs no extra setup.
+
+3. Configure the Union CLI and provision data plane resources:
 
    ```bash
    uctl config init --host=<ORG_NAME>.union.ai
@@ -37,13 +49,28 @@ If you have not yet set up the required Crusoe resources (CMK cluster, Cloud Sto
    ```
 
    * The command will output the ID, name, and a secret that will be used by the Union services to communicate with your control plane.
-     It will also generate a YAML values file specific to the `custom` provider.
+     You will pass the client ID and client secret to the Helm chart in step 7.
 
-   * Save the secret that is displayed. Union does not store the credentials; rerunning the same command can be used to retrieve the secret later.
+   * Save the secret that is displayed. Union does not store it, and it cannot be retrieved later.
 
    We use `--provider custom` for Crusoe because the Union operator treats Crusoe as a generic S3-compatible / Kubernetes environment rather than a first-class cloud provider integration (like AWS/GCP/Azure).
 
-3. Update the generated values file with your Crusoe-specific storage configuration. Replace the placeholders with your actual credentials and settings.
+4. Create a values file for the data plane chart. Start from the base values file and layer your Crusoe-specific storage configuration on top, replacing the placeholders with your actual credentials and settings:
+
+   ```bash
+   curl -O https://raw.githubusercontent.com/unionai/helm-charts/main/charts/dataplane/values.yaml
+   ```
+
+   Rather than putting your access keys in the values file, store them in a Kubernetes Secret and reference it from the chart. Create the namespace and the secret first -- the chart reads the secret while rendering, so it must exist before you install:
+
+   ```bash
+   kubectl create namespace union
+   kubectl create secret generic storage-credentials -n union \
+     --from-literal=access_key_id=<ACCESS_KEY_ID> \
+     --from-literal=secret_key=<SECRET_ACCESS_KEY>
+   ```
+
+   Then write the values file:
 
    ```yaml
    host: <ORG_NAME>.union.ai
@@ -52,88 +79,75 @@ If you have not yet set up the required Crusoe resources (CMK cluster, Cloud Sto
    provider: custom
 
    storage:
-     provider: custom
+     provider: compat
+     authType: accesskey
      bucketName: <BUCKET_NAME>
      fastRegistrationBucketName: <BUCKET_NAME>
-     custom:
-       type: stow
-       container: <BUCKET_NAME>
-       stow:
-         kind: s3
-         config:
-           region: <CRUSOE_REGION>
-           auth_type: accesskey
-           access_key_id: <ACCESS_KEY_ID>
-           secret_key: <SECRET_ACCESS_KEY>
-           endpoint: https://object.crusoecloud.com    # [VERIFY endpoint]
-           disable_ssl: false
-           disable_force_path_style: false             # [VERIFY: set true if Crusoe requires virtual-hosted style]
-
-   executor:
-     extraEnvVars:
-       - name: FLYTE_AWS_ENDPOINT
-         value: "https://object.crusoecloud.com"      # [VERIFY]
-       - name: AWS_ACCESS_KEY_ID
-         value: <ACCESS_KEY_ID>
-       - name: AWS_SECRET_ACCESS_KEY
-         value: <SECRET_ACCESS_KEY>
-       - name: AWS_DEFAULT_REGION
-         value: <CRUSOE_REGION>
+     endpoint: https://object.crusoecloud.com    # [VERIFY endpoint]
+     region: <CRUSOE_REGION>
+     disableSSL: false
+     credentialsSecretRef:
+       name: storage-credentials
 
    config:
      k8s:
        plugins:
          k8s:
            default-env-vars:
-             - FLYTE_AWS_ENDPOINT: https://object.crusoecloud.com   # [VERIFY]
-             - AWS_ACCESS_KEY_ID: <ACCESS_KEY_ID>
-             - AWS_SECRET_ACCESS_KEY: <SECRET_ACCESS_KEY>
              - AWS_DEFAULT_REGION: <CRUSOE_REGION>
 
    operator:
      enableTunnelService: true
 
-   secrets:
-     admin:
-       create: true
-       clientId: <CLIENT_ID>
-       clientSecret: <CLIENT_SECRET>
-
    fluentbit:
      enabled: true
      env:
        - name: AWS_ACCESS_KEY_ID
-         value: <ACCESS_KEY_ID>
+         valueFrom:
+           secretKeyRef:
+             name: storage-credentials
+             key: access_key_id
        - name: AWS_SECRET_ACCESS_KEY
-         value: <SECRET_ACCESS_KEY>
+         valueFrom:
+           secretKeyRef:
+             name: storage-credentials
+             key: secret_key
    ```
 
-   > [!NOTE]
-   > The `uctl selfserve provision-dataplane-resources` command in step 2 generates the `<CLIENT_ID>` and `<CLIENT_SECRET>` values. Use the values from that command's output.
+   With `storage.provider: compat` and `authType: accesskey`, the chart builds the stow config itself and injects `FLYTE_AWS_ENDPOINT`, `FLYTE_AWS_ACCESS_KEY_ID`, and `FLYTE_AWS_SECRET_ACCESS_KEY` into task pods from `storage.endpoint` and the secret, so those no longer need to be listed by hand.
 
-4. Add the {{< key product_name >}} Helm repo:
+   > [!NOTE]
+   > The chart resolves the secret with a Helm `lookup`, which returns nothing during `helm template` or `--dry-run`. Those commands render the storage config without credentials; only a real install picks them up. If your secret uses different field names, set `credentialsSecretRef.accessKeyIdKey` and `credentialsSecretRef.secretKeyKey` to match.
+
+   > [!NOTE]
+   > The `uctl selfserve provision-dataplane-resources` command in step 3 generates the `<CLIENT_ID>` and `<CLIENT_SECRET>` values. Use the values from that command's output.
+
+5. Add the {{< key product_name >}} Helm repo:
 
    ```bash
    helm repo add unionai https://unionai.github.io/helm-charts/
    helm repo update
    ```
 
-5. Install the Custom Resource Definitions (CRDs):
+6. Install the Custom Resource Definitions (CRDs):
 
    ```bash
    helm upgrade --install unionai-dataplane-crds unionai/dataplane-crds
    ```
 
-6. Install the data plane. Replace `<PATH_TO_VALUES_FILE>` with the path to the Helm values file you customized in step 3.
+7. Install the data plane. Replace `<PATH_TO_VALUES_FILE>` with the path to the Helm values file you customized in step 4, and `<CLIENT_ID>` / `<CLIENT_SECRET>` with the credentials printed in step 3.
 
    ```bash
    helm upgrade --install unionai-dataplane unionai/dataplane \
      --namespace union --create-namespace \
      --values <PATH_TO_VALUES_FILE> \
+     --set global.AUTH_CLIENT_ID=<CLIENT_ID> \
+     --set-string secrets.admin.clientId=<CLIENT_ID> \
+     --set secrets.admin.clientSecret=<CLIENT_SECRET> \
      --timeout 10m
    ```
 
-7. Verify the pods are running:
+8. Verify the pods are running:
 
    ```bash
    kubectl get pods -n union
@@ -141,27 +155,19 @@ If you have not yet set up the required Crusoe resources (CMK cluster, Cloud Sto
 
    When the deployment succeeds, all pods show a `Running` status, including `union-operator-proxy`, `union-operator-buildkit`, `flytepropeller`, and `executor`.
 
-8. Verify the cluster is registered with the control plane:
+9. Verify the cluster is registered with the control plane:
 
    ```bash
-   uctl get cluster
+   flyte get cluster
    ```
 
    The output is similar to the following:
 
    ```text
-   NAME              ORG       STATE          HEALTH
-   union-crusoe      my-org    STATE_ENABLED  HEALTHY
+   Enabled Clusters
+   NAME            ORG       STATE     HEALTH
+   union-crusoe    my-org    enabled   healthy
    ```
-
-9. **Required for helm charts on a version <= 2026.5.8.** Create an API key for your organization. This is required for v2 workflow executions on the data plane. If you have already created one, rerun the same command to propagate the key to the new cluster:
-
-   ```bash
-   uctl create apikey --keyName EAGER_API_KEY --org <ORG_NAME>
-   ```
-
-   > [!NOTE]
-   > If you receive a `PermissionDenied` error, contact [Union.ai support](https://www.union.ai/) to have the permission enabled for your organization.
 
 ## Test a workflow
 
@@ -206,9 +212,9 @@ To run a sample workflow, complete the following steps:
 
 | Symptom                                      | Cause                                                  | Fix                                                                                                                       |
 | -------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
-| `PathStyleRequestNotAllowed 400`             | Control plane generates path-style URLs but Crusoe requires virtual-hosted. | Set `storage.custom.stow.config.disable_force_path_style: true`.                                  |
+| `PathStyleRequestNotAllowed 400`             | Control plane generates path-style URLs but Crusoe requires virtual-hosted. | `compat` cannot express this setting. Switch `storage` to `provider: custom` with an explicit `stow` block setting `disable_force_path_style: true`. Keep `credentialsSecretRef` (it still injects the task-pod variables) and resolve the stow credentials with a `lookup` expression, as the [CoreWeave page](../selfmanaged-coreweave/deploy-dataplane) shows. |
 | `403 Forbidden` on S3 operations             | No access policy attached to the storage key.          | Create/attach an object storage access policy in the Crusoe Cloud Console.                                                |
-| Task pods reach `s3.us-east-1.amazonaws.com` | Task pods missing the Crusoe endpoint.                 | Add `FLYTE_AWS_ENDPOINT` to `config.k8s.plugins.k8s.default-env-vars`.                                                    |
+| Task pods reach `s3.us-east-1.amazonaws.com` | Task pods missing the Crusoe endpoint.                 | The chart injects `FLYTE_AWS_ENDPOINT` from `storage.endpoint` when `injectPodEnvVars` is enabled (the default); confirm that value is set.                     |
 | "All enabled clusters are unhealthy"         | Control plane can't reach the data plane.              | Verify the tunnel service: `kubectl get pods -n union \| grep proxy`.                                                     |
 | "Remote image builder is not enabled"        | Remote builder not enabled on the control plane.       | Contact Union.ai or use `--image` with a pre-built image.                                                                 |
 | `invalid keys: collectbillableresourceusage` | Chart/operator version mismatch.                       | Use matching chart and operator image versions.                                                                           |

--- a/content/deployment/selfmanaged/selfmanaged-crusoe/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-crusoe/deploy-dataplane.md
@@ -33,7 +33,7 @@ If you have not yet set up the required Crusoe resources (CMK cluster, Cloud Sto
 2. Configure the `flyte` CLI to talk to your control plane, then register the cluster name:
 
    ```bash
-   flyte create config --endpoint dns:///<ORG_NAME>.union.ai --org <ORG_NAME>
+   flyte create config --endpoint <YOUR_UNION_CONTROLPLANE_URL> --org <ORG_NAME>
    flyte create cluster <CLUSTER_NAME> --pool default
    ```
 

--- a/content/deployment/selfmanaged/selfmanaged-gcp/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-gcp/deploy-dataplane.md
@@ -20,6 +20,8 @@ If you have not yet set up the required GCP resources (GKE cluster, GCS, Artifac
 
 * Install [Helm 3](https://helm.sh/docs/intro/install/).
 * Install [uctl](../../../api-reference/uctl-cli/_index).
+* Install the [`flyte` CLI](../../../api-reference/flyte-cli).
+* Install the [`flyteplugins-union` plugin](../../../api-reference/flyte-cli#plugin-commands), which provides the `flyte get cluster` command: `pip install flyteplugins-union`.
 
 ## Deploy the {{< key product_name >}} operator
 
@@ -30,7 +32,18 @@ If you have not yet set up the required GCP resources (GKE cluster, GCS, Artifac
    helm repo update
    ```
 
-2. Use the `uctl selfserve provision-dataplane-resources` command to generate a new client and client secret for communicating with your Union control plane, provision authorization permissions for the app to operate on the Union cluster name you have selected, generate values file to install dataplane in your Kubernetes cluster and provide follow-up instructions:
+2. Configure the `flyte` CLI to talk to your control plane, then register the cluster name:
+
+   ```bash
+   flyte create config --endpoint dns:///<YOUR_UNION_CONTROL_PLANE_URL> --org <YOUR_ORG_NAME>
+   flyte create cluster <YOUR_SELECTED_CLUSTERNAME> --pool default
+   ```
+
+   `flyte create config` writes `.flyte/config.yaml`. The first command that contacts the control plane opens a browser to authenticate you.
+
+   Register the cluster before you install the chart -- the data plane binds to this record when it starts. Every organization is provisioned with a `default` pool, so `--pool default` needs no extra setup.
+
+3. Use the `uctl selfserve provision-dataplane-resources` command to generate a new client and client secret for communicating with your Union control plane, provision authorization permissions for the app to operate on the Union cluster name you have selected, and provide follow-up instructions:
 
    ```bash
    uctl config init --host=<YOUR_UNION_CONTROL_PLANE_URL>
@@ -38,51 +51,53 @@ If you have not yet set up the required GCP resources (GKE cluster, GCS, Artifac
    ```
 
    * The command will output the ID, name, and a secret that will be used by the Union services to communicate with your control plane.
-     It will also generate a YAML file specific to the provider that you specify, in this case `gcp`.
+     You will pass the client ID and client secret to the Helm chart in step 5.
 
-   * Save the secret that is displayed. Union does not store the credentials; rerunning the same command can be used to retrieve the secret later.
+   * Save the secret that is displayed. Union does not store it, and it cannot be retrieved later.
 
-3. Update the generated values file with your infrastructure details:
+4. Download the GCP values file for the data plane chart and fill in your infrastructure details:
 
-   Using the [environment variables](../selfmanaged-gcp/prepare-infra#environment-variables) from the prepare infrastructure step:
+   ```bash
+   curl -O https://raw.githubusercontent.com/unionai/helm-charts/main/charts/dataplane/values.gcp.yaml
+   ```
 
+   Using the [environment variables](../selfmanaged-gcp/prepare-infra#environment-variables) from the prepare infrastructure step, set the following keys under `global`. The rest of the file (storage, service account annotations, Workload Identity) is templated from these values, so you do not need to edit it:
+
+   - Set `global.UNION_CONTROL_PLANE_HOST` and `global.CONTROLPLANE_HOST` to your control plane hostname (no scheme, no port).
+   - Set `global.CLUSTER_NAME` to the cluster name you registered in step 2.
+   - Set `global.ORG_NAME` to your organization name.
+   - Set `global.GOOGLE_PROJECT_ID` to `${PROJECT_ID}`.
+   - Set `global.GCP_REGION` to `${REGION}`.
    - Set `global.METADATA_BUCKET` to `${BUCKET_PREFIX}-metadata`.
    - Set `global.FAST_REGISTRATION_BUCKET` to `${BUCKET_PREFIX}-fast-reg`.
    - Set `global.BACKEND_IAM_ROLE_ARN` to `${GSA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com`.
    - Set `global.WORKER_IAM_ROLE_ARN` to the same value (or a separate GSA if you use distinct worker permissions).
-   - Set `storage.bucketName` to `${BUCKET_PREFIX}-metadata`.
-   - Set `storage.fastRegistrationBucketName` to `${BUCKET_PREFIX}-fast-reg`.
-   - Set `storage.region` to `${REGION}`.
-   - Set `storage.gcp.projectId` to `${PROJECT_ID}`.
-   - Set `commonServiceAccount.annotations."iam.gke.io/gcp-service-account"` to `${GSA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com`.
-   - Set `imageBuilder.registryName` to `${AR_REPOSITORY}` (defaults to `union-dataplane`; the chart auto-generates the full Artifact Registry URL from the project ID and region).
+   - Optionally set `imageBuilder.registryName` to `${AR_REPOSITORY}` (defaults to `union-dataplane`; the chart auto-generates the full Artifact Registry URL from the project ID and region).
 
-4. Install the data plane Helm chart:
+5. Install the data plane Helm chart, passing the client ID and client secret from step 3:
 
    ```bash
    helm upgrade --install union unionai/dataplane \
-     -f <GENERATED_VALUES_FILE> \
+     -f values.gcp.yaml \
+     --set global.AUTH_CLIENT_ID=<CLIENT_ID> \
+     --set-string secrets.admin.clientId=<CLIENT_ID> \
+     --set secrets.admin.clientSecret=<CLIENT_SECRET> \
      --namespace union \
      --create-namespace \
-     --force-conflicts
-   ```
-
-5. **Required for helm charts on a version <= 2026.5.8.** Create an API key for your organization. This is required for v2 workflow executions on the data plane. If you have already created one, rerun the same command to propagate the key to the new cluster:
-
-   ```bash
-   uctl create apikey --keyName EAGER_API_KEY --org <YOUR_ORG_NAME>
    ```
 
 6. Once deployed you can check to see if the cluster has been successfully registered to the control plane:
 
    ```bash
-   uctl get cluster
-    ----------- ------- --------------- -----------
-   | NAME      | ORG   | STATE         | HEALTH    |
-    ----------- ------- --------------- -----------
-   | <cluster> | <org> | STATE_ENABLED | HEALTHY   |
-    ----------- ------- --------------- -----------
-   1 rows
+   flyte get cluster
+   ```
+
+   The command groups clusters by state. A successfully registered cluster appears under **Enabled Clusters**:
+
+   ```text
+   Enabled Clusters
+   NAME        ORG     STATE     HEALTH
+   <cluster>   <org>   enabled   healthy
    ```
 
 7. Follow the [Quickstart](../../../user-guide/quickstart) to run your first workflow and verify your cluster is working correctly.

--- a/content/deployment/selfmanaged/selfmanaged-gcp/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-gcp/deploy-dataplane.md
@@ -35,7 +35,7 @@ If you have not yet set up the required GCP resources (GKE cluster, GCS, Artifac
 2. Configure the `flyte` CLI to talk to your control plane, then register the cluster name:
 
    ```bash
-   flyte create config --endpoint dns:///<YOUR_UNION_CONTROL_PLANE_URL> --org <YOUR_ORG_NAME>
+   flyte create config --endpoint <YOUR_UNION_CONTROL_PLANE_URL> --org <YOUR_ORG_NAME>
    flyte create cluster <YOUR_SELECTED_CLUSTERNAME> --pool default
    ```
 

--- a/content/deployment/selfmanaged/selfmanaged-gcp/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-gcp/deploy-dataplane.md
@@ -83,7 +83,7 @@ If you have not yet set up the required GCP resources (GKE cluster, GCS, Artifac
      --set-string secrets.admin.clientId=<CLIENT_ID> \
      --set secrets.admin.clientSecret=<CLIENT_SECRET> \
      --namespace union \
-     --create-namespace \
+     --create-namespace 
    ```
 
 6. Once deployed you can check to see if the cluster has been successfully registered to the control plane:

--- a/content/deployment/selfmanaged/selfmanaged-gcp/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-gcp/deploy-dataplane.md
@@ -8,6 +8,9 @@ variants: -flyte +union
 
 If you have not yet set up the required GCP resources (GKE cluster, GCS, Artifact Registry, Workload Identity), see [Prepare infrastructure](../selfmanaged-gcp/prepare-infra) first.
 
+> [!NOTE] Planning more than one cluster?
+> This page covers the single-cluster path: one cluster in the `default` cluster pool, as created by the `flyte create cluster ... --pool default` command below. If you plan to connect several clusters to the same control plane, read [Multiple clusters](../configuration/multi-cluster) first. Pool membership governs metadata sharing -- clusters in the same pool share one metadata bucket, and clusters in different pools must use different ones -- so it affects the metadata bucket you configure below.
+
 ## Assumptions
 
 * You have a {{< key product_name >}} organization, and you know the control plane URL for your organization (e.g. `https://your-org-name.us-east-2.unionai.cloud`).

--- a/content/deployment/selfmanaged/selfmanaged-gcp/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-gcp/deploy-dataplane.md
@@ -9,7 +9,7 @@ variants: -flyte +union
 If you have not yet set up the required GCP resources (GKE cluster, GCS, Artifact Registry, Workload Identity), see [Prepare infrastructure](../selfmanaged-gcp/prepare-infra) first.
 
 > [!NOTE] Planning more than one cluster?
-> This page covers the single-cluster path: one cluster in the `default` cluster pool, as created by the `flyte create cluster ... --pool default` command below. If you plan to connect several clusters to the same control plane, read [Multiple clusters](../configuration/multi-cluster) first. Pool membership governs metadata sharing -- clusters in the same pool share one metadata bucket, and clusters in different pools must use different ones -- so it affects the metadata bucket you configure below.
+> This page covers the single-cluster path: one cluster in the `default` cluster pool, as created by the `flyte create cluster ... --pool default` command below. If you plan to connect several clusters to the same control plane, read [Multiple clusters](../configuration/multi-cluster) first. Pool membership governs metadata sharing: clusters in the same pool share one metadata bucket, and clusters in different pools must use different ones, so it affects the metadata bucket you configure below.
 
 ## Assumptions
 
@@ -44,7 +44,7 @@ If you have not yet set up the required GCP resources (GKE cluster, GCS, Artifac
 
    `flyte create config` writes `.flyte/config.yaml`. The first command that contacts the control plane opens a browser to authenticate you.
 
-   Register the cluster before you install the chart -- the data plane binds to this record when it starts. Every organization is provisioned with a `default` pool, so `--pool default` needs no extra setup.
+   Register the cluster before you install the chart: the data plane binds to this record when it starts. Every organization is provisioned with a `default` pool, so `--pool default` needs no extra setup.
 
 3. Use the `uctl selfserve provision-dataplane-resources` command to generate a new client and client secret for communicating with your Union control plane, provision authorization permissions for the app to operate on the Union cluster name you have selected, and provide follow-up instructions:
 

--- a/content/deployment/selfmanaged/selfmanaged-generic/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-generic/deploy-dataplane.md
@@ -20,6 +20,8 @@ If you have not yet set up the required resources (Kubernetes cluster, object st
 
 * Install [Helm 3](https://helm.sh/docs/intro/install/).
 * Install [uctl](../../../api-reference/uctl-cli/_index).
+* Install the [`flyte` CLI](../../../api-reference/flyte-cli).
+* Install the [`flyteplugins-union` plugin](../../../api-reference/flyte-cli#plugin-commands), which provides the `flyte get cluster` command: `pip install flyteplugins-union`.
 
 ## Deploy the {{< key product_name >}} operator
 
@@ -30,7 +32,18 @@ If you have not yet set up the required resources (Kubernetes cluster, object st
    helm repo update
    ```
 
-2. Use the `uctl selfserve provision-dataplane-resources` command to generate a new client and client secret for communicating with your Union control plane, provision authorization permissions for the app to operate on the Union cluster name you have selected, generate values file to install dataplane in your Kubernetes cluster and provide follow-up instructions:
+2. Configure the `flyte` CLI to talk to your control plane, then register the cluster name:
+
+   ```bash
+   flyte create config --endpoint dns:///<YOUR_UNION_CONTROL_PLANE_URL> --org <YOUR_ORG_NAME>
+   flyte create cluster <YOUR_SELECTED_CLUSTERNAME> --pool default
+   ```
+
+   `flyte create config` writes `.flyte/config.yaml`. The first command that contacts the control plane opens a browser to authenticate you.
+
+   The second command registers the cluster before you install the chart -- the data plane binds to this record when it starts. Every organization is provisioned with a `default` pool, so `--pool default` needs no extra setup.
+
+3. Use the `uctl selfserve provision-dataplane-resources` command to generate a new client and client secret for communicating with your Union control plane, provision authorization permissions for the app to operate on the Union cluster name you have selected, and provide follow-up instructions:
 
    ```bash
    uctl config init --host=<YOUR_UNION_CONTROL_PLANE_URL>
@@ -38,44 +51,72 @@ If you have not yet set up the required resources (Kubernetes cluster, object st
    ```
 
    * The command will output the ID, name, and a secret that will be used by the Union services to communicate with your control plane.
-     It will also generate a YAML file specific to the provider that you specify, in this case `custom` (generic / on-premise).
+     You will pass the client ID and client secret to the Helm chart in step 5.
 
-   * Save the secret that is displayed. Union does not store the credentials; rerunning the same command can be used to retrieve the secret later.
+   * Save the secret that is displayed. Union does not store it, and it cannot be retrieved later.
 
-3. Update the generated values file with your infrastructure details:
+4. Download the base values file for the data plane chart and fill in your infrastructure details:
 
+   ```bash
+   curl -O https://raw.githubusercontent.com/unionai/helm-charts/main/charts/dataplane/values.yaml
+   ```
+
+   The published overlays cover AWS, GCP, and Azure only, so a generic or on-premise environment starts from the base values file:
+
+   - Set `global.UNION_CONTROL_PLANE_HOST` and `global.CONTROLPLANE_HOST` to your control plane hostname (no scheme, no port).
+   - Set `global.CLUSTER_NAME` to the cluster name you registered in step 2.
+   - Set `global.ORG_NAME` to your organization name.
    - Set `storage.endpoint` to your S3-compatible storage endpoint (e.g. your MinIO URL).
-   - Set `storage.accessKey` and `storage.secretKey` to your storage credentials.
    - Set `storage.bucketName` and `storage.fastRegistrationBucketName` to your bucket name(s).
    - Set `storage.region` to the region of your storage provider.
    - The same credentials are also needed in `fluentbit.env` for log shipping.
 
-4. Install the data plane Helm chart:
+   Rather than putting your storage credentials in the values file, store them in a Kubernetes Secret and reference it from the chart. Create the namespace and the secret first -- the chart reads the secret while rendering, so it must exist before you install:
+
+   ```bash
+   kubectl create namespace union
+   kubectl create secret generic storage-credentials -n union \
+     --from-literal=access_key_id=<ACCESS_KEY_ID> \
+     --from-literal=secret_key=<SECRET_ACCESS_KEY>
+   ```
+
+   Then reference it instead of setting `storage.accessKey` and `storage.secretKey`:
+
+   ```yaml
+   storage:
+     provider: compat
+     authType: accesskey
+     credentialsSecretRef:
+       name: storage-credentials
+   ```
+
+   > [!NOTE]
+   > The chart resolves the secret with a Helm `lookup`, which returns nothing during `helm template` or `--dry-run`. Those commands render the storage config without credentials; only a real install picks them up. If your secret uses different field names, set `credentialsSecretRef.accessKeyIdKey` and `credentialsSecretRef.secretKeyKey` to match.
+
+5. Install the data plane Helm chart, passing the client ID and client secret from step 3:
 
    ```bash
    helm upgrade --install union unionai/dataplane \
-     -f <GENERATED_VALUES_FILE> \
+     -f values.yaml \
+     --set global.AUTH_CLIENT_ID=<CLIENT_ID> \
+     --set-string secrets.admin.clientId=<CLIENT_ID> \
+     --set secrets.admin.clientSecret=<CLIENT_SECRET> \
      --namespace union \
      --create-namespace \
-     --force-conflicts
-   ```
-
-5. **Required for helm charts on a version <= 2026.5.8.** Create an API key for your organization. This is required for v2 workflow executions on the data plane. If you have already created one, rerun the same command to propagate the key to the new cluster:
-
-   ```bash
-   uctl create apikey --keyName EAGER_API_KEY --org <YOUR_ORG_NAME>
    ```
 
 6. Once deployed you can check to see if the cluster has been successfully registered to the control plane:
 
    ```bash
-   uctl get cluster
-    ----------- ------- --------------- -----------
-   | NAME      | ORG   | STATE         | HEALTH    |
-    ----------- ------- --------------- -----------
-   | <cluster> | <org> | STATE_ENABLED | HEALTHY   |
-    ----------- ------- --------------- -----------
-   1 rows
+   flyte get cluster
+   ```
+
+   The command groups clusters by state. A successfully registered cluster appears under **Enabled Clusters**:
+
+   ```text
+   Enabled Clusters
+   NAME        ORG     STATE     HEALTH
+   <cluster>   <org>   enabled   healthy
    ```
 
 7. Follow the [Quickstart](../../../user-guide/quickstart) to run your first workflow and verify your cluster is working correctly.

--- a/content/deployment/selfmanaged/selfmanaged-generic/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-generic/deploy-dataplane.md
@@ -35,7 +35,7 @@ If you have not yet set up the required resources (Kubernetes cluster, object st
 2. Configure the `flyte` CLI to talk to your control plane, then register the cluster name:
 
    ```bash
-   flyte create config --endpoint dns:///<YOUR_UNION_CONTROL_PLANE_URL> --org <YOUR_ORG_NAME>
+   flyte create config --endpoint <YOUR_UNION_CONTROL_PLANE_URL> --org <YOUR_ORG_NAME>
    flyte create cluster <YOUR_SELECTED_CLUSTERNAME> --pool default
    ```
 

--- a/content/deployment/selfmanaged/selfmanaged-generic/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-generic/deploy-dataplane.md
@@ -9,7 +9,7 @@ variants: -flyte +union
 If you have not yet set up the required resources (Kubernetes cluster, object storage, container registry, credentials), see [Prepare infrastructure](../selfmanaged-generic/prepare-infra) first.
 
 > [!NOTE] Planning more than one cluster?
-> This page covers the single-cluster path: one cluster in the `default` cluster pool, as created by the `flyte create cluster ... --pool default` command below. If you plan to connect several clusters to the same control plane, read [Multiple clusters](../configuration/multi-cluster) first. Pool membership governs metadata sharing -- clusters in the same pool share one metadata bucket, and clusters in different pools must use different ones -- so it affects the metadata bucket you configure below.
+> This page covers the single-cluster path: one cluster in the `default` cluster pool, as created by the `flyte create cluster ... --pool default` command below. If you plan to connect several clusters to the same control plane, read [Multiple clusters](../configuration/multi-cluster) first. Pool membership governs metadata sharing: clusters in the same pool share one metadata bucket, and clusters in different pools must use different ones, so it affects the metadata bucket you configure below.
 
 ## Assumptions
 
@@ -44,7 +44,7 @@ If you have not yet set up the required resources (Kubernetes cluster, object st
 
    `flyte create config` writes `.flyte/config.yaml`. The first command that contacts the control plane opens a browser to authenticate you.
 
-   The second command registers the cluster before you install the chart -- the data plane binds to this record when it starts. Every organization is provisioned with a `default` pool, so `--pool default` needs no extra setup.
+   The second command registers the cluster before you install the chart: the data plane binds to this record when it starts. Every organization is provisioned with a `default` pool, so `--pool default` needs no extra setup.
 
 3. Use the `uctl selfserve provision-dataplane-resources` command to generate a new client and client secret for communicating with your Union control plane, provision authorization permissions for the app to operate on the Union cluster name you have selected, and provide follow-up instructions:
 
@@ -74,7 +74,7 @@ If you have not yet set up the required resources (Kubernetes cluster, object st
    - Set `storage.region` to the region of your storage provider.
    - The same credentials are also needed in `fluentbit.env` for log shipping.
 
-   Rather than putting your storage credentials in the values file, store them in a Kubernetes Secret and reference it from the chart. Create the namespace and the secret first -- the chart reads the secret while rendering, so it must exist before you install:
+   Rather than putting your storage credentials in the values file, store them in a Kubernetes Secret and reference it from the chart. Create the namespace and the secret first; the chart reads the secret while rendering, so it must exist before you install:
 
    ```bash
    kubectl create namespace union

--- a/content/deployment/selfmanaged/selfmanaged-generic/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-generic/deploy-dataplane.md
@@ -8,6 +8,9 @@ variants: -flyte +union
 
 If you have not yet set up the required resources (Kubernetes cluster, object storage, container registry, credentials), see [Prepare infrastructure](../selfmanaged-generic/prepare-infra) first.
 
+> [!NOTE] Planning more than one cluster?
+> This page covers the single-cluster path: one cluster in the `default` cluster pool, as created by the `flyte create cluster ... --pool default` command below. If you plan to connect several clusters to the same control plane, read [Multiple clusters](../configuration/multi-cluster) first. Pool membership governs metadata sharing -- clusters in the same pool share one metadata bucket, and clusters in different pools must use different ones -- so it affects the metadata bucket you configure below.
+
 ## Assumptions
 
 * You have a {{< key product_name >}} organization, and you know the control plane URL for your organization (e.g. `https://your-org-name.us-east-2.unionai.cloud`).

--- a/content/deployment/selfmanaged/selfmanaged-generic/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-generic/deploy-dataplane.md
@@ -102,7 +102,7 @@ If you have not yet set up the required resources (Kubernetes cluster, object st
      --set-string secrets.admin.clientId=<CLIENT_ID> \
      --set secrets.admin.clientSecret=<CLIENT_SECRET> \
      --namespace union \
-     --create-namespace \
+     --create-namespace 
    ```
 
 6. Once deployed you can check to see if the cluster has been successfully registered to the control plane:

--- a/content/deployment/selfmanaged/selfmanaged-generic/prepare-infra.md
+++ b/content/deployment/selfmanaged/selfmanaged-generic/prepare-infra.md
@@ -104,7 +104,7 @@ Note the registry URL (e.g. `registry.example.com:5000/union`); you will configu
 
 ## Identity & access
 
-On generic Kubernetes, Union authenticates to object storage and the container registry using static credentials (access key and secret key). These are configured in the generated values file during deployment.
+On generic Kubernetes, Union authenticates to object storage and the container registry using static credentials (access key and secret key). These are configured in the Helm values file during deployment.
 
 ### Storage credentials
 

--- a/content/deployment/selfmanaged/selfmanaged-nebius/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-nebius/deploy-dataplane.md
@@ -35,7 +35,7 @@ If you have not yet set up the required Nebius resources (MK8s cluster, Object S
 2. Configure the `flyte` CLI to talk to your control plane, then register the cluster name:
 
    ```bash
-   flyte create config --endpoint dns:///<ORG_NAME>.union.ai --org <ORG_NAME>
+   flyte create config --endpoint <ORG_NAME>.union.ai --org <ORG_NAME>
    flyte create cluster <CLUSTER_NAME> --pool default
    ```
 

--- a/content/deployment/selfmanaged/selfmanaged-nebius/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-nebius/deploy-dataplane.md
@@ -9,7 +9,7 @@ variants: -flyte +union
 If you have not yet set up the required Nebius resources (MK8s cluster, Object Storage bucket, service account, access key), see [Prepare infrastructure](../selfmanaged-nebius/prepare-infra) first.
 
 > [!NOTE] Planning more than one cluster?
-> This page covers the single-cluster path: one cluster in the `default` cluster pool, as created by the `flyte create cluster ... --pool default` command below. If you plan to connect several clusters to the same control plane, read [Multiple clusters](../configuration/multi-cluster) first. Pool membership governs metadata sharing -- clusters in the same pool share one metadata bucket, and clusters in different pools must use different ones -- so it affects the metadata bucket you configure below.
+> This page covers the single-cluster path: one cluster in the `default` cluster pool, as created by the `flyte create cluster ... --pool default` command below. If you plan to connect several clusters to the same control plane, read [Multiple clusters](../configuration/multi-cluster) first. Pool membership governs metadata sharing: clusters in the same pool share one metadata bucket, and clusters in different pools must use different ones, so it affects the metadata bucket you configure below.
 
 ## Assumptions
 
@@ -44,7 +44,7 @@ If you have not yet set up the required Nebius resources (MK8s cluster, Object S
 
    `flyte create config` writes `.flyte/config.yaml`. The first command that contacts the control plane opens a browser to authenticate you.
 
-   Register the cluster before you install the chart -- the data plane binds to this record when it starts. Every organization is provisioned with a `default` pool, so `--pool default` needs no extra setup.
+   Register the cluster before you install the chart: the data plane binds to this record when it starts. Every organization is provisioned with a `default` pool, so `--pool default` needs no extra setup.
 
 3. Configure the Union CLI and provision data plane resources:
 
@@ -53,7 +53,7 @@ If you have not yet set up the required Nebius resources (MK8s cluster, Object S
    uctl selfserve provision-dataplane-resources --clusterName <CLUSTER_NAME> --provider custom
    ```
 
-   The command outputs the client ID and client secret your data plane uses to communicate with Union's control plane. Save the secret that is displayed — Union does not store it, and it cannot be retrieved later.
+   The command outputs the client ID and client secret your data plane uses to communicate with Union's control plane. Save the secret that is displayed. Union does not store it, and it cannot be retrieved later.
 
 4. Create a values file for the data plane chart. Start from the base values file and layer your Nebius-specific storage configuration on top, replacing the placeholders with your actual credentials and settings:
 
@@ -61,7 +61,7 @@ If you have not yet set up the required Nebius resources (MK8s cluster, Object S
    curl -O https://raw.githubusercontent.com/unionai/helm-charts/main/charts/dataplane/values.yaml
    ```
 
-   Rather than putting your bucket access keys in the values file, store them in a Kubernetes Secret and reference it from the chart. Create the namespace and the secret first -- the chart reads the secret while rendering, so it must exist before you install:
+   Rather than putting your bucket access keys in the values file, store them in a Kubernetes Secret and reference it from the chart. Create the namespace and the secret first; the chart reads the secret while rendering, so it must exist before you install:
 
    ```bash
    kubectl create namespace union

--- a/content/deployment/selfmanaged/selfmanaged-nebius/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-nebius/deploy-dataplane.md
@@ -20,6 +20,7 @@ If you have not yet set up the required Nebius resources (MK8s cluster, Object S
 * Install [Helm 3](https://helm.sh/docs/intro/install/).
 * Install [uctl](../../../api-reference/uctl-cli/_index).
 * Install the [`flyte` CLI](../../../api-reference/flyte-cli) (used later to run a sample workflow).
+* Install the [`flyteplugins-union` plugin](../../../api-reference/flyte-cli#plugin-commands), which provides the `flyte get cluster` command: `pip install flyteplugins-union`.
 * Install the [Nebius CLI](https://docs.nebius.com/cli) and authenticate with `nebius profile create`.
 
 ## Deploy the {{< key product_name >}} operator
@@ -31,16 +32,42 @@ If you have not yet set up the required Nebius resources (MK8s cluster, Object S
    export KUBECONFIG=<PATH_TO_KUBECONFIG>
    ```
 
-2. Configure the Union CLI and provision data plane resources:
+2. Configure the `flyte` CLI to talk to your control plane, then register the cluster name:
+
+   ```bash
+   flyte create config --endpoint dns:///<ORG_NAME>.union.ai --org <ORG_NAME>
+   flyte create cluster <CLUSTER_NAME> --pool default
+   ```
+
+   `flyte create config` writes `.flyte/config.yaml`. The first command that contacts the control plane opens a browser to authenticate you.
+
+   Register the cluster before you install the chart -- the data plane binds to this record when it starts. Every organization is provisioned with a `default` pool, so `--pool default` needs no extra setup.
+
+3. Configure the Union CLI and provision data plane resources:
 
    ```bash
    uctl config init --host=<ORG_NAME>.union.ai
    uctl selfserve provision-dataplane-resources --clusterName <CLUSTER_NAME> --provider custom
    ```
 
-   The command generates a YAML values file specific to the `custom` provider, including the secrets necessary so your data plane can communicate with Union's control plane.
+   The command outputs the client ID and client secret your data plane uses to communicate with Union's control plane. Save the secret that is displayed — Union does not store it, and it cannot be retrieved later.
 
-3. Update the generated values file with your Nebius-specific storage configuration. Replace the placeholders with your actual credentials and settings.
+4. Create a values file for the data plane chart. Start from the base values file and layer your Nebius-specific storage configuration on top, replacing the placeholders with your actual credentials and settings:
+
+   ```bash
+   curl -O https://raw.githubusercontent.com/unionai/helm-charts/main/charts/dataplane/values.yaml
+   ```
+
+   Rather than putting your bucket access keys in the values file, store them in a Kubernetes Secret and reference it from the chart. Create the namespace and the secret first -- the chart reads the secret while rendering, so it must exist before you install:
+
+   ```bash
+   kubectl create namespace union
+   kubectl create secret generic storage-credentials -n union \
+     --from-literal=access_key_id=<YOUR_BUCKET_ACCESS_KEY> \
+     --from-literal=secret_key=<YOUR_BUCKET_SECRET_KEY>
+   ```
+
+   Then point the values file at that secret:
 
    ```yaml
    host: <ORG_NAME>.union.ai
@@ -49,41 +76,38 @@ If you have not yet set up the required Nebius resources (MK8s cluster, Object S
    provider: custom
 
    storage:
-     accessKey: <YOUR_BUCKET_ACCESS_KEY>
      bucketName: <YOUR_STORAGE_BUCKET_NAME>
      endpoint: https://storage.<REGION>.nebius.cloud
      fastRegistrationBucketName: <YOUR_STORAGE_BUCKET_NAME>
      provider: compat
      region: <REGION>
-     secretKey: <YOUR_BUCKET_SECRET_KEY>
-
-   secrets:
-     admin:
-       create: true
-       clientId: <CLIENT_ID>
-       clientSecret: <CLIENT_SECRET>
+     credentialsSecretRef:
+       name: storage-credentials
    ```
 
    > [!NOTE]
-   > The `uctl selfserve provision-dataplane-resources` command in step 2 generates the `<CLIENT_ID>` and `<CLIENT_SECRET>` values and feeds them into the values file. Don't modify them.
+   > The chart resolves the secret with a Helm `lookup`, which returns nothing during `helm template` or `--dry-run`. Those commands render the storage config without credentials; only a real install picks them up. If your secret uses different field names, set `credentialsSecretRef.accessKeyIdKey` and `credentialsSecretRef.secretKeyKey` to match.
 
-4. Add the {{< key product_name >}} Helm repo:
+5. Add the {{< key product_name >}} Helm repo:
 
    ```bash
    helm repo add unionai https://unionai.github.io/helm-charts/
    helm repo update
    ```
 
-5. Install the data plane. Replace `<PATH_TO_VALUES_FILE>` with the path to the Helm values file you customized in step 3.
+6. Install the data plane. Replace `<PATH_TO_VALUES_FILE>` with the path to the Helm values file you customized in step 4, and `<CLIENT_ID>` / `<CLIENT_SECRET>` with the credentials printed in step 3.
 
    ```bash
    helm upgrade --install unionai-dataplane unionai/dataplane \
      --namespace union --create-namespace \
      --values <PATH_TO_VALUES_FILE> \
+     --set-string global.AUTH_CLIENT_ID=<CLIENT_ID> \
+     --set secrets.admin.clientId=<CLIENT_ID> \
+     --set secrets.admin.clientSecret=<CLIENT_SECRET> \
      --timeout 10m
    ```
 
-6. Verify the pods are running:
+7. Verify the pods are running:
 
    ```bash
    kubectl get pods -n union
@@ -91,27 +115,19 @@ If you have not yet set up the required Nebius resources (MK8s cluster, Object S
 
    When the deployment succeeds, all pods show a `Running` status, including `union-operator-proxy`, `union-operator-buildkit`, and `executor`.
 
-7. Verify the cluster is registered with the control plane:
+8. Verify the cluster is registered with the control plane:
 
    ```bash
-   uctl get cluster
+   flyte get cluster
    ```
 
    The output is similar to the following:
 
    ```text
-   NAME            ORG       STATE          HEALTH
-   union-nebius    my-org    STATE_ENABLED  HEALTHY
+   Enabled Clusters
+   NAME            ORG       STATE     HEALTH
+   union-nebius    my-org    enabled   healthy
    ```
-
-8. **Required for helm charts on a version <= 2026.5.8.** Create an API key for your organization. This is required for v2 workflow executions on the data plane. If you have already created one, rerun the same command to propagate the key to the new cluster:
-
-   ```bash
-   uctl create apikey --keyName EAGER_API_KEY --org <ORG_NAME>
-   ```
-
-   > [!NOTE]
-   > If you receive a `PermissionDenied` error, contact [Union.ai support](https://www.union.ai/) to have the permission enabled for your organization.
 
 ## GPU node configuration (Nebius-specific)
 

--- a/content/deployment/selfmanaged/selfmanaged-nebius/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-nebius/deploy-dataplane.md
@@ -8,6 +8,9 @@ variants: -flyte +union
 
 If you have not yet set up the required Nebius resources (MK8s cluster, Object Storage bucket, service account, access key), see [Prepare infrastructure](../selfmanaged-nebius/prepare-infra) first.
 
+> [!NOTE] Planning more than one cluster?
+> This page covers the single-cluster path: one cluster in the `default` cluster pool, as created by the `flyte create cluster ... --pool default` command below. If you plan to connect several clusters to the same control plane, read [Multiple clusters](../configuration/multi-cluster) first. Pool membership governs metadata sharing -- clusters in the same pool share one metadata bucket, and clusters in different pools must use different ones -- so it affects the metadata bucket you configure below.
+
 ## Assumptions
 
 * You have a {{< key product_name >}} organization, and you know the control plane URL for your organization.

--- a/content/deployment/selfmanaged/selfmanaged-oci/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-oci/deploy-dataplane.md
@@ -8,6 +8,9 @@ variants: -flyte +union
 
 If you have not yet set up the required OCI resources (OKE cluster, Object Storage, Container Registry, IAM access), see [Prepare infrastructure](../selfmanaged-oci/prepare-infra) first.
 
+> [!NOTE] Planning more than one cluster?
+> This page covers the single-cluster path: one cluster in the `default` cluster pool, as created by the `flyte create cluster ... --pool default` command below. If you plan to connect several clusters to the same control plane, read [Multiple clusters](../configuration/multi-cluster) first. Pool membership governs metadata sharing -- clusters in the same pool share one metadata bucket, and clusters in different pools must use different ones -- so it affects the metadata bucket you configure below.
+
 ## Assumptions
 
 * You have a {{< key product_name >}} organization, and you know the control plane URL for your organization.

--- a/content/deployment/selfmanaged/selfmanaged-oci/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-oci/deploy-dataplane.md
@@ -79,7 +79,7 @@ If you have not yet set up the required OCI resources (OKE cluster, Object Stora
      --set-string secrets.admin.clientId=<CLIENT_ID> \
      --set secrets.admin.clientSecret=<CLIENT_SECRET> \
      --namespace union \
-     --create-namespace \
+     --create-namespace 
      --force-conflicts
    ```
 

--- a/content/deployment/selfmanaged/selfmanaged-oci/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-oci/deploy-dataplane.md
@@ -20,6 +20,8 @@ If you have not yet set up the required OCI resources (OKE cluster, Object Stora
 
 * Install [Helm 3](https://helm.sh/docs/intro/install/).
 * Install [uctl](../../../api-reference/uctl-cli/_index).
+* Install the [`flyte` CLI](../../../api-reference/flyte-cli).
+* Install the [`flyteplugins-union` plugin](../../../api-reference/flyte-cli#plugin-commands), which provides the `flyte get cluster` command: `pip install flyteplugins-union`.
 
 ## Deploy the {{< key product_name >}} operator
 
@@ -30,7 +32,18 @@ If you have not yet set up the required OCI resources (OKE cluster, Object Stora
    helm repo update
    ```
 
-2. Use the `uctl selfserve provision-dataplane-resources` command to generate a new client and client secret for communicating with your Union control plane, provision authorization permissions for the app to operate on the union cluster name you have selected, generate values file to install dataplane in your Kubernetes cluster and provide follow-up instructions:
+2. Configure the `flyte` CLI to talk to your control plane, then register the cluster name:
+
+   ```bash
+   flyte create config --endpoint dns:///<YOUR_UNION_CONTROL_PLANE_URL> --org <YOUR_ORG_NAME>
+   flyte create cluster <YOUR_SELECTED_CLUSTERNAME> --pool default
+   ```
+
+   `flyte create config` writes `.flyte/config.yaml`. The first command that contacts the control plane opens a browser to authenticate you.
+
+   Register the cluster before you install the chart -- the data plane binds to this record when it starts. Every organization is provisioned with a `default` pool, so `--pool default` needs no extra setup.
+
+3. Use the `uctl selfserve provision-dataplane-resources` command to generate a new client and client secret for communicating with your Union control plane, provision authorization permissions for the app to operate on the union cluster name you have selected, and provide follow-up instructions:
 
    ```bash
    uctl config init --host=<YOUR_UNION_CONTROL_PLANE_URL>
@@ -38,42 +51,50 @@ If you have not yet set up the required OCI resources (OKE cluster, Object Stora
    ```
 
    * The command will output the ID, name, and a secret that will be used by the Union services to communicate with your control plane.
-     It will also generate a YAML file specific to the provider that you specify, in this case `oci`.
+     You will pass the client ID and client secret to the Helm chart in step 5.
 
-   * Save the secret that is displayed. Union does not store the credentials; rerunning the same command can be used to retrieve the secret later.
+   * Save the secret that is displayed. Union does not store it, and it cannot be retrieved later.
 
-3. Update the generated values file with your infrastructure details:
+4. Download the base values file for the data plane chart and fill in your infrastructure details:
 
+   ```bash
+   curl -O https://raw.githubusercontent.com/unionai/helm-charts/main/charts/dataplane/values.yaml
+   ```
+
+   There is no published OCI overlay, so start from the base values file and set the OCI-specific keys on top of it:
+
+   - Set `global.UNION_CONTROL_PLANE_HOST` and `global.CONTROLPLANE_HOST` to your control plane hostname (no scheme, no port).
+   - Set `global.CLUSTER_NAME` to the cluster name you registered in step 2.
+   - Set `global.ORG_NAME` to your organization name.
    - Set `storage.bucketName` and `storage.fastRegistrationBucketName` to your Object Storage bucket name(s).
    - Set `storage.region` to your OCI region.
    - If using static credentials (Option B), set `storage.accessKey` and `storage.secretKey` to your S3 Compatibility API credentials.
 
-4. Install the data plane Helm chart:
+5. Install the data plane Helm chart, passing the client ID and client secret from step 3:
 
    ```bash
    helm upgrade --install union unionai/dataplane \
-     -f <GENERATED_VALUES_FILE> \
+     -f values.yaml \
+     --set global.AUTH_CLIENT_ID=<CLIENT_ID> \
+     --set-string secrets.admin.clientId=<CLIENT_ID> \
+     --set secrets.admin.clientSecret=<CLIENT_SECRET> \
      --namespace union \
      --create-namespace \
      --force-conflicts
    ```
 
-5. **Required for helm charts on a version <= 2026.5.8.** Create an API key for your organization. This is required for v2 workflow executions on the data plane. If you have already created one, rerun the same command to propagate the key to the new cluster:
-
-   ```bash
-   uctl create apikey --keyName EAGER_API_KEY --org <YOUR_ORG_NAME>
-   ```
-
 6. Once deployed you can check to see if the cluster has been successfully registered to the control plane:
 
    ```bash
-   uctl get cluster
-    ----------- ------- --------------- -----------
-   | NAME      | ORG   | STATE         | HEALTH    |
-    ----------- ------- --------------- -----------
-   | <cluster> | <org> | STATE_ENABLED | HEALTHY   |
-    ----------- ------- --------------- -----------
-   1 rows
+   flyte get cluster
+   ```
+
+   The command groups clusters by state. A successfully registered cluster appears under **Enabled Clusters**:
+
+   ```text
+   Enabled Clusters
+   NAME        ORG     STATE     HEALTH
+   <cluster>   <org>   enabled   healthy
    ```
 
 7. Follow the [Quickstart](../../../user-guide/quickstart) to run your first workflow and verify your cluster is working correctly.

--- a/content/deployment/selfmanaged/selfmanaged-oci/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-oci/deploy-dataplane.md
@@ -35,7 +35,7 @@ If you have not yet set up the required OCI resources (OKE cluster, Object Stora
 2. Configure the `flyte` CLI to talk to your control plane, then register the cluster name:
 
    ```bash
-   flyte create config --endpoint dns:///<YOUR_UNION_CONTROL_PLANE_URL> --org <YOUR_ORG_NAME>
+   flyte create config --endpoint <YOUR_UNION_CONTROL_PLANE_URL> --org <YOUR_ORG_NAME>
    flyte create cluster <YOUR_SELECTED_CLUSTERNAME> --pool default
    ```
 

--- a/content/deployment/selfmanaged/selfmanaged-oci/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-oci/deploy-dataplane.md
@@ -9,7 +9,7 @@ variants: -flyte +union
 If you have not yet set up the required OCI resources (OKE cluster, Object Storage, Container Registry, IAM access), see [Prepare infrastructure](../selfmanaged-oci/prepare-infra) first.
 
 > [!NOTE] Planning more than one cluster?
-> This page covers the single-cluster path: one cluster in the `default` cluster pool, as created by the `flyte create cluster ... --pool default` command below. If you plan to connect several clusters to the same control plane, read [Multiple clusters](../configuration/multi-cluster) first. Pool membership governs metadata sharing -- clusters in the same pool share one metadata bucket, and clusters in different pools must use different ones -- so it affects the metadata bucket you configure below.
+> This page covers the single-cluster path: one cluster in the `default` cluster pool, as created by the `flyte create cluster ... --pool default` command below. If you plan to connect several clusters to the same control plane, read [Multiple clusters](../configuration/multi-cluster) first. Pool membership governs metadata sharing: clusters in the same pool share one metadata bucket, and clusters in different pools must use different ones, so it affects the metadata bucket you configure below.
 
 ## Assumptions
 
@@ -44,7 +44,7 @@ If you have not yet set up the required OCI resources (OKE cluster, Object Stora
 
    `flyte create config` writes `.flyte/config.yaml`. The first command that contacts the control plane opens a browser to authenticate you.
 
-   Register the cluster before you install the chart -- the data plane binds to this record when it starts. Every organization is provisioned with a `default` pool, so `--pool default` needs no extra setup.
+   Register the cluster before you install the chart: the data plane binds to this record when it starts. Every organization is provisioned with a `default` pool, so `--pool default` needs no extra setup.
 
 3. Use the `uctl selfserve provision-dataplane-resources` command to generate a new client and client secret for communicating with your Union control plane, provision authorization permissions for the app to operate on the union cluster name you have selected, and provide follow-up instructions:
 
@@ -82,8 +82,7 @@ If you have not yet set up the required OCI resources (OKE cluster, Object Stora
      --set-string secrets.admin.clientId=<CLIENT_ID> \
      --set secrets.admin.clientSecret=<CLIENT_SECRET> \
      --namespace union \
-     --create-namespace 
-     --force-conflicts
+     --create-namespace
    ```
 
 6. Once deployed you can check to see if the cluster has been successfully registered to the control plane:

--- a/content/deployment/selfmanaged/selfmanaged-oci/prepare-infra.md
+++ b/content/deployment/selfmanaged/selfmanaged-oci/prepare-infra.md
@@ -141,4 +141,4 @@ oci iam customer-secret-key create \
 
 > [!NOTE] The command output contains the secret key value. Save it immediately; it cannot be retrieved again.
 
-You will configure these credentials in the generated values file during deployment (see step 3 in [Deploy the dataplane](../selfmanaged-oci/deploy-dataplane)).
+You will configure these credentials in the Helm values file during deployment (see step 3 in [Deploy the dataplane](../selfmanaged-oci/deploy-dataplane)).


### PR DESCRIPTION
Updating self managed setup docs so guidance is alligned with current product capabilities.

Changes include:

- Reducing `uctl` to the `selfserve` step
- Allign with the current "no generated values" approach
- Update some cloud-provider-specific instructions with recent findings from customer engagements
- Update with changes to EAGER API KEY process and queues