### PR TITLE
docs: self-hosted multi–data-plane task routing and connectivity

### DIFF
--- a/content/deployment/selfhosted/getting-started.md
+++ b/content/deployment/selfhosted/getting-started.md
@@ -398,9 +398,9 @@ The data plane operator self-registers with the control plane on first contact �
 
 1. Uses its existing OAuth client credentials (configured into the chart via `AUTH_CLIENT_ID` + secret) to authenticate to the control plane.
 2. The control plane's authorizer recognizes the identity (bound to the org admin policy at install time via the control plane chart's `services.authorizer.configMap.authorizer.bootstrap.serviceAccounts` block) and lazily creates the per-cluster authz Resource on the first `Heartbeat` and `UpdateStatus` call.
-3. On every `UpdateStatus` call, the operator reports a `connection_config` blob — the reachable host and TLS posture the control plane uses to dial this data plane, so it can reach a data plane in a separate cluster without a statically-configured endpoint.
+3. On every `UpdateStatus` call, the operator reports a `connection_config` blob — the host and TLS posture the control plane uses to dial this data plane back. The reported host **must be resolvable and network-reachable from the control plane**, because the control plane connects to it directly. When the planes run in **separate clusters**, this is the data plane's externally-reachable DNS name. When they **share a cluster**, use the data plane's cluster-local Service address — a local network name only the in-cluster control plane needs to reach — so the return path stays in-cluster instead of hairpinning out through a public ingress.
 
-For the third step to take effect, opt in and set the data plane's externally-reachable hostname in the chart's `updateStatus.connectionConfig` block:
+For the third step to take effect, opt in and set that host in the chart's `updateStatus.connectionConfig` block:
 
 ```yaml
 updateStatus:
@@ -408,10 +408,13 @@ updateStatus:
     # Opt in to self-reporting (off by default). Enable only on operator
     # images that support connection_config.
     enabled: true
-    # DP-reachable hostname the control plane should dial back to reach this
-    # data plane. The operator self-reports this bare host in every
-    # UpdateStatus call; the control plane (2026.7.0+) constructs the dial
-    # target (dns:///<host>:443) and reverse-proxy URL from it.
+    # Bare host the control plane dials back to reach this data plane. It must
+    # be resolvable and reachable FROM the control plane. The operator
+    # self-reports it in every UpdateStatus call; the control plane (2026.7.0+)
+    # builds the dial target (dns:///<host>:443) and reverse-proxy URL from it.
+    #   Separate clusters:  an externally-reachable DNS name (below).
+    #   Shared cluster:     the DP's cluster-local Service, e.g.
+    #     "dataplane-nginx-controller.<dataplane-namespace>.svc.cluster.local"
     host: "dp-1.internal.<your-tenant-domain>"
     # CP dials with plain HTTP/2 when true. Default false.
     insecure: false
@@ -420,7 +423,7 @@ updateStatus:
     insecureSkipVerify: false
 ```
 
-If `host` is left empty, the operator skips self-reporting and the control plane routes to its statically-configured data plane URL (the intra-cluster default).
+If `host` is left empty the operator skips self-reporting, and the control plane falls back to a statically-configured data plane endpoint (or routes via the control-plane Host header when none is set). Self-reporting applies to **both** topologies — a co-located data plane still reports a host, just a cluster-local one.
 
 For a control plane serving **multiple** data planes, also set the dataproxy `clusterSelector.type: direct` on the control-plane chart so it routes across data planes using these self-reports; the default `local` does single-data-plane self-resolution only. Once enabled, adding a further data plane needs no control plane re-deploy.
 
@@ -474,6 +477,16 @@ global:
 ```
 
 `QUEUE_GRPC_ENDPOINT` is the auth-less path task pods use for queue events (task pods don't carry OAuth credentials; see chart `MIGRATION.md`).
+
+The two globals above wire the **forward** path (DP→CP). The **reverse** path (CP→DP) — how the control plane dials the data plane back — comes from the data plane's self-reported host (see [Data plane self-registration](#data-plane-self-registration)). In a shared cluster, point that host at the data plane's cluster-local Service so the return path also stays in-cluster:
+
+```yaml
+updateStatus:
+  connectionConfig:
+    enabled: true
+    host: "dataplane-nginx-controller.<dataplane-namespace>.svc.cluster.local"
+    insecureSkipVerify: true   # the DP presents a self-signed cert in-cluster
+```
 
 See [Infrastructure requirements → Intra-cluster topology](./infrastructure-requirements#intra-cluster-topology) for the substrate trade-offs (shared etcd, shared node pools, migration path to split-cluster).
 

--- a/content/deployment/selfhosted/operations/_index.md
+++ b/content/deployment/selfhosted/operations/_index.md
@@ -14,6 +14,10 @@ Guides for operating a {{< key product_name >}} self-hosted deployment after ini
 Deploy workflows from CI/CD pipelines using non-interactive authentication
 {{< /link-card >}}
 
+{{< link-card target="./task-routing" icon="route" title="Task routing" >}}
+Configure cluster pools, queues, and per-project routing so tasks run on a data plane
+{{< /link-card >}}
+
 {{< link-card target="./troubleshooting" icon="life-buoy" title="Troubleshooting" >}}
 Diagnose common control plane, data plane, and cloud-binding issues
 {{< /link-card >}}

--- a/content/deployment/selfhosted/operations/task-routing.md
+++ b/content/deployment/selfhosted/operations/task-routing.md
@@ -1,0 +1,165 @@
+---
+title: Task routing
+weight: 3
+variants: -flyte +union
+---
+
+# Task routing
+
+After installing a {{< key product_name >}} self-hosted deployment, the control plane still needs to be told **which data plane runs a given project's tasks**. Until that routing exists, a submitted run has no queue to land on, and control-plane bootstrap jobs that build images fail with `no enabled cluster in pool`.
+
+This guide covers the queue model and the one-time steps to configure routing for each data plane. Perform them after the control plane and data plane are installed and healthy, and after the data plane has registered with the control plane.
+
+## The queue model
+
+Routing a task requires three constructs, created in order:
+
+1. A **cluster pool** — carries the object store, secret store, and image registry contract that tasks in the pool use.
+2. A **cluster** subscribed to that pool. Subscribing a cluster implicitly creates a **queue** of the same name.
+3. A **`run.default_queue`** setting on each `(project, domain)` pair, pointing at a queue.
+
+A run submitted for a `(project, domain)` resolves to its default queue, which resolves to the pool the queue is bound to, which resolves to an enabled, healthy cluster in that pool.
+
+The simplest topology — and the recommended default — is **one pool, one cluster, one queue per data plane, all sharing the data plane's name.** You then point each project's `run.default_queue` at the data plane that should run its tasks.
+
+> [!NOTE]
+> Configuration is **create-only and additive.** At present there is no supported way to rename, delete, or repoint a cluster pool, cluster, or queue — draining is gated server-side. Choose data plane and pool names deliberately, and treat every step below as adding routing, never reconciling it. See [Changing existing routing](#changing-existing-routing) for the operational escape hatch when you must repoint an already-configured environment.
+
+## Prerequisites
+
+- The `flyte` CLI is installed (`pip install flyte` or `uv pip install flyte`) and authenticated against your control plane. In CI, set `FLYTE_API_KEY` — see [CI/CD integration](./cicd).
+- The projects you intend to route already exist. The three base projects (`flytesnacks`, `system`, and `union-health-monitoring`) are always registered by the control plane. Register any additional project **before** routing it — routing an unregistered project fails.
+
+## Step 1: Create a cluster pool
+
+Describe the pool in a `cluster-pool.yaml`. `name` is the pool name (use the data plane's name); `config` binds the pool to the data plane's object store, secret store, and image registry.
+
+{{< tabs >}}
+{{< tab "AWS" >}}
+{{< markdown >}}
+
+```yaml
+name: my-data-plane
+config:
+  object_store_ref:
+    uri: s3://my-metadata-bucket
+    endpoint: ""
+  secret_store:
+    type: AWS_SECRETS_MANAGER
+    locator: us-east-2          # region
+  image_registry:
+    locator: <account>.dkr.ecr.us-east-2.amazonaws.com/my-images
+```
+
+{{< /markdown >}}
+{{< /tab >}}
+{{< tab "GCP" >}}
+{{< markdown >}}
+
+```yaml
+name: my-data-plane
+config:
+  object_store_ref:
+    uri: gs://my-metadata-bucket
+    endpoint: ""
+  secret_store:
+    type: GCP_SECRET_MANAGER
+    locator: my-gcp-project     # control plane project ID
+  image_registry:
+    locator: us-central1-docker.pkg.dev/my-gcp-project/my-images
+```
+
+{{< /markdown >}}
+{{< /tab >}}
+{{< /tabs >}}
+
+Create the pool:
+
+```shell
+flyte create cluster-pool my-data-plane --file cluster-pool.yaml
+```
+
+## Step 2: Create a cluster
+
+Subscribe a cluster to the pool. Use the same name for the cluster, the pool, and the resulting queue so routing is easy to reason about. Subscribing the cluster implicitly creates a queue of that name.
+
+```shell
+flyte create cluster my-data-plane --pool my-data-plane
+```
+
+## Step 3: Route projects to a queue
+
+Set `run.default_queue` for each `(project, domain)` pair. Put the target queue in a settings file and apply it per project and domain:
+
+```shell
+cat > settings.yaml <<'EOF'
+run.default_queue: my-data-plane
+EOF
+
+flyte edit settings --project flytesnacks --domain development --from-file settings.yaml
+```
+
+Repeat for every project and domain you want to route. A common baseline is to route the three base projects (`flytesnacks`, `system`, `union-health-monitoring`) across all three domains (`development`, `staging`, `production`) to your first data plane — that is enough for image-build bootstrap and end-to-end tests to run. Route additional projects to whichever data plane should run their tasks.
+
+Once routing is in place, submit a run and confirm it lands on the expected cluster.
+
+## Changing existing routing
+
+A cluster's pool binding and a queue's pool binding are **immutable through the API**. This is deliberate: it prevents work from being silently re-routed out from under running executions. Because configuration is create-only for the same reason, you cannot repoint an existing binding by re-running the steps above.
+
+You will hit this only on an environment that already accumulated a *different* pool topology — for example, a cluster or queue previously subscribed to a differently-named pool. The symptoms are:
+
+- On `flyte create cluster <name> --pool <name>`:
+  `cannot change cluster pool from "<old-pool>" to "<new-pool>"`.
+- On task routing or test runs:
+  `no enabled, healthy cluster in pool "<old-pool>"` — the queue still points at the old pool, which is now empty because the cluster moved.
+
+A fresh environment never hits this.
+
+### Repoint the bindings in the control-plane database
+
+Until a day-2 update command is available, repoint the bindings directly in the control-plane Postgres database. This bypasses the immutability guard on purpose — only do it on an environment you own, and only for clusters and queues with no in-flight work.
+
+The control-plane database is typically a private-network managed Postgres instance, so run a throwaway `psql` client **inside the cluster**. The connection host, database name, and user come from any control-plane pod that talks to the database (its mounted `config.yaml`); the password comes from the mounted database-password secret.
+
+```shell
+NS=<controlplane-namespace>
+
+kubectl -n "$NS" run pgclient --rm -i --restart=Never \
+  --image=postgres:16 \
+  --env="PGPASSWORD=$(kubectl -n "$NS" exec deploy/cluster -- cat /etc/db/pass.txt)" \
+  --command -- psql -h "<DB_HOST>" -U "<DB_USER>" -d "<DB_NAME>"
+```
+
+1. **Inspect** the current bindings (replace `<org>` with your organization / tenant):
+
+   ```sql
+   SELECT organization, name, cluster_pool_name, state, health
+     FROM clusters WHERE organization = '<org>' ORDER BY name;
+   SELECT organization, name, cluster_pool_name
+     FROM queues   WHERE organization = '<org>' ORDER BY name;
+   ```
+
+2. **Unpin the clusters.** Setting the existing pool to `NULL` skips the immutability check, so the next `flyte create cluster <name> --pool <name>` assigns the intended pool and runs its normal side effects:
+
+   ```sql
+   UPDATE clusters SET cluster_pool_name = NULL
+     WHERE organization = '<org>' AND name IN ('<cluster-a>', '<cluster-b>');
+   ```
+
+3. **Repoint the queues** to the intended pool (each data plane's queue → its own pool):
+
+   ```sql
+   UPDATE queues SET cluster_pool_name = '<data-plane>'
+     WHERE organization = '<org>' AND name = '<data-plane>';
+   ```
+
+4. **Flush the data proxy cache.** The data proxy caches the `(project, domain) → cluster pool` resolution for up to 30 minutes, so after fixing the database it keeps resolving the old (now-empty) pool until the cache expires. Restart it to re-resolve immediately:
+
+   ```shell
+   kubectl -n "$NS" rollout restart deploy/dataproxy
+   ```
+
+5. **Re-run** the configuration steps above. Pools, clusters, and queues that are already correct are tolerated; the previously failing create now succeeds.
+
+Stale pools and queues from the old topology are left in place — they are harmless once nothing routes to them.

--- a/content/deployment/selfhosted/operations/task-routing.md
+++ b/content/deployment/selfhosted/operations/task-routing.md
@@ -15,12 +15,12 @@ This guide covers the queue model and the one-time steps to configure routing fo
 Routing a task requires three constructs, created in order:
 
 1. A **cluster pool** — carries the object store, secret store, and image registry contract that tasks in the pool use.
-2. A **cluster** subscribed to that pool. Subscribing a cluster implicitly creates a **queue** of the same name.
+2. A **cluster** subscribed to that pool. Subscribing a cluster implicitly creates a **queue** that takes the cluster's name.
 3. A **`run.default_queue`** setting on each `(project, domain)` pair, pointing at a queue.
 
 A run submitted for a `(project, domain)` resolves to its default queue, which resolves to the pool the queue is bound to, which resolves to an enabled, healthy cluster in that pool.
 
-The simplest topology — and the recommended default — is **one pool, one cluster, one queue per data plane, all sharing the data plane's name.** You then point each project's `run.default_queue` at the data plane that should run its tasks.
+The simplest topology — and the recommended default — is **one pool, one cluster, one queue per data plane, reusing the data plane's name for all three.** Reusing the name is a readability convention, not a requirement: the pool name is independent of the cluster name, so a cluster can subscribe to any existing pool. You then point each project's `run.default_queue` at the data plane that should run its tasks.
 
 > [!NOTE]
 > Configuration is **create-only and additive.** At present there is no supported way to rename, delete, or repoint a cluster pool, cluster, or queue — draining is gated server-side. Choose data plane and pool names deliberately, and treat every step below as adding routing, never reconciling it. See [Changing existing routing](#changing-existing-routing) for the operational escape hatch when you must repoint an already-configured environment.
@@ -81,7 +81,7 @@ flyte create cluster-pool my-data-plane --file cluster-pool.yaml
 
 ## Step 2: Create a cluster
 
-Subscribe a cluster to the pool. Use the same name for the cluster, the pool, and the resulting queue so routing is easy to reason about. Subscribing the cluster implicitly creates a queue of that name.
+Subscribe a cluster to the pool. Subscribing the cluster implicitly creates a queue that takes the **cluster's** name. The `--pool` value just names an existing pool to subscribe to — it does not have to match the cluster name. Reusing the data plane's name for the cluster and pool (as below) keeps routing easy to reason about, but it isn't required.
 
 ```shell
 flyte create cluster my-data-plane --pool my-data-plane
@@ -118,7 +118,10 @@ A fresh environment never hits this.
 
 ### Repoint the bindings in the control-plane database
 
-Until a day-2 update command is available, repoint the bindings directly in the control-plane Postgres database. This bypasses the immutability guard on purpose — only do it on an environment you own, and only for clusters and queues with no in-flight work.
+> [!WARNING] Unsupported, destructive operation
+> Editing the control-plane database directly bypasses the API's immutability guard. It is **not a supported operation** and has **no guaranteed behavior for in-flight runs** — executions that are queued or running against an affected cluster or queue may be lost or misrouted. Only do this on an environment you own, only when the affected clusters and queues have no in-flight work, and take a database backup first. A supported day-2 update path is planned; wherever possible, prefer standing up a fresh, correctly-named topology instead.
+
+Until a day-2 update command is available, repoint the bindings directly in the control-plane Postgres database.
 
 The control-plane database is typically a private-network managed Postgres instance, so run a throwaway `psql` client **inside the cluster**. The connection host, database name, and user come from any control-plane pod that talks to the database (its mounted `config.yaml`); the password comes from the mounted database-password secret.
 


### PR DESCRIPTION
**Context.** A self-hosted control plane fans work out to one or more data planes. Two things must be configured for that to work, and neither was covered end-to-end in the self-hosted docs: **which data plane runs a given project's tasks** (routing), and **how the control plane reaches each data plane** (connectivity). This PR documents both.

**What this PR does.**

*Task routing* — adds `operations/task-routing.md`, a new Operations guide covering the queue model (cluster pool → cluster → queue → `run.default_queue`) and the one-time steps to route each project to a data plane with the `flyte` CLI, with AWS and GCP `cluster-pool.yaml` examples and the control-plane-DB escape hatch for repointing the immutable cluster/queue → pool bindings. Adds a link card on the operations index.

*Connectivity* — clarifies the data plane's self-reported connection in `getting-started.md`. The self-registration section framed `updateStatus.connectionConfig` as a separate-cluster feature and implied a co-located data plane leaves `host` empty; both are wrong. States the general rule — the reported host **must be resolvable and network-reachable from the control plane**, since the CP dials it directly — gives the split (external DNS) vs shared-cluster (cluster-local Service address) guidance, adds the reverse-path `connectionConfig` block to the intracluster-topology section (mirroring the existing forward-path block), and fixes the empty-host note. Verified against a live intra-cluster deployment where the CP resolves the DP's self-reported `…svc.cluster.local` host and reverse-proxies to it.

**Design notes.** Routing config is create-only and additive (no rename/delete/repoint through the API yet). `union`-variant only. Docs-only.

Stacked on #932 (self-hosted deployment docs) — the `operations/` section and `getting-started.md` are introduced there. Retargets to `main` once #932 lands. (Supersedes #1260, folded in here.)

## Test plan

- [x] Hugo `union` variant builds cleanly (~1600 pages, no errors/warnings).
- [x] `operations/task-routing/` renders — title, `flyte create` commands, both AWS/GCP config tabs; `route` icon card on the operations index.
- [x] `getting-started` renders the reachability rule, the reverse-path block, and the cluster-local host example; the `#data-plane-self-registration` cross-anchor resolves.