### PR TITLE
docsy(v2): note flyteplugins-union also provides `flyte create cluster` (self-managed prereqs)

### DIFF
--- a/content/deployment/selfmanaged/selfmanaged-aws/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-aws/deploy-dataplane.md
@@ -24,7 +24,7 @@ If you have not yet set up the required AWS resources (EKS cluster, S3, ECR, IAM
 * Install [Helm 3](https://helm.sh/docs/intro/install/).
 * Install [uctl](../../../api-reference/uctl-cli/_index).
 * Install the [`flyte` CLI](../../../api-reference/flyte-cli).
-* Install the [`flyteplugins-union` plugin](../../../api-reference/flyte-cli#plugin-commands), which provides the `flyte get cluster` command: `pip install flyteplugins-union`.
+* Install the [`flyteplugins-union` plugin](../../../api-reference/flyte-cli#plugin-commands), which provides the `flyte create cluster` and `flyte get cluster` commands: `pip install flyteplugins-union`.
 
 ## Deploy the {{< key product_name >}} operator
 

--- a/content/deployment/selfmanaged/selfmanaged-azure/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-azure/deploy-dataplane.md
@@ -24,7 +24,7 @@ If you have not yet set up the required Azure resources (AKS cluster, Storage Ac
 * Install [Helm 3](https://helm.sh/docs/intro/install/).
 * Install [uctl](../../../api-reference/uctl-cli/_index).
 * Install the [`flyte` CLI](../../../api-reference/flyte-cli).
-* Install the [`flyteplugins-union` plugin](../../../api-reference/flyte-cli#plugin-commands), which provides the `flyte get cluster` command: `pip install flyteplugins-union`.
+* Install the [`flyteplugins-union` plugin](../../../api-reference/flyte-cli#plugin-commands), which provides the `flyte create cluster` and `flyte get cluster` commands: `pip install flyteplugins-union`.
 
 ## Deploy the {{< key product_name >}} operator
 

--- a/content/deployment/selfmanaged/selfmanaged-coreweave/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-coreweave/deploy-dataplane.md
@@ -23,7 +23,7 @@ If you have not yet set up the required CoreWeave resources (CKS cluster, AI Obj
 * Install [Helm 3](https://helm.sh/docs/intro/install/).
 * Install [uctl](../../../api-reference/uctl-cli/_index).
 * Install the [`flyte` CLI](../../../api-reference/flyte-cli) (used later to run a sample workflow).
-* Install the [`flyteplugins-union` plugin](../../../api-reference/flyte-cli#plugin-commands), which provides the `flyte get cluster` command: `pip install flyteplugins-union`.
+* Install the [`flyteplugins-union` plugin](../../../api-reference/flyte-cli#plugin-commands), which provides the `flyte create cluster` and `flyte get cluster` commands: `pip install flyteplugins-union`.
 
 ## Deploy the {{< key product_name >}} operator
 

--- a/content/deployment/selfmanaged/selfmanaged-crusoe/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-crusoe/deploy-dataplane.md
@@ -23,7 +23,7 @@ If you have not yet set up the required Crusoe resources (CMK cluster, Cloud Sto
 * Install [Helm 3](https://helm.sh/docs/intro/install/).
 * Install [uctl](../../../api-reference/uctl-cli/_index).
 * Install the [`flyte` CLI](../../../api-reference/flyte-cli) (used later to run a sample workflow).
-* Install the [`flyteplugins-union` plugin](../../../api-reference/flyte-cli#plugin-commands), which provides the `flyte get cluster` command: `pip install flyteplugins-union`.
+* Install the [`flyteplugins-union` plugin](../../../api-reference/flyte-cli#plugin-commands), which provides the `flyte create cluster` and `flyte get cluster` commands: `pip install flyteplugins-union`.
 
 ## Deploy the {{< key product_name >}} operator
 

--- a/content/deployment/selfmanaged/selfmanaged-gcp/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-gcp/deploy-dataplane.md
@@ -24,7 +24,7 @@ If you have not yet set up the required GCP resources (GKE cluster, GCS, Artifac
 * Install [Helm 3](https://helm.sh/docs/intro/install/).
 * Install [uctl](../../../api-reference/uctl-cli/_index).
 * Install the [`flyte` CLI](../../../api-reference/flyte-cli).
-* Install the [`flyteplugins-union` plugin](../../../api-reference/flyte-cli#plugin-commands), which provides the `flyte get cluster` command: `pip install flyteplugins-union`.
+* Install the [`flyteplugins-union` plugin](../../../api-reference/flyte-cli#plugin-commands), which provides the `flyte create cluster` and `flyte get cluster` commands: `pip install flyteplugins-union`.
 
 ## Deploy the {{< key product_name >}} operator
 

--- a/content/deployment/selfmanaged/selfmanaged-generic/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-generic/deploy-dataplane.md
@@ -24,7 +24,7 @@ If you have not yet set up the required resources (Kubernetes cluster, object st
 * Install [Helm 3](https://helm.sh/docs/intro/install/).
 * Install [uctl](../../../api-reference/uctl-cli/_index).
 * Install the [`flyte` CLI](../../../api-reference/flyte-cli).
-* Install the [`flyteplugins-union` plugin](../../../api-reference/flyte-cli#plugin-commands), which provides the `flyte get cluster` command: `pip install flyteplugins-union`.
+* Install the [`flyteplugins-union` plugin](../../../api-reference/flyte-cli#plugin-commands), which provides the `flyte create cluster` and `flyte get cluster` commands: `pip install flyteplugins-union`.
 
 ## Deploy the {{< key product_name >}} operator
 

--- a/content/deployment/selfmanaged/selfmanaged-nebius/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-nebius/deploy-dataplane.md
@@ -23,7 +23,7 @@ If you have not yet set up the required Nebius resources (MK8s cluster, Object S
 * Install [Helm 3](https://helm.sh/docs/intro/install/).
 * Install [uctl](../../../api-reference/uctl-cli/_index).
 * Install the [`flyte` CLI](../../../api-reference/flyte-cli) (used later to run a sample workflow).
-* Install the [`flyteplugins-union` plugin](../../../api-reference/flyte-cli#plugin-commands), which provides the `flyte get cluster` command: `pip install flyteplugins-union`.
+* Install the [`flyteplugins-union` plugin](../../../api-reference/flyte-cli#plugin-commands), which provides the `flyte create cluster` and `flyte get cluster` commands: `pip install flyteplugins-union`.
 * Install the [Nebius CLI](https://docs.nebius.com/cli) and authenticate with `nebius profile create`.
 
 ## Deploy the {{< key product_name >}} operator

--- a/content/deployment/selfmanaged/selfmanaged-oci/deploy-dataplane.md
+++ b/content/deployment/selfmanaged/selfmanaged-oci/deploy-dataplane.md
@@ -24,7 +24,7 @@ If you have not yet set up the required OCI resources (OKE cluster, Object Stora
 * Install [Helm 3](https://helm.sh/docs/intro/install/).
 * Install [uctl](../../../api-reference/uctl-cli/_index).
 * Install the [`flyte` CLI](../../../api-reference/flyte-cli).
-* Install the [`flyteplugins-union` plugin](../../../api-reference/flyte-cli#plugin-commands), which provides the `flyte get cluster` command: `pip install flyteplugins-union`.
+* Install the [`flyteplugins-union` plugin](../../../api-reference/flyte-cli#plugin-commands), which provides the `flyte create cluster` and `flyte get cluster` commands: `pip install flyteplugins-union`.
 
 ## Deploy the {{< key product_name >}} operator
 


### PR DESCRIPTION
Follow-up to the merged **#1253** (self-managed setup doc updates).

## What
The self-managed `deploy-dataplane` prerequisites credit the `flyteplugins-union` plugin only with `flyte get cluster`, but the cluster-registration step that runs first — `flyte create cluster ... --pool default` — is **also** provided by that plugin (not the flyte-sdk core CLI). Updated the prereq line on all 8 provider pages to name both commands.

## Why / verification
Confirmed against `flyteplugins-union` `origin/main` (the on-PyPI plugin, not the flyte-sdk core CLI):
- `src/flyteplugins/union/cli/cluster.py` → `create_cluster` command (`--pool` → `cluster_pool_name`)
- `src/flyteplugins/union/remote/_cluster.py` → `Cluster.create(name, *, cluster_pool_name="")` — `--pool` is optional.

So a reader who installs the plugin "for `get cluster`" actually needs it for the earlier `create cluster` step too.

## Scope
One-line wording change × 8 pages (aws, azure, coreweave, crusoe, gcp, generic, nebius, oci). No structural/nav changes.

Tracked in DOC-1283 (the docs-owner review of #1253). Draft — human disposes the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)