### PR TITLE
docsy(v2): hide "Try Flyte 2 in your browser" callouts (demo link dead)

### DIFF
--- a/content/user-guide/quickstart.md
+++ b/content/user-guide/quickstart.md
@@ -8,9 +8,13 @@ variants: +flyte +union
 
 Let's get you up and running with your first workflow on your local machine.
 
-{{< note >}}
-Want to try Flyte without installing anything? [Try Flyte 2 in your browser](https://flyte2intro.apps.demo.hosted.unionai.cloud/).
-{{< /note >}}
+<!--
+Hidden until the in-browser demo is repaired. The linked demo
+(https://flyte2intro.apps.demo.hosted.unionai.cloud/) is currently unreachable.
+To restore: re-add a note callout reading "Want to try Flyte without installing
+anything? Try Flyte 2 in your browser" linking to the demo URL once it is live.
+-->
+
 
 ## What you'll need
 

--- a/content/user-guide/run-modes/running-remote.md
+++ b/content/user-guide/run-modes/running-remote.md
@@ -8,9 +8,13 @@ variants: +flyte +union
 
 This guide covers setting up your local development environment and configuring the `flyte` CLI and SDK to connect to your {{< key product_name >}} instance.
 
-{{< note >}}
-Want to try Flyte without installing anything? [Try Flyte 2 in your browser](https://flyte2intro.apps.demo.hosted.unionai.cloud/).
-{{< /note >}}
+<!--
+Hidden until the in-browser demo is repaired. The linked demo
+(https://flyte2intro.apps.demo.hosted.unionai.cloud/) is currently unreachable.
+To restore: re-add a note callout reading "Want to try Flyte without installing
+anything? Try Flyte 2 in your browser" linking to the demo URL once it is live.
+-->
+
 
 ## Prerequisites
 


### PR DESCRIPTION
## Why

The in-browser demo at `https://flyte2intro.apps.demo.hosted.unionai.cloud/` is currently **unreachable** (connection fails). Two note callouts link to it and now dead-end:

- `content/user-guide/quickstart.md`
- `content/user-guide/run-modes/running-remote.md`

Both read: "Want to try Flyte without installing anything? [Try Flyte 2 in your browser](…)".

## Change

Hide both callouts until the demo is repaired. Each `{{< note >}}` block is replaced with an **inert HTML comment** documenting exactly what to restore (Hugo processes shortcodes even inside HTML comments, so the live `note` syntax is removed rather than commented, to guarantee it doesn't render).

## Restore

When the demo is live again, re-add to each file:

```
{{< note >}}
Want to try Flyte without installing anything? [Try Flyte 2 in your browser](https://flyte2intro.apps.demo.hosted.unionai.cloud/).
{{< /note >}}
```

Temporary hide, not a deletion of intent — the repair is owned by the demo/infra side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)