### PR TITLE
docsy(v1): mirror the docs-versioning apparatus (inert, aligned with main)

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -23,8 +23,10 @@ on:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
 
+# contents: write — the one-merge cut (DOC-1245) materializes + pushes the stable
+# tag named by versions.toml as a pre-build step (mirrors main; inert without one).
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 # Opt in early to the Node.js 24 runtime for JavaScript actions. GitHub forces
@@ -59,7 +61,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          fetch-depth: 1
+          # 0 (was 1): the multi-version assembly + cut checkout tags + v1 into
+          # isolated worktrees, so it needs full history + all tags.
+          fetch-depth: 0
 
       - name: Set up Hugo
         uses: peaceiris/actions-hugo@v3
@@ -83,10 +87,42 @@ jobs:
           uv --version
           echo "::endgroup::"
 
+      # One-merge cut (DOC-1245), mirrored from main: versions.toml names the stable
+      # tag /docs/v1 serves. If it doesn't exist yet, THIS merge is the promotion —
+      # materialize it (guarded) BEFORE the build, so the v1 line assembles from it in
+      # the same job (no cut↔deploy race). Inert until versioning go-live (no
+      # versions.toml → skipped), so v1 stays a single static build until then.
+      - name: Materialize stable tag if needed (cut)
+        if: github.event_name == 'push'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_ROOT: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          if [ ! -f versions.toml ]; then
+            echo "no versions.toml → versioning off; skip cut"; exit 0
+          fi
+          STABLE=$(sed -n 's/^stable *= *"\(.*\)"/\1/p' versions.toml | head -1)
+          if [ -z "$STABLE" ]; then echo "versions.toml has no stable → skip"; exit 0; fi
+          if git rev-parse -q --verify "refs/tags/$STABLE" >/dev/null; then
+            echo "stable tag $STABLE already cut → no-op"; exit 0
+          fi
+          echo "stable $STABLE not yet cut → materializing at this merge"
+          bash unionai-docs-infra/scripts/cut-docs-version.sh --push
+
       - name: Build dist
         run: |
           start=$(date +%s)
-          make dist
+          # Docs versioning (DOC-1245): when versions.toml is present, assemble the
+          # multi-version dist for the v1 line; else the single-version build. Inert
+          # (no-op) until versions.toml is added, so merging this is safe on frozen v1.
+          if [ -f versions.toml ]; then
+            echo "versions.toml present -> multi-version assembly"
+            LATEST_REF=origin/v1 bash unionai-docs-infra/scripts/build_versions.sh
+          else
+            echo "no versions.toml -> single-version build (current behavior)"
+            make dist
+          fi
           echo "BUILD_SECONDS=$(( $(date +%s) - start ))" >> "$GITHUB_ENV"
 
       - name: Emit build provenance

--- a/.github/workflows/docs-cut.yml
+++ b/.github/workflows/docs-cut.yml
@@ -1,0 +1,127 @@
+name: "Cut docs version"
+
+# Propose a manual docs-version cut (DOC-1245, prds docs_versioning §9.4).
+#
+# One-merge model: a cut is materialized at MERGE by build-and-deploy (which mints
+# the tag named by versions.toml). So this workflow does NOT tag directly — it opens
+# a draft PR that bumps versions.toml to the next version, for a human to merge.
+# Two symmetric "buttons" produce the same shape (a versions.toml-bump PR):
+#
+#   * flyte-sdk release (automatic) — regen-api-docs.yml folds the promote into its
+#     regen PR (a new v1.x.y.0). Handled there, not here.
+#   * manual cut (this workflow)    — a maintainer clicks "Run workflow" to cut
+#     v1.x.y.(z+1) when enough non-SDK change has accumulated with no SDK release.
+#
+# Manual cut = two steps: (1) click Run workflow → this opens the versions.toml PR;
+# (2) merge it → build-and-deploy mints the tag + rebuilds /docs/v1.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Resolve + print the next version only; do not open a PR."
+        type: boolean
+        default: false
+
+concurrency:
+  # Serialize so two dispatches can't open competing versions.toml PRs.
+  group: docs-cut
+  cancel-in-progress: false
+
+permissions:
+  contents: write        # push the PR branch
+  pull-requests: write   # open the draft PR
+
+jobs:
+  cut:
+    name: "Propose a docs-version cut"
+    runs-on: ubuntu-latest
+    # Job-level env so the App id is referenceable in step `if:` (secrets aren't).
+    env:
+      DOCSY_BOT_APP_ID: ${{ secrets.DOCSY_BOT_APP_ID }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true   # need unionai-docs-infra (the resolver tool)
+          fetch-depth: 0     # need all tags for the z computation
+
+      # Mint a docsy-bot App token so the PR triggers CI (PRs opened by the default
+      # GITHUB_TOKEN do not). Falls back to GITHUB_TOKEN when the App isn't configured.
+      - name: Mint docsy-bot App token
+        id: app-token
+        if: ${{ env.DOCSY_BOT_APP_ID != '' }}
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.DOCSY_BOT_APP_ID }}
+          private-key: ${{ secrets.DOCSY_BOT_PRIVATE_KEY }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Resolve next version
+        id: resolve
+        env:
+          # The flyte-variant backend version is read from flyteorg/flyte releases.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_ROOT: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          eval "$(uv run --quiet unionai-docs-infra/tools/api_generator/manifest.py --check --format shell)"
+          echo "tag=${DOCS_TAG}" >> "$GITHUB_OUTPUT"
+          echo "kind=${DOCS_CUT_KIND}" >> "$GITHUB_OUTPUT"
+          echo "on_pypi=${DOCS_SDK_ON_PYPI}" >> "$GITHUB_OUTPUT"
+          echo "Next cut: ${DOCS_TAG} (${DOCS_CUT_KIND}, sdk=${DOCS_SDK}, on_pypi=${DOCS_SDK_ON_PYPI})"
+
+      - name: Dry run — stop before opening a PR
+        if: ${{ inputs.dry_run }}
+        run: |
+          echo "dry_run: would open a PR bumping versions.toml to ${{ steps.resolve.outputs.tag }}."
+          echo "Re-run without dry_run to open it."
+
+      - name: Promote into versions.toml
+        if: ${{ ! inputs.dry_run }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_ROOT: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          # --promote refuses a non-PyPI SDK version (guarded), then writes versions.toml.
+          uv run --quiet unionai-docs-infra/tools/api_generator/manifest.py --promote
+
+      - name: Build PR body
+        if: ${{ ! inputs.dry_run }}
+        run: |
+          {
+            echo "## Manual docs-version cut → \`${{ steps.resolve.outputs.tag }}\`"
+            echo ""
+            echo "Bumps \`versions.toml\` to promote a new docs version (\`${{ steps.resolve.outputs.kind }}\` cut). Merging this **is** the cut: \`build-and-deploy\` mints the tag \`${{ steps.resolve.outputs.tag }}\` at merge and rebuilds \`/docs/v1\` (stable) + the pinned \`/docs/${{ steps.resolve.outputs.tag }}/\` copy."
+            echo ""
+            echo "Triggered manually (\`workflow_dispatch\`). Left as a **draft** for review (agent proposes; human disposes)."
+            echo ""
+            echo "> If checks aren't running, the docsy-bot App isn't configured — set \`DOCSY_BOT_APP_ID\` + \`DOCSY_BOT_PRIVATE_KEY\` (PRs opened by GITHUB_TOKEN do not trigger workflows)."
+          } > /tmp/pr-body.md
+
+      - name: Open draft PR
+        if: ${{ ! inputs.dry_run }}
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+          branch: docsy/v1-cut-${{ steps.resolve.outputs.tag }}
+          base: v1
+          draft: true
+          add-paths: versions.toml
+          commit-message: "docs: cut ${{ steps.resolve.outputs.tag }} (promote versions.toml)"
+          # DCO: "Check DCO" is required on main — the bot commit must sign off.
+          author: "unionai-docsy-bot[bot] <295918299+unionai-docsy-bot[bot]@users.noreply.github.com>"
+          committer: "unionai-docsy-bot[bot] <295918299+unionai-docsy-bot[bot]@users.noreply.github.com>"
+          signoff: true
+          title: "docsy(v1): cut ${{ steps.resolve.outputs.tag }}"
+          body-path: /tmp/pr-body.md
+          labels: docsy
+          delete-branch: true

--- a/api-packages.toml
+++ b/api-packages.toml
@@ -316,3 +316,16 @@ plugin = "flytekitplugins.whylogs"
 title = "whylogs"
 name = "whylogs"
 frozen = true
+
+# === Docs versioning (DOC-1245) ===
+# Point the shared docs-version resolver (unionai-docs-infra manifest.py) at the v1
+# line's packages. Without this section (as on main/v2) the resolver defaults to
+# flyte / flyteplugins-union / the v2.0.x backend. Here the SDK is flytekit (1.x), so
+# the docs version is v1.x.y.z; the independently-versioned passenger is the union SDK.
+[docs_version]
+sdk_package = "flytekit"
+sdk_label = "flytekit"
+passenger_package = "union"
+passenger_label = "union"
+backend_repo = "flyteorg/flyte"
+backend_series = "v1."


### PR DESCRIPTION
Mirrors the DOC-1245 versioning machinery onto the **v1** line, plus the v1-specific config so it can **function if ever turned on** — while staying a single static build until a deliberate go-live (everything is gated on `versions.toml`, which is **not** committed, exactly like main).

## What's here
- **`api-packages.toml` `[docs_version]`** — points the shared resolver at the v1 line's packages: SDK **flytekit** (so the docs version is `v1.x.y.z`), passenger the **union** SDK, backend `flyteorg/flyte` v1.x. Without this section the resolver defaults to v2's `flyte`.
- **`docs-cut.yml`** — manual-cut dispatch (opens a `versions.toml`-bump PR), mirrored from main with v1 branch/base/title.
- **`build-and-deploy.yml`** — cut pre-step (materialize the stable tag at merge) + feature-gated multi-version assembly (`LATEST_REF=origin/v1`); `contents: write`; `fetch-depth: 0`. Falls back to `make dist` without `versions.toml`.

## Not mirrored (deliberate)
- **`regen-api-docs` / SDK-release auto-cut** — v1 is frozen content, so only the manual-cut path applies.
- **Infra submodule pointer bump** — follows with main's (the shared `unionai-docs-infra` resolver/display changes live in infra#161/#162).

## Verified locally against the v1 tree
- Resolver computes **`v1.16.23.0`** (flytekit 1.16.23; PyPI guard passes).
- A full v1 build renders the **footer** (`flytekit 1.16.23 · union 0.1.203`), the cross-line **selector**, and correct **noindex** (`/docs/v1` indexed, pinned noindex).

Depends on the shared infra (infra#161 resolver branch-awareness, infra#162 display) — inert until those merge + the pointer bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)