### PR TITLE
docsy(v2): enable docs versioning (add versions.toml + go-live infra bump)

### DIFF
--- a/versions.toml
+++ b/versions.toml
@@ -1,0 +1,3 @@
+stable = "v2.5.12.0"
+enumerated = [
+]


### PR DESCRIPTION
## DOC-1245 go-live — v2 line

Enables docs versioning on the **v2** line by adding `versions.toml` and bumping `unionai-docs-infra` to the merged go-live commit (`af86078`: line-aware `build_versions` #167 + flat selector/dedup/badges #168).

**What merging this does** (build-and-deploy on `main`, push event):
1. **Cut step runs** → materializes the `v2.5.12.0` tag at this commit (pre-flight resolver confirmed `main` resolves to `v2.5.12.0`).
2. `build_versions` assembles the multi-version dist: `/docs/latest` (main tip, **noindex**) + `/docs/v2` (stable `2.5.12.0`, **indexed**).
3. Deploys to **prod** (`--branch=main`).

**User-visible change:** `/docs/v2` content flips from main-tip to the stable tag; `/docs/latest` appears; the version selector shows 3 entries (`v2`: LATEST, `2.5.12.0` STABLE; `v1`: `1.16.23.0`).

Validated end-to-end on a CF Pages staging preview (both lines) before this merge. Companion v1 go-live follows on the `v1` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
