### PR TITLE
docsy(v1): enable docs versioning (add versions.toml + go-live infra bump)

### DIFF
--- a/versions.toml
+++ b/versions.toml
@@ -1,0 +1,4 @@
+stable = "v1.16.23.0"
+enumerated = [
+]
+latest = false


### PR DESCRIPTION
## DOC-1245 go-live — v1 line

Enables docs versioning on the **v1** line (symmetric to the already-live v2 go-live, #1279). Adds `versions.toml` and bumps `unionai-docs-infra` to the go-live commit (`af86078`).

**What merging this does** (build-and-deploy on `v1`, push event):
1. **Cut `v1.16.23.0`** (pre-flight resolver confirmed `v1` resolves to it).
2. `build_versions` (line-aware) assembles **`/docs/v1`** (stable `1.16.23.0`, indexed) — **no `/docs/latest`** (`latest=false`; that URL is v2's).
3. Deploys to the **v1 deployment**.

**Result:** `/docs/v1` pages get the flat version selector; closed state reads `v1 1.16.23.0` (bare number, no STABLE badge — deliberate de-emphasis of the legacy line). Cross-line nav works via CloudFront (`/docs/v1*` → v1 deployment). v1 stays indexed for now (DOC-1291 to noindex later).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
