### PR TITLE
docsy(v1): sync PR-preview CI with main (build-pr + deploy-pr-preview split)

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -5,22 +5,20 @@ name: Build and deploy docs
 # Replaces CF Pages' native build runner — CF Pages stays only as the
 # static host.
 #
+# Production-only path (mirrors main). PR previews are handled by the two-stage
+# pair `build-pr.yml` (untrusted build, no secrets) + `deploy-pr-preview.yml`
+# (trusted workflow_run deploy, has secrets), because GitHub does NOT expose repo
+# secrets to pull_request workflows triggered from forks. See DOC-1228.
+#
 # Triggers:
-#   - push to v1 — production deploy (project=docs, --branch=v1).
-#     This is the prod path; CF auto-deploys on the `docs` project are
-#     disabled, so GHA owns prod end-to-end.
-#   - pull_request — branch deploy to the `docs` project. Each PR gets
-#     a preview at <sanitized-branch>.docs-dog.pages.dev, identical to
-#     what CF Pages' bot used to produce. Sticky comment posts the URL.
-#   - workflow_dispatch — manual run; redeploys whatever commit the branch
-#     is at to the docs project (useful for re-runs after a flake).
+#   - push to v1 — production deploy (project=docs, --branch=v1). The prod path;
+#     CF auto-deploys are disabled, so GHA owns prod end-to-end.
+#   - workflow_dispatch — manual run; redeploys the branch's current commit.
 
 on:
   push:
     branches:
       - v1
-  pull_request:
-    types: [opened, synchronize, reopened]
   workflow_dispatch:
 
 # contents: write — the one-merge cut (DOC-1245) materializes + pushes the stable

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,0 +1,129 @@
+name: Build PR
+
+# PR-build half of the two-stage preview pipeline (DOC-1228).
+#
+# Runs on `pull_request` and builds the docs via `make dist`, but holds NO
+# secrets and performs NO deploy. GitHub does not expose repo secrets to
+# pull_request runs from forks, so anything secret-bearing here would fail on
+# fork PRs (it failed external PR #1055). Instead this job just builds and
+# uploads the dist + PR metadata as an artifact; the trusted companion
+# workflow `deploy-pr-preview.yml` picks it up via `workflow_run` (where
+# secrets ARE available) and deploys it.
+#
+# The job name is intentionally "Build and deploy docs" — the same name the
+# old single-stage workflow used — so the branch-protection required status
+# check keeps matching by check-run name without any reconfiguration.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+# Opt in early to the Node.js 24 runtime for JavaScript actions (see
+# build-and-deploy.yml for the full rationale).
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+# Cancel any in-flight build when a new commit lands on the same PR — only
+# the latest commit's preview matters.
+concurrency:
+  group: build-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    # Name preserved from the original single-stage workflow so the existing
+    # branch-protection required status check (matched by check-run name)
+    # keeps passing — no admin reconfiguration needed.
+    name: "Build and deploy docs"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 1
+
+      - name: Set up Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: '0.161.1'
+          extended: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Print environment
+        run: |
+          echo "::group::versions"
+          hugo version
+          python --version
+          uv --version
+          echo "::endgroup::"
+
+      - name: Build dist
+        run: |
+          start=$(date +%s)
+          make dist
+          echo "BUILD_SECONDS=$(( $(date +%s) - start ))" >> "$GITHUB_ENV"
+
+      - name: Emit build provenance
+        if: success()
+        run: |
+          # Write build-info.json at dist/docs/ (served at /docs/build-info.json
+          # once deployed). Lets incident response probe "what version is this?".
+          mkdir -p dist/docs
+          cat > dist/docs/build-info.json <<EOF
+          {
+            "builder": "github-actions",
+            "repository": "${{ github.repository }}",
+            "workflow_file": ".github/workflows/build-pr.yml",
+            "run_id": "${{ github.run_id }}",
+            "run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            "commit": "${{ github.event.pull_request.head.sha }}",
+            "ref": "${{ github.head_ref }}",
+            "event": "${{ github.event_name }}",
+            "built_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          }
+          EOF
+          cat dist/docs/build-info.json
+
+      - name: Build summary
+        if: always()
+        run: |
+          echo "::group::dist tree (top 2 levels)"
+          find dist -maxdepth 2 -mindepth 1 -print 2>/dev/null | sort || true
+          echo "::endgroup::"
+          echo "::group::dist size"
+          du -sh dist 2>/dev/null || true
+          du -sh dist/docs/v2 dist/docs/v1 2>/dev/null || true
+          echo "::endgroup::"
+          if [ -n "${BUILD_SECONDS:-}" ]; then
+            echo "Build wall time: ${BUILD_SECONDS}s"
+          fi
+
+      - name: Write PR metadata
+        run: |
+          cat > pr-meta.json <<EOF
+          {"pr_number": "${{ github.event.pull_request.number }}", "head_sha": "${{ github.event.pull_request.head.sha }}", "head_ref": "${{ github.head_ref }}"}
+          EOF
+
+      - name: Upload PR dist artifact
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-dist
+          path: |
+            dist
+            pr-meta.json
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -1,0 +1,118 @@
+name: Deploy PR preview
+
+# Deploy half of the two-stage preview pipeline (DOC-1228).
+#
+# Triggered by `workflow_run` after "Build PR" completes. A workflow_run
+# always executes in the TRUSTED base-repo context (using the base ref's
+# workflow definition and with repo secrets available), even when the
+# triggering PR came from a fork. That is what makes fork-PR previews work:
+# the untrusted build happens secret-less in build-pr.yml, and this job only
+# ever DOWNLOADS that prebuilt artifact and deploys it — it never checks out
+# or executes untrusted PR code/build scripts with secrets in scope.
+
+on:
+  workflow_run:
+    workflows: ["Build PR"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: read
+
+# Opt in early to the Node.js 24 runtime for JavaScript actions (see
+# build-and-deploy.yml for the full rationale).
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  deploy:
+    # Only deploy for successful PR builds. workflow_run fires for every
+    # completion; gate on the originating event + a green build.
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Download PR dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-dist
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: .
+
+      - name: Parse PR metadata
+        id: meta
+        run: |
+          pr_number=$(jq -r '.pr_number' pr-meta.json)
+          head_sha=$(jq -r '.head_sha' pr-meta.json)
+          head_ref=$(jq -r '.head_ref' pr-meta.json)
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "head_ref=$head_ref" >> "$GITHUB_OUTPUT"
+          echo "Parsed PR #$pr_number, head_ref '$head_ref', head_sha $head_sha"
+
+      - name: Sanitize branch name for CF Pages
+        id: branch
+        run: |
+          # CF Pages branch names: lowercase alphanumeric + hyphens, max 28 chars.
+          #
+          # Compose `pr-<num>-<branch>` then sanitize. The `pr-<num>` prefix
+          # (a) makes each PR's preview alias unique even when two PRs share a
+          # long common branch-name prefix, and (b) guarantees a PR deploy can
+          # never sanitize to a production branch name like `main` or `v1`.
+          pr_num="${{ steps.meta.outputs.pr_number }}"
+          raw_branch="${{ steps.meta.outputs.head_ref }}"
+          full=$(printf 'pr-%s-%s' "$pr_num" "$raw_branch" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^a-z0-9]+#-#g' | sed -E 's#^-+|-+$##g')
+          sanitized=$(printf '%s' "$full" | cut -c1-28 | sed -E 's#-+$##g')
+          echo "Source PR #$pr_num branch '$raw_branch' → CF Pages branch: $sanitized"
+          echo "name=$sanitized" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy to Cloudflare Pages
+        id: deploy
+        # Step-level cap: fail a hung wrangler upload fast (normal deploy ~1-3
+        # min) instead of consuming the whole job budget. Parity with
+        # build-and-deploy.yml. See DOC-1229.
+        timeout-minutes: 10
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_PAGES_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # --commit-dirty: the prebuilt dist contains regenerated tracked
+          # files, so wrangler would otherwise warn about a dirty tree. The
+          # warning is noise here.
+          command: pages deploy ./dist --project-name=docs --branch=${{ steps.branch.outputs.name }} --commit-dirty=true
+
+      - name: Deploy summary
+        if: success()
+        run: |
+          echo "## Deployment" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Project: \`docs\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Branch (CF Pages): \`${{ steps.branch.outputs.name }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Commit: \`${{ steps.meta.outputs.head_sha }}\`" >> "$GITHUB_STEP_SUMMARY"
+          if [ -n "${{ steps.deploy.outputs.deployment-url }}" ]; then
+            echo "- Deployment URL: ${{ steps.deploy.outputs.deployment-url }}" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Post / update preview comment on PR
+        if: success()
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: gha-build-and-deploy-preview
+          # workflow_run runs detached from any PR, so the comment target must
+          # be named explicitly via `number`.
+          number: ${{ steps.meta.outputs.pr_number }}
+          message: |
+            ### GHA build & deploy preview
+
+            Built by `.github/workflows/build-pr.yml` and deployed to the **`docs`** CF Pages project by `.github/workflows/deploy-pr-preview.yml`.
+
+            | | |
+            |---|---|
+            | Branch alias | <https://${{ steps.branch.outputs.name }}.docs-dog.pages.dev> |
+            | This commit | ${{ steps.deploy.outputs.deployment-url }} |
+            | Commit SHA | `${{ steps.meta.outputs.head_sha }}` |
+
+            Updated automatically on every push.


### PR DESCRIPTION
Ports main's #1111 fork-PR-preview split to v1: adds `build-pr.yml` + `deploy-pr-preview.yml` and makes `build-and-deploy.yml` production-only (drops `pull_request`). Fixes v1/main CI symmetry + the latent fork-PR-secrets bug + the cut-PR false-negative that blocks the v1 versioning go-live (DOC-1245). Ported workflows are branch-agnostic (PR-context refs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)