### PR TITLE
docsy(v2): fold version-manifest.json into cut/regen PRs (inline tags)

### DIFF
--- a/.github/workflows/docs-cut.yml
+++ b/.github/workflows/docs-cut.yml
@@ -93,6 +93,7 @@ jobs:
           set -euo pipefail
           # --promote refuses a non-PyPI SDK version (guarded), then writes versions.toml.
           uv run --quiet unionai-docs-infra/tools/api_generator/manifest.py --promote
+          uv run --quiet unionai-docs-infra/tools/api_generator/manifest.py --write --variant both --out data/version-manifest.json
 
       - name: Build PR body
         if: ${{ ! inputs.dry_run }}
@@ -115,7 +116,9 @@ jobs:
           branch: docsy/v2-cut-${{ steps.resolve.outputs.tag }}
           base: main
           draft: true
-          add-paths: versions.toml
+          add-paths: |
+            versions.toml
+            data/version-manifest.json
           commit-message: "docs: cut ${{ steps.resolve.outputs.tag }} (promote versions.toml)"
           # DCO: "Check DCO" is required on main — the bot commit must sign off.
           author: "unionai-docsy-bot[bot] <295918299+unionai-docsy-bot[bot]@users.noreply.github.com>"

--- a/.github/workflows/regen-api-docs.yml
+++ b/.github/workflows/regen-api-docs.yml
@@ -118,7 +118,8 @@ jobs:
           eval "$(REPO_ROOT=$PWD uv run --quiet unionai-docs-infra/tools/api_generator/manifest.py --check --format shell)"
           if [ "${DOCS_CUT_KIND:-}" = "sdk-release" ] && [ "${DOCS_SDK_ON_PYPI:-}" = "true" ]; then
             REPO_ROOT=$PWD uv run --quiet unionai-docs-infra/tools/api_generator/manifest.py --promote
-            echo "Folded ${DOCS_TAG} promotion into this regen PR (versions.toml stable=${DOCS_TAG})."
+            REPO_ROOT=$PWD uv run --quiet unionai-docs-infra/tools/api_generator/manifest.py --write --variant both --out data/version-manifest.json
+            echo "Folded ${DOCS_TAG} into this regen PR: versions.toml stable=${DOCS_TAG} + data/version-manifest.json (inline cut tag)."
           else
             echo "Not an SDK-release cut (kind=${DOCS_CUT_KIND:-none}, on_pypi=${DOCS_SDK_ON_PYPI:-?}) → no promotion."
           fi
@@ -237,6 +238,7 @@ jobs:
             content/api-reference/**
             linkmap/*-linkmap.json
             versions.toml
+            data/version-manifest.json
           commit-message: "docs(api-reference): regenerate API docs (automated)"
           # DCO: "Check DCO" is a required status check on main (DOC-1244), so the
           # automated regen commit must carry a Signed-off-by trailer or the PR


### PR DESCRIPTION
Companion to infra #170. Makes `regen-api-docs.yml` + `docs-cut.yml` also write + add-path `data/version-manifest.json` (next to the `versions.toml` promote), so the cut PR carries the manifest → it's on `main` in the merge commit → the cut tags that commit **inline**. Part of DOC-1245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)