### PR TITLE
docsy(v2): migrate matchable-attribute uctl workflow to flyte settings

### DIFF
--- a/content/deployment/byoc/enabling-aws-resources/_index.md
+++ b/content/deployment/byoc/enabling-aws-resources/_index.md
@@ -175,9 +175,9 @@ In AWS:
 * Add the `userflyterole` policy to `<CustomRole>`.
 * Add `<CustomPolicy>` to `<CustomRole>`.
 
-In {{< key product_name >}} (using `uctl`):
+In {{< key product_name >}}:
 
-* Bind `<CustomRole>` to the project-domain pair desired.
+* Bind `<CustomRole>` to the project-domain pair desired (see [Bind the IAM role to a project-domain pair](#bind-the-iam-role-to-a-project-domain-pair) below).
 
 ### Create the IAM role
 
@@ -205,29 +205,8 @@ In {{< key product_name >}} (using `uctl`):
 10. Select **Create role**.
 11. In the **Summary** section of the new role's details pane, note the ARN value.
 
-### Configure the cluster to use the new IAM role
+### Bind the IAM role to a project-domain pair
 
-Repeat the following steps for each project-domain pair:
-
-1. Create a file named `cluster_resource_attributes.yaml` with the following contents:
-
-```yaml
-attributes:
-defaultUserRoleValue: <ARN from step 11 above>
-domain: <domain>
-project: <project>
-```
-
-2. Run the following command to override the IAM role used for {{< key product_name >}} Tasks in this Project-Domain:
-
-```bash
-uctl update cluster-resource-attribute --attrFile cluster_resource_attributes.yaml
-```
-
-3. You can verify the overrides by running:
-
-```bash
-uctl get cluster-resource-attribute -p <project> -d <domain>
-```
+Once the IAM role exists, the mapping from a project-domain pair to that role is applied in the {{< key product_name >}} control plane. Provide the {{< key product_name >}} team with the role ARN (from step 11 above) and the project-domain pairs it should apply to, and they will bind the role to those namespaces.
 
 **At this point, only code in your chosen project-domain pairs will have access to the cloud resource as defined by your custom policy.**

--- a/content/deployment/selfmanaged/configuration/authentication.md
+++ b/content/deployment/selfmanaged/configuration/authentication.md
@@ -466,7 +466,7 @@ The SDK and CLI use PKCE (Proof Key for Code Exchange) for interactive authentic
 5. The SDK exchanges the code for tokens and stores them locally.
 6. Subsequent requests include the token in the `flyte-authorization` header.
 
-No additional SDK configuration is required beyond the standard `uctl` or Union config:
+No additional SDK configuration is required beyond the standard `flyte` connection config:
 
 ```yaml
 admin:

--- a/content/deployment/selfmanaged/configuration/multi-cluster.md
+++ b/content/deployment/selfmanaged/configuration/multi-cluster.md
@@ -35,50 +35,54 @@ dr-region:
   - dr-site-cluster
 ```
 
-## Using cluster pools
+## Routing work to a cluster pool
 
-Once the Union team configures the clusterPools in the control plane, you can proceed to configure mappings:
+Work reaches a cluster pool through a [queue](../../../user-guide/cluster-workload-management/queues). A queue lives in one cluster pool and routes runs to the clusters in it; users submit to a queue, never to a pool or a cluster directly. See [Cluster pools](../../../user-guide/cluster-workload-management/cluster-pools) and [Managing queues](../../../user-guide/cluster-workload-management/queues) for the full model.
 
-### project-domain-clusterPool mapping
+> [!NOTE] Requires the `flyteplugins-union` plugin
+> The `flyte create queue` and related commands are provided by the `flyteplugins-union` package. Install it with `pip install flyteplugins-union`.
 
-1. Create a YAML file that includes the project, domain, and clusterPool:
+### Route a project or domain to a pool
 
-**Example: cpa-dev.yaml**
+Create a queue in the target pool, then set it as the default queue for the project-domain scope through the [settings](../../../user-guide/core-concepts/settings) hierarchy.
 
-```yaml
-domain: development
-project: flytesnacks
-clusterPoolName: development-cp
-```
-
-2. Update the control plane with this mapping:
+1. Create a queue in the pool the work should land in:
 
 ```bash
-uctl update cluster-pool-attributes --attrFile cpa-dev.yaml
+flyte create queue development-queue \
+  --cluster-pool development-cp \
+  --run-concurrency 100 \
+  --action-concurrency 1000
 ```
 
-3. New executions in `flytesnacks-development` should now run in the `my-dev-cluster`
-
-### project-domain-workflow-clusterPool mapping
-
-1. Create a YAML file that includes the project, domain, and clusterPool:
-
-**Example: cpa-dev.yaml**
-
-```yaml
-domain: production
-project: flytesnacks
-workflow: my_critical_wf
-clusterPoolName: production-cp
-```
-
-2. Update the control plane with this mapping:
+2. Set that queue as the default for the project-domain scope:
 
 ```bash
-uctl update cluster-pool-attributes --attrFile cpa-prod.yaml
+flyte edit settings --domain development --project flytesnacks
 ```
 
-3. New executions of the `my_critical_wf` workflow in `flytesnacks-production` should now run in any of the clusters under `production-cp`
+   Uncomment and set `run.default_queue` in the editor:
+
+```yaml
+run.default_queue: development-queue
+```
+
+New runs in `flytesnacks-development` are submitted to `development-queue`, which routes them to the clusters in `development-cp`.
+
+### Route a specific workflow to a pool
+
+Routing is per task environment rather than per matchable attribute. To send one workflow to a different pool, target a queue in that pool with the `queue` parameter on the workflow's `flyte.TaskEnvironment` (or on an individual task):
+
+```python
+import flyte
+
+env = flyte.TaskEnvironment(
+    name="critical",
+    queue="production-queue",  # a queue that lives in production-cp
+)
+```
+
+You can also choose a queue when you launch a run, or from a trigger, without touching task code. See [Queues](../../../user-guide/task-configuration/queues) for every way to target a queue.
 
 ## Data sharing between cluster pools
 

--- a/content/user-guide/project-patterns/resource-management.md
+++ b/content/user-guide/project-patterns/resource-management.md
@@ -26,52 +26,43 @@ A production domain in particular ensures a clean slate, so cached executions fr
 
 A common pattern is to split clusters and networking across domains as well: for example, a dedicated production cluster with stricter network controls, separate from the cluster development and staging share. See [multi-cluster and multi-cloud](../../deployment/byoc/multi-cluster) for how this maps to underlying cloud accounts.
 
-## Resource quotas
+## Resource limits
 
-### Set quotas per project-domain pair
+### Set per-task resource limits per project-domain pair
 
-Quotas should be configured for each project-domain pair, not globally. This ensures workflows can't exceed designated limits and prevents any single project or domain from impacting resources available to others.
+Resource limits are configured through the [settings](../core-concepts/settings) hierarchy, which resolves through the org → domain → project chain. Set them for a whole domain, or narrow them to a single project-domain pair:
 
-Configure via `uctl` with a YAML attribute file:
+```bash
+# Domain-wide, inherited by every project in the domain
+flyte edit settings --domain production
+
+# Narrowed to one project-domain pair
+flyte edit settings --domain production --project team-alpha
+```
+
+The command opens an editor. Uncomment and set the `task_resource` keys you want:
+
+- **`task_resource.max.cpu`**, **`task_resource.max.memory`**, **`task_resource.max.storage`**: hard per-task ceilings. A per-task `flyte.Resources` request above the maximum is **capped to the maximum rather than rejected**. This is how you bound how large any single task in a domain or project can get.
+- **`task_resource.min.cpu`**, **`task_resource.min.memory`**, **`task_resource.min.storage`**: the default request applied when a task doesn't specify one.
+- **`task_resource.max.gpu`**, **`task_resource.min.gpu`**: the same ceiling and default, applied to GPU.
+
+For scripted or CI setup, apply a YAML file non-interactively instead of opening the editor:
+
+```bash
+flyte edit settings --domain production --from-file limits.yaml
+```
 
 ```yaml
-domain: development
-project: team-alpha
-attributes:
-  projectQuotaCpu: "500"
-  projectQuotaMemory: 2Ti
+task_resource.max.cpu: "8"
+task_resource.max.memory: 32Gi
+task_resource.max.gpu: "4"
 ```
 
-Apply it with:
+See [Settings](../core-concepts/settings) for the full key list and how inheritance and overrides work.
 
-```bash
-uctl update cluster-resource-attribute --attrFile cra.yaml
-```
+### Why limits matter
 
-Verify with:
-
-```bash
-uctl get cluster-resource-attribute -p <project> -d <domain>
-```
-
-### GPU limits
-
-The `projectQuota*` attributes above set namespace CPU and memory quotas; there is no equivalent standard GPU quota key. GPU limits are enforced instead through the [settings](../core-concepts/settings) system, which resolves through the org → domain → project hierarchy:
-
-- **`task_resource.max.gpu`**: the maximum GPU per task pod, enforced as a hard ceiling: a per-task `flyte.Resources` GPU request above it is **capped to the maximum rather than rejected**. This is how you cap (or raise) the GPU ceiling for a domain or project.
-- **`task_resource.min.gpu`**: the default GPU request applied when a task doesn't specify one.
-
-Set them at the scope you want with `flyte edit settings`, then uncomment and edit the relevant key:
-
-```bash
-flyte edit settings --domain production
-```
-
-Unlike the CPU and memory quotas above, these are per-task limits rather than a namespace-wide aggregate. See [Settings](../core-concepts/settings) for the full key list and how inheritance and overrides work.
-
-### Why quotas matter
-
-Without quotas, projects can starve each other for shared resources. Runs that exceed available capacity are still dispatched to the cluster, and pods sit pending while the execution shows as "running." Quotas turn that silent contention into an explicit, fail-fast signal teams can act on.
+These are per-task ceilings, not a namespace-wide aggregate: they bound how large any individual task can get, which keeps a single oversized task from claiming a whole node's worth of capacity. Setting a sane `task_resource.max` per domain (tighter in development, looser in production) is a low-effort guardrail against noisy-neighbor contention. Coordinate the ceilings with whoever sizes tasks so requests stay within them.
 
 ## Task-level resources
 
@@ -92,7 +83,7 @@ def my_task():
     ...
 ```
 
-If a task's resource request exceeds your project-domain quota, the execution fails immediately rather than queueing forever. That's the behavior you want, but it means teams should know what their quota is before sizing tasks. Coordinate with whoever owns quota configuration so requests stay within budget, or so the budget gets raised intentionally.
+If a task requests more than the `task_resource.max` ceiling set for its project-domain, the request is capped to that ceiling rather than rejected, so the task still runs but with the maximum the scope allows. Teams should know the ceilings before sizing tasks. Coordinate with whoever owns the [settings](../core-concepts/settings) for the scope so requests stay within the ceiling, or so the ceiling gets raised intentionally.
 
 ### Be explicit about ephemeral storage
 
@@ -141,22 +132,21 @@ shared_preprocess = flyte.remote.Task.get(
 
 This requires governance around versioning and backward compatibility, but it scales better than copy-paste.
 
-### Use cluster assignment for multi-cluster deployments
+### Route work to the right cluster pool in multi-cluster deployments
 
-The cluster assignment matchable attribute pins matching executions to a specific Union cluster in multi-cluster deployments. Without an explicit assignment, cluster selection is random: fine for homogeneous setups, but a poor default once cluster heterogeneity exists (for example, GPU clusters alongside CPU-only clusters).
-
-Set the assignment per project-domain with `uctl`:
-
-```yaml
-# cpa.yaml
-domain: production
-project: team-alpha
-clusterPoolName: gpu-pool
-```
+In a multi-cluster deployment, work reaches a cluster through a [queue](../cluster-workload-management/queues), which routes to a [cluster pool](../cluster-workload-management/cluster-pools). To pin a project or domain's work to a specific pool (for example, a GPU pool), create a queue in that pool and set it as the default queue for the scope:
 
 ```bash
-uctl update cluster-pool-attributes --attrFile cpa.yaml
+flyte edit settings --domain production --project team-alpha
 ```
+
+Set `run.default_queue` to a queue that lives in the target pool:
+
+```yaml
+run.default_queue: gpu-queue
+```
+
+An individual task environment can also target a queue directly with the `queue` parameter. See [Managing queues](../cluster-workload-management/queues) for how queues bind to pools and clusters.
 
 ### Treat production as a managed service
 
@@ -170,13 +160,13 @@ The [Union Terraform provider](../../deployment/terraform/_index) is a good fit 
 |---|---|
 | Team isolation | One project per team or ML product |
 | Environments | Use domains (dev / staging / prod) |
-| Quota scope | Per project-domain pair, never global |
-| Task resources | Declare `cpu`, `memory`, and `disk` on `flyte.Resources` and stay within your quota |
+| Resource limits | Per-task ceilings via settings, scoped per project-domain |
+| Task resources | Declare `cpu`, `memory`, and `disk` on `flyte.Resources` and stay within your limits |
 | Ephemeral storage | Set `disk` explicitly for data-heavy tasks |
 | RBAC | Bind roles via policies at the scope you actually need (project-domain, domain, project, or org) |
 | Production access | CI/CD service accounts + admins only |
 | Secrets | Scope to narrowest project-domain |
-| Multi-cluster | Use cluster assignment, not random routing |
+| Multi-cluster | Route via queues to a cluster pool |
 | Shared tasks | Put in a dedicated project, target via `flyte.remote.Task` |
 | Production config | Manage with the Union Terraform provider |
 | Naming | `<team>-<product>` once you exceed ~10 projects |


### PR DESCRIPTION
## What

Migrates the Flyte 1 **matchable-attribute (`uctl`)** workflow to the Flyte 2 hierarchical **settings** (`flyte edit settings`, ORG → DOMAIN → PROJECT) and **queue** model across four v2 (`+union`) pages. Each page keeps its existing `variants:` frontmatter.

Refs DOC-1277.

## Pages changed

| Page | Change |
|---|---|
| `user-guide/project-patterns/resource-management.md` | Resource quotas → per-task `task_resource.min/max.{cpu,memory,storage,gpu}` via `flyte edit settings` (scoped per domain/project, `--from-file` for CI). Cluster assignment → queue + `run.default_queue`. Retitled "Resource quotas" → "Resource limits"; harmonized the task-level-resources paragraph and quick-reference rows to the capping (not fail-fast) semantics. |
| `deployment/byoc/enabling-aws-resources/_index.md` | `cluster-resource-attribute` (the `defaultUserRoleValue` per-project-domain IAM-role binding) has **no v2 `flyte settings` equivalent**. Removed the stale `uctl` commands; the binding is routed to the Union team as a control-plane step, consistent with the page's BYOC framing. |
| `deployment/selfmanaged/configuration/multi-cluster.md` | `cluster-pool-attributes` mappings → create a queue in the pool + set `run.default_queue` (domain/project routing); the `queue` parameter on `TaskEnvironment` (workflow-level routing). Cross-linked to the canonical cluster-pools / queues docs. |
| `deployment/selfmanaged/configuration/authentication.md` | "standard `uctl` or Union config" → "standard `flyte` connection config" (YAML block unchanged). |

## Verification

- Verified the v2 mapping live against `flyte-sdk` `_settings.py`, flyteidl `settings_definition.proto`, the `flyte` CLI source, and the live `cluster-workload-management` docs.
- **There is no `flyte queue` CLI command** and **no project/domain → cluster-pool matchable attribute** in v2. Queues are org-scoped; per-scope routing is done via the `run.default_queue` setting. Queue/cluster-pool commands come from the `flyteplugins-union` package (noted on the page).
- `make check-links`: **green** (flyte + union all OK).

## Open question for eng (cross-surface)

`cluster-resource-attribute` covered two v1 mechanisms with **no documented v2 self-service surface**:
1. Namespace-aggregate project quotas (`projectQuotaCpu` / `projectQuotaMemory`) — v2 settings only offer **per-task** ceilings, not a namespace aggregate.
2. Per-project-domain IAM role override (`defaultUserRoleValue`) — no `flyte settings` key.

The docs no longer teach the retired `uctl` commands for these; please confirm the intended v2 replacement (or that both are control-plane/Union-team-configured only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)