### PR TITLE
docsy(v2): re-list the deprecated agentic plugin API refs as frozen

### DIFF
--- a/api-packages.toml
+++ b/api-packages.toml
@@ -46,6 +46,7 @@
 #   title    - Display title for the documentation
 #   name     - Folder name under output_base
 #   extras   - (optional) pip extras to install, e.g. ["bigquery", "snowflake"]
+#   frozen   - (optional) If true, skip clean/generate (committed content, no longer regenerable)
 
 # === SDK packages ===
 
@@ -87,6 +88,20 @@ output_base = "content/api-reference/integrations"
 default_include = "include/api.plugin.md"
 no_flatten = true  # v2: hierarchical output (separate class files per package)
 
+# Frozen agentic plugins. flyteplugins-{anthropic,gemini,openai} were removed from
+# the SDK; agents now run on Flyte through the framework adapters documented under
+# content/integrations/agents/. Their API-reference dirs are retained by hand as
+# version-stamped snapshots carrying a deprecation notice, for users still on an
+# older release. Listed here (rather than deleted) so the registry stays the full
+# account of what lives under output_base; `frozen` keeps the regen, clean, and
+# PyPI drift checks off them. Do not unfreeze - the packages no longer publish.
+[[plugins]]
+package = "flyteplugins-anthropic"
+plugin = "flyteplugins.anthropic"
+title = "Anthropic"
+name = "anthropic"
+frozen = true
+
 [[plugins]]
 package = "flyteplugins-bigquery"
 plugin = "flyteplugins.bigquery"
@@ -112,6 +127,13 @@ title = "Databricks"
 name = "databricks"
 
 [[plugins]]
+package = "flyteplugins-gemini"
+plugin = "flyteplugins.gemini"
+title = "Gemini"
+name = "gemini"
+frozen = true  # see "Frozen agentic plugins" above
+
+[[plugins]]
 package = "flyteplugins-hydra"
 plugin = "flyteplugins.hydra"
 title = "Hydra"
@@ -128,6 +150,13 @@ package = "flyteplugins-mlflow"
 plugin = "flyteplugins.mlflow"
 title = "MLflow"
 name = "mlflow"
+
+[[plugins]]
+package = "flyteplugins-openai"
+plugin = "flyteplugins.openai"
+title = "OpenAI"
+name = "openai"
+frozen = true  # see "Frozen agentic plugins" above
 
 [[plugins]]
 package = "flyteplugins-omegaconf"


### PR DESCRIPTION
Follow-up to #1249.

## Why

#1249 dropped `flyteplugins-{anthropic,gemini,openai}` from `api-packages.toml` while deliberately **keeping** their `content/api-reference/integrations/<name>/` dirs, restored with a deprecation `[!WARNING]` and a frozen `version:` stamp, for users still on an older release. That's the right call for a removed package.

The side effect is that those three dirs landed in a tooling blind spot:

- `check_versions.py` no longer drift-checks them, which is **correct and desirable** (the packages no longer publish to PyPI, so a check would fail).
- But `check_generated_content.py` only walks the registry **outward to the filesystem**. There is no reverse pass, so nothing anywhere recorded that these dirs exist or why. That's why CI stayed green.

So a future reader, or a `/docsy --refresh-api` run, that finds an `anthropic/` dir with no `anthropic` entry has no stated answer. The two plausible wrong moves are to re-add the entry (regen fails, package is gone) or to delete the dir (silently drops docs that users on older releases still need, and which can never be regenerated).

## What

Re-list the three with **`frozen = true`** rather than leaving them unlisted with a comment. `frozen` is not new: it is already in production on the `uctl` CLI entry, and it is honored for **plugins** across the toolchain, at `check_versions.py:75`, `clean_generated.py:76`, `compare_generated_docs.py:92`, and `check_generated_content.py:94`.

That makes the registry the full account of what lives under `output_base` again, while keeping regen, clean, and PyPI drift checks off the dead packages.

Also documents `frozen` under the `[[plugins]]` field list in the header, where it was previously noted only for `[[clis]]` even though the plugin path has always honored it.

## Verification

Run locally against merged `main`:

- `make check-generated-content` -> `All generated content is present.`
- `make check-api-docs` -> `All API docs are up-to-date.`, and the output lists **neither** `anthropic`, `gemini`, nor `openai`, confirming no PyPI lookup is attempted for the removed packages.

Also confirmed the regen driver cannot touch them: `check-api-docs` and `update-api-docs` are the same script (`check_versions.py --check` / `--update`), which skips frozen plugins, so a frozen entry never reaches `api_plugin_venv_setup.py` (which takes an explicit `--plugin-name` and never loops the registry itself). The three `linkmap/*-linkmap.json` files are still present, so inline-code autolinking on the frozen pages keeps resolving.

Config-only, no content or rendered-output change.

Follow-up filed separately: `check_generated_content.py` currently **skips** frozen entries rather than asserting their content still exists. For frozen content the existence check arguably matters more, not less, since it cannot be regenerated if deleted.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>