### PR TITLE
vpc requirements

### DIFF
--- a/content/deployment/byoc/data-plane-setup-on-aws.md
+++ b/content/deployment/byoc/data-plane-setup-on-aws.md
@@ -704,6 +704,27 @@ The VPC should be configured with the following characteristics.
     - Ensure the security groups allow all traffic from within the VPC.
     - Enable [Private DNS](https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints-s3.html#private-dns-s3) to support out of the box compatibility with data plane services.
 
+### Outbound access required by private subnets
+
+Private subnets need outbound access to the AWS services the data plane depends on, not
+only general internet access. These are the EC2 API, ECR, S3, CloudWatch Logs and the EKS
+API. A subnet with a valid `0.0.0.0/0` route can still be unable to reach them.
+
+{{< markdown >}}
+{{< callout type="warning" >}}
+**Interface endpoints take precedence over routing.**
+
+Private DNS applies across the whole VPC and has no fallback. Once an interface endpoint
+exists for a service with private DNS enabled, every instance in the VPC resolves that
+service to the endpoint's private addresses, regardless of route tables or NAT gateways.
+
+Each endpoint's security group must therefore allow TCP 443 from every private subnet
+CIDR, and the S3 gateway endpoint must be associated with every private subnet's route
+table. Where a security group lists CIDRs explicitly rather than allowing the whole VPC,
+keep that list in step with your subnets.
+{{< /callout >}}
+{{< /markdown >}}
+
 Once your VPC is set up, you will need to provide the {{< key product_name >}} team with the following information:
 
 - **VPC ID**

--- a/content/deployment/byoc/data-plane-setup-on-aws.md
+++ b/content/deployment/byoc/data-plane-setup-on-aws.md
@@ -710,20 +710,15 @@ Private subnets need outbound access to the AWS services the data plane depends 
 only general internet access. These are the EC2 API, ECR, S3, CloudWatch Logs and the EKS
 API. A subnet with a valid `0.0.0.0/0` route can still be unable to reach them.
 
-{{< markdown >}}
-{{< callout type="warning" >}}
-**Interface endpoints take precedence over routing.**
-
-Private DNS applies across the whole VPC and has no fallback. Once an interface endpoint
-exists for a service with private DNS enabled, every instance in the VPC resolves that
-service to the endpoint's private addresses, regardless of route tables or NAT gateways.
-
-Each endpoint's security group must therefore allow TCP 443 from every private subnet
-CIDR, and the S3 gateway endpoint must be associated with every private subnet's route
-table. Where a security group lists CIDRs explicitly rather than allowing the whole VPC,
-keep that list in step with your subnets.
-{{< /callout >}}
-{{< /markdown >}}
+> [!WARNING] Interface endpoints take precedence over routing
+> Private DNS applies across the whole VPC and has no fallback. Once an interface endpoint
+> exists for a service with private DNS enabled, every instance in the VPC resolves that
+> service to the endpoint's private addresses, regardless of route tables or NAT gateways.
+>
+> Each endpoint's security group must therefore allow TCP 443 from every private subnet
+> CIDR, and the S3 gateway endpoint must be associated with every private subnet's route
+> table. Where a security group lists CIDRs explicitly rather than allowing the whole VPC,
+> keep that list in step with your subnets.
 
 Once your VPC is set up, you will need to provide the {{< key product_name >}} team with the following information:
 

--- a/content/deployment/byoc/data-plane-setup-on-azure.md
+++ b/content/deployment/byoc/data-plane-setup-on-azure.md
@@ -137,6 +137,21 @@ We recommend using a VNet within the same Azure tenant as your {{< key product_n
 - (Recommended): Enable [virtual network service endpoints](https://learn.microsoft.com/en-us/azure/virtual-network/virtual-network-service-endpoints-overview) `Microsoft.Storage`, `Microsoft.ContainerRegistry`, and `Microsoft.KeyVault`.
 - (Recommended) Create a [NAT gateway for virtual network](https://learn.microsoft.com/en-us/azure/nat-gateway/quickstart-create-nat-gateway-portal) egress traffic. This allows scaling out public IP addresses and limit potential external rate limiting scenarios.
 
+{{< markdown >}}
+{{< callout type="warning" >}}
+**Service endpoints are configured per subnet.**
+
+The service endpoints above are enabled on individual subnets, not on the virtual network
+as a whole. A subnet without them does not inherit the access other subnets have, so every
+subnet used for Kubernetes nodes or pods needs `Microsoft.Storage`,
+`Microsoft.ContainerRegistry` and `Microsoft.KeyVault` enabled.
+
+The same applies to any resource firewall that allows specific subnets, such as a storage
+account or key vault restricted to selected networks. Those allow lists must be kept in
+step with your subnets.
+{{< /callout >}}
+{{< /markdown >}}
+
 Once your VPC is set up, provide the following to {{< key product_name >}}:
 
 - The Virtual Network's subscription ID.

--- a/content/deployment/byoc/data-plane-setup-on-azure.md
+++ b/content/deployment/byoc/data-plane-setup-on-azure.md
@@ -137,20 +137,15 @@ We recommend using a VNet within the same Azure tenant as your {{< key product_n
 - (Recommended): Enable [virtual network service endpoints](https://learn.microsoft.com/en-us/azure/virtual-network/virtual-network-service-endpoints-overview) `Microsoft.Storage`, `Microsoft.ContainerRegistry`, and `Microsoft.KeyVault`.
 - (Recommended) Create a [NAT gateway for virtual network](https://learn.microsoft.com/en-us/azure/nat-gateway/quickstart-create-nat-gateway-portal) egress traffic. This allows scaling out public IP addresses and limit potential external rate limiting scenarios.
 
-{{< markdown >}}
-{{< callout type="warning" >}}
-**Service endpoints are configured per subnet.**
-
-The service endpoints above are enabled on individual subnets, not on the virtual network
-as a whole. A subnet without them does not inherit the access other subnets have, so every
-subnet used for Kubernetes nodes or pods needs `Microsoft.Storage`,
-`Microsoft.ContainerRegistry` and `Microsoft.KeyVault` enabled.
-
-The same applies to any resource firewall that allows specific subnets, such as a storage
-account or key vault restricted to selected networks. Those allow lists must be kept in
-step with your subnets.
-{{< /callout >}}
-{{< /markdown >}}
+> [!WARNING] Service endpoints are configured per subnet
+> The service endpoints above are enabled on individual subnets, not on the virtual network
+> as a whole. A subnet without them does not inherit the access other subnets have, so every
+> subnet used for Kubernetes nodes or pods needs `Microsoft.Storage`,
+> `Microsoft.ContainerRegistry` and `Microsoft.KeyVault` enabled.
+>
+> The same applies to any resource firewall that allows specific subnets, such as a storage
+> account or key vault restricted to selected networks. Those allow lists must be kept in
+> step with your subnets.
 
 Once your VPC is set up, provide the following to {{< key product_name >}}:
 

--- a/content/deployment/byoc/data-plane-setup-on-gcp.md
+++ b/content/deployment/byoc/data-plane-setup-on-gcp.md
@@ -204,6 +204,19 @@ The VPC should be configured with the following characteristics:
   * A secondary range with /18 CIDR mask. This is used for Kubernetes service IP address. We recommend associating the name with services, e.g. `gke-services`.
   * Identify a /28 CIDR block that will be used for the Kubernetes Master IP addresses. Note this CIDR block is not reserved within the subnet. Google Kubernetes Engine requires this /28 block to be available.
 
+{{< markdown >}}
+{{< callout type="warning" >}}
+**Firewall rules are scoped to address ranges.**
+
+{{< key product_name >}} creates firewall rules permitting traffic within the subnet's own
+ranges, and permitting the GKE control plane to reach nodes on ports `8443` and `9443`,
+which admission webhooks require.
+
+If you maintain additional firewall rules that list source or destination ranges
+explicitly, keep them in step with your subnet's primary and secondary ranges.
+{{< /callout >}}
+{{< /markdown >}}
+
 Once your VPC is set up, provide the following to {{< key product_name >}}:
 
 * VPC name

--- a/content/deployment/byoc/data-plane-setup-on-gcp.md
+++ b/content/deployment/byoc/data-plane-setup-on-gcp.md
@@ -204,18 +204,13 @@ The VPC should be configured with the following characteristics:
   * A secondary range with /18 CIDR mask. This is used for Kubernetes service IP address. We recommend associating the name with services, e.g. `gke-services`.
   * Identify a /28 CIDR block that will be used for the Kubernetes Master IP addresses. Note this CIDR block is not reserved within the subnet. Google Kubernetes Engine requires this /28 block to be available.
 
-{{< markdown >}}
-{{< callout type="warning" >}}
-**Firewall rules are scoped to address ranges.**
-
-{{< key product_name >}} creates firewall rules permitting traffic within the subnet's own
-ranges, and permitting the GKE control plane to reach nodes on ports `8443` and `9443`,
-which admission webhooks require.
-
-If you maintain additional firewall rules that list source or destination ranges
-explicitly, keep them in step with your subnet's primary and secondary ranges.
-{{< /callout >}}
-{{< /markdown >}}
+> [!WARNING] Firewall rules are scoped to address ranges
+> {{< key product_name >}} creates firewall rules permitting traffic within the subnet's own
+> ranges, and permitting the GKE control plane to reach nodes on ports `8443` and `9443`,
+> which admission webhooks require.
+>
+> If you maintain additional firewall rules that list source or destination ranges
+> explicitly, keep them in step with your subnet's primary and secondary ranges.
 
 Once your VPC is set up, provide the following to {{< key product_name >}}:
 


### PR DESCRIPTION
Our BYOC setup docs ask for a NAT gateway and list cloud-provider endpoints as a recommended cost optimization. They never say that private connectivity mechanisms override routing, so a subnet with valid internet egress can still be unable to reach the services a cluster needs to come up.

Adds that to the AWS, GCP and Azure pages, each in its own terms: interface endpoint security groups and S3 gateway route table associations on AWS, per-subnet service endpoints on Azure, and firewall rules scoped to address ranges on GCP.