### PR TITLE
docsy(v2): clarify a cluster pool determines the data plane configuration

### DIFF
--- a/content/user-guide/cluster-workload-management/_index.md
+++ b/content/user-guide/cluster-workload-management/_index.md
@@ -16,8 +16,8 @@ As a {{< key product_name >}} deployment grows past a single cluster, you need t
 control *where* a workload runs and *under what limits*. Three primitives do this:
 
 - **Cluster pool**: an isolation boundary. The clusters and queues inside a pool
-  share one **data plane**: the same object store, secret store, and container
-  registry. Work cannot cross from one pool to another (see
+  share one **data plane configuration**: the same object store, secret store,
+  and container registry. Work cannot cross from one pool to another (see
   [Crossing a pool boundary](#crossing-a-pool-boundary)).
 - **Cluster**: an execution cluster that lives in exactly one pool.
 - **Queue**: what you submit work to. A queue lives in one pool, **routes** work to

--- a/content/user-guide/cluster-workload-management/clusters.md
+++ b/content/user-guide/cluster-workload-management/clusters.md
@@ -12,7 +12,8 @@ variants: -flyte +union
 
 A **cluster** is an execution cluster registered with {{< key product_name >}}.
 Every cluster subscribes to exactly one [cluster pool](./cluster-pools), which
-determines the data plane (object store, secrets, registry) the cluster uses.
+determines the data plane configuration (object store, secret store, container
+registry) the cluster uses.
 
 Creating a cluster record registers the cluster in the control plane. It does not
 install Kubernetes resources or deploy the data plane itself. For self-managed
@@ -118,8 +119,8 @@ which queues are bound to it, useful when deciding where to route or pin a queue
 A cluster's pool assignment is fixed for the life of the cluster record: a
 registration that names a different pool for an existing cluster is rejected,
 because the cluster may already have reported status, synced configuration, and
-served workloads against the old pool's data plane. Moving a cluster is
-therefore a delete-and-re-register:
+served workloads against the old pool's data plane configuration. Moving a
+cluster is therefore a delete-and-re-register:
 
 1. [Drain](./queues#drain-and-reactivate-a-queue) the queues that pin the
    cluster, so in-flight work finishes without new submissions landing.


### PR DESCRIPTION
Fixes [DOC-1314](https://linear.app/unionai/issue/DOC-1314/clusters-page-determines-the-data-plane-should-be-data-plane).

Reported in Slack by James Hoover, 2026-07-30: [thread](https://unionai.slack.com/archives/C01R4HFGR2T/p1785448494310309).

## The problem

The [Clusters](https://www.union.ai/docs/v2/union/user-guide/cluster-workload-management/clusters/) page opened with:

> Every cluster subscribes to exactly one cluster pool, which determines the data plane (object store, secrets, registry) the cluster uses.

A pool does not determine *the data plane*. It determines the data plane **configuration**. Object store, secret store, and container registry are configuration the data plane is built against, not the data plane itself.

Two pieces of evidence:

1. The sibling [Cluster pools](https://www.union.ai/docs/v2/union/user-guide/cluster-workload-management/cluster-pools/) page already uses the precise term: "A **cluster pool** is a named group of clusters that share one **data plane configuration**: the same object store, secret store, and container registry."
2. The Clusters page contradicted itself two paragraphs later, where the cluster *is* the data plane: "It does not install Kubernetes resources or deploy the data plane itself."

## Changes

| File | Change |
|---|---|
| `content/user-guide/cluster-workload-management/clusters.md` | Lede: "determines the data plane (object store, secrets, registry)" to "determines the data plane configuration (object store, secret store, container registry)". Parenthetical also aligned to the pools page's term list. |
| `content/user-guide/cluster-workload-management/clusters.md` | "Move a cluster to a different pool": "served workloads against the old pool's data plane" to "the old pool's data plane configuration". |
| `content/user-guide/cluster-workload-management/_index.md` | Section-index bullet: "share one **data plane**: the same object store, secret store, and container registry" to "share one **data plane configuration**: ...". Same sentence as the Cluster pools lede with the word dropped. |

## Deliberately not changed

- `clusters.md` "validated against the target pool's **data plane contract**" — used deliberately, and the pools page uses it too.
- Every other "data plane" in this section (`_index.md`, `queues.md`, `cluster-pools.md`) refers to the actual infrastructure that clusters read and write, which is the correct sense. The pools page itself keeps that sense ("every cluster in a pool reads and writes the same data plane").

## Scope check

Grepped the whole v2 `union` corpus (432 "data plane" mentions) for the same slippage, a pool *having* or *determining* a data plane rather than a data plane configuration. The only occurrence outside `clusters.md` was the `_index.md` bullet included above. No corpus-wide pattern, so no follow-up sweep is owed.

Prose-only change: no shortcodes, links, or frontmatter touched.
