### PR TITLE
docs(tutorials): hide union-only link cards from the flyte variant

### DIFF
--- a/content/tutorials/_index.md
+++ b/content/tutorials/_index.md
@@ -54,16 +54,22 @@ Prompt engineering, prompt optimization, and context construction.
 Training, fine-tuning, and hyperparameter optimization of models at scale.
 {{< /link-card >}}
 
+{{< variant union >}}
 {{< link-card target="reinforcement-learning" title="Reinforcement Learning" >}}
 RL fine-tuning of language models.
 {{< /link-card >}}
+{{< /variant >}}
 
+{{< variant union >}}
 {{< link-card target="data-processing" title="Data Processing" >}}
 Large-scale data processing and batching strategies.
 {{< /link-card >}}
+{{< /variant >}}
 
+{{< variant union >}}
 {{< link-card target="inference" title="Inference" >}}
 Serving models and building inference applications as Flyte apps.
 {{< /link-card >}}
+{{< /variant >}}
 
 {{< /grid >}}

--- a/content/tutorials/geospatial/_index.md
+++ b/content/tutorials/geospatial/_index.md
@@ -15,8 +15,10 @@ Tutorials for satellite imagery, remote sensing, and earth and atmospheric model
 Run ensemble atmospheric simulations on H200 GPUs with multi-source data ingestion and real-time extreme event detection.
 {{< /link-card >}}
 
+{{< variant union >}}
 {{< link-card target="satellite_image_classification" title="Satellite image classification" >}}
 Build a production-grade EfficientNet pipeline for land-use classification with caching, experiment tracking, and reporting.
 {{< /link-card >}}
+{{< /variant >}}
 
 {{< /grid >}}

--- a/content/user-guide/project-patterns/_index.md
+++ b/content/user-guide/project-patterns/_index.md
@@ -25,8 +25,10 @@ How to structure Flyte projects with uv, from single-package setups to multi-tea
 How to deploy a Flyte project from CI. Uses GitHub Actions as the reference, but the building blocks (API key, `flyte deploy`, commit-pinned versions) translate to any runner.
 {{< /link-card >}}
 
+{{< variant union >}}
 {{< link-card target="resource-management" title="Resource management and multi-team scaling" >}}
 Projects, domains, quotas, RBAC, and secrets: the primitives to set up before you have ten teams and a noisy-neighbor problem.
 {{< /link-card >}}
+{{< /variant >}}
 
 {{< /grid >}}


### PR DESCRIPTION
Five link cards render on the **flyte** build pointing at pages marked `variants: -flyte +union`. The card appears; the page doesn't exist in that build. Live on production now.

| page | card target |
|---|---|
| `tutorials/_index.md` | `reinforcement-learning`, `data-processing`, `inference` |
| `tutorials/geospatial/_index.md` | `satellite_image_classification` |
| `user-guide/project-patterns/_index.md` | `resource-management` |

Wrapped each in `{{< variant union >}}` — the same gate the target pages already use. There was no existing precedent for a variant-wrapped link card, so this establishes it.

## Verified on a full build

The three tutorials cards are **absent from the flyte output** and **present in union**, while `model-training` — available in both — is untouched in each.

## How these were found

By extending the internal-link checker to resolve link-card targets ([unionai-docs-infra#189](https://github.com/unionai/unionai-docs-infra/pull/189)). **They could not have been found before:** the checker matches markdown `[text](url)` syntax, and a link-card target is a shortcode *attribute* — so all 201 cards on this branch had never been validated.

This is the [DOC-1325](https://linear.app/unionai/issue/DOC-1325) argument arriving again. Link cards weren't in the link graph, so nothing could check them; now they're real `<a href>` and the gap in the checker is the remaining half.

## Note for reviewers

`content/tutorials/data-processing/micro-batching/_index.md` is **generated** from a notebook in `unionai-examples` — running `make dist` rewrites it and reverts committed editorial fixes (sentence-case headings back to Title Case). It was briefly swept into this commit and has been removed. Worth knowing that a local `make dist` dirties that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)