### PR TITLE
docs(v1): fix five broken link-card targets

### DIFF
--- a/content/tutorials/_index.md
+++ b/content/tutorials/_index.md
@@ -20,7 +20,7 @@ The example applications range from training XGBoost models in tabular datasets 
 Fine-tune a pre-trained language model in the IMDB dataset for sentiment classification.
 {{< /link-card >}}
 
-{{< link-card target="language-models/agentic-rag" icon="" title="Agentic Retrieval Augmented Generation" >}}
+{{< link-card target="retrieval-augmented-generation/agentic-rag" icon="" title="Agentic Retrieval Augmented Generation" >}}
 Build an agentic retrieval augmented generation system with ChromaDB and Langchain.
 {{< /link-card >}}
 
@@ -28,7 +28,7 @@ Build an agentic retrieval augmented generation system with ChromaDB and Langcha
 Use HDBSCAN soft clustering with headline embeddings and UMAP on GPUs.
 {{< /link-card >}}
 
-{{< link-card target="language-models/llama_edge_deployment" icon="" title="Deploy a Fine-Tuned Llama Model to an iOS App with MLC-LLM" >}}
+{{< link-card target="serving/llama_edge_deployment" icon="" title="Deploy a Fine-Tuned Llama Model to an iOS App with MLC-LLM" >}}
 Fine-tune a Llama 3 model on the Cohere Aya Telugu subset and generate a model artifact for deployment as an iOS app.
 {{< /link-card >}}
 
@@ -57,11 +57,11 @@ Use NVIDIA RAPIDS `cuDF` DataFrame library and `cuML` machine learning to predic
 Pre-process raw sequencing reads, build an index, and perform alignment to a reference genome using the Bowtie2 aligner.
 {{< /link-card >}}
 
-{{< link-card target="multimodal-ai/video-dubbing" icon="" title="Video Dubbing with Open-Source Models" >}}
+{{< link-card target="compound-ai-systems/video-dubbing" icon="" title="Video Dubbing with Open-Source Models" >}}
 Use open-source models to dub videos.
 {{< /link-card >}}
 
-{{< link-card target="language-models/vllm-serving-on-actor" icon="" title="Efficient Named Entity Recognition with vLLM" >}}
+{{< link-card target="serving/vllm-serving-on-actor" icon="" title="Efficient Named Entity Recognition with vLLM" >}}
 Serve a vLLM model on a warm container and trigger inference automatically with artifacts.
 {{< /link-card >}}
 

--- a/content/user-guide/_index.md
+++ b/content/user-guide/_index.md
@@ -87,7 +87,7 @@ Learn about {{< key product_name >}}-specific programming constructs.
 {{< key product_full_name >}} administrators can manage users, projects, and resources.
 {{< /link-card >}}
 
-{{< link-card target="integrations" icon="tools" title="Integrations" >}}
+{{< link-card target="../integrations" icon="tools" title="Integrations" >}}
 {{< key product_full_name >}} integrates with your cloud resources and external services.
 {{< /link-card >}}
 


### PR DESCRIPTION
Five link cards on v1 render a card that leads nowhere. **Live on production.**

| page | target was | should be |
|---|---|---|
| `user-guide/_index.md` | `integrations` | `../integrations` |
| `tutorials/_index.md` | `language-models/agentic-rag` | `retrieval-augmented-generation/agentic-rag` |
| `tutorials/_index.md` | `language-models/llama_edge_deployment` | `serving/llama_edge_deployment` |
| `tutorials/_index.md` | `multimodal-ai/video-dubbing` | `compound-ai-systems/video-dubbing` |
| `tutorials/_index.md` | `language-models/vllm-serving-on-actor` | `serving/vllm-serving-on-actor` |

Integrations is a **top-level** section, not a child of `user-guide`, so its relative target resolved to `user-guide/integrations` → 404. The four tutorials pages all exist but were re-categorised, and the cards kept the old paths.

Every corrected target verified present.

## Why nothing caught these

The internal-link checker matches markdown `[text](url)` syntax. A link-card target is a shortcode **attribute**, so all 113 cards on this branch went unvalidated — and four tutorials could be re-categorised without anything noticing their cards had been orphaned.

[unionai-docs-infra#189](https://github.com/unionai/unionai-docs-infra/pull/189) closes that gap (merged). With it, this branch reports clean on both variants.

Separate from [#1320](https://github.com/unionai/unionai-docs/pull/1320), the v1 submodule bump, so these fixes can land without waiting on a review of the whole-line restyle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)