### PR TITLE
docsy(v1): restore 'latest = false' (DOC-1330)

### DIFF
--- a/versions.toml
+++ b/versions.toml
@@ -3,7 +3,10 @@
 # stable     = newest tag, served at /docs/<line> (the one indexed URL).
 # enumerated = OLDER tags only, served at /docs/<tag>. The newest is NEVER
 #              enumerated -- no byte-identical duplicate tree.
+# latest     = whether this line owns the global /docs/latest URL. Only the
+#              primary line does; a secondary line (v1) sets false.
 stable = "v1.16.26.1"
 enumerated = [
   "v1.16.26.0",
 ]
+latest = false


### PR DESCRIPTION
Restores the key the `v1.16.26.1` cut deleted. Requires [#1329](https://github.com/unionai/unionai-docs/pull/1329) (merged) so the STABLE badge survives.

## What it fixes

```
+ latest = false
```

Present at `origin/v1~1`, absent after the cut — `_emit_versions_toml` had no `latest` parameter, so the key was destroyed on rewrite ([infra#193](https://github.com/unionai/unionai-docs-infra/pull/193) stops that recurring).

With the key gone the flag defaults to true and v1 behaves as the **primary** line:

- a `LATEST` entry in v1's menu pointing at `/docs/latest`, which the edge routes to **v2** — it takes readers off the v1 line entirely
- a whole `/docs/latest` tree built on v1 that is meant to be skipped (`v1.docs-dog.pages.dev/docs/latest/` currently returns 200)

## Intended behaviour, confirmed

v1's branch tip exists in git, but it is **not built and not linked** — only the stable tag and older pins are served. v1 keeps its `STABLE` badge, since infra#193 untied the badge from this flag.

Formatted to match `_emit_versions_toml` exactly, so the next cut produces no spurious diff.