### PR TITLE
docsy(v2): shared CI build step + full-fidelity previews for versioning PRs (DOC-1333)

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -115,18 +115,13 @@ jobs:
       - name: Build dist
         run: |
           start=$(date +%s)
-          # Docs versioning (DOC-1245): when versions.toml is present, assemble the
-          # multi-version dist — /docs/latest (main, noindex), /docs/v2 (the stable
-          # tag, indexed) and each pinned /docs/v2.x.y.z (noindex). Until versions.toml
-          # is added (after the first cut), fall back to the single-version build, so
-          # merging this change is a NO-OP until versioning is switched on.
-          if [ -f versions.toml ]; then
-            echo "versions.toml present -> multi-version assembly"
-            LATEST_REF=origin/main bash unionai-docs-infra/scripts/build_versions.sh
-          else
-            echo "no versions.toml -> single-version build (current behavior)"
-            make dist
-          fi
+          # One shared CI build step (DOC-1333): `auto` = the versions.toml gate,
+          # identical to the previous inline logic (multi-version assembly when
+          # present — /docs/latest, /docs/v2, pins — else single-version).
+          # build-pr.yml calls the SAME script with an explicit mode, so the two
+          # build paths cannot silently drift again (that drift is how previews
+          # spent months building a different artifact class than production).
+          LATEST_REF=origin/main bash unionai-docs-infra/scripts/ci-build-dist.sh auto
           echo "BUILD_SECONDS=$(( $(date +%s) - start ))" >> "$GITHUB_ENV"
 
       - name: Emit build provenance

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -2,7 +2,7 @@ name: Build PR
 
 # PR-build half of the two-stage preview pipeline (DOC-1228).
 #
-# Runs on `pull_request` and builds the docs via `make dist`, but holds NO
+# Runs on `pull_request` and builds the docs, but holds NO
 # secrets and performs NO deploy. GitHub does not expose repo secrets to
 # pull_request runs from forks, so anything secret-bearing here would fail on
 # fork PRs (it failed external PR #1055). Instead this job just builds and
@@ -13,6 +13,15 @@ name: Build PR
 # The job name is intentionally "Build and deploy docs" — the same name the
 # old single-stage workflow used — so the branch-protection required status
 # check keeps matching by check-run name without any reconfiguration.
+#
+# Build fidelity (DOC-1333): previews default to the cheap SINGLE-VERSION build
+# — no /docs/latest, no pinned trees, no versions.json. That is a deliberate,
+# documented trade-off (most PRs never touch the assembly), not drift: a PR
+# that touches a versioning surface (versions.toml, the unionai-docs-infra
+# pointer, data/version-manifest.json, .github/workflows/) gets the FULL
+# multi-version assembly (~3x build time) so its preview matches production in
+# exactly the dimension under test. Both modes run the same shared script as
+# the push deploy (unionai-docs-infra/scripts/ci-build-dist.sh).
 
 on:
   pull_request:
@@ -46,7 +55,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          fetch-depth: 1
+          # Full history + tags (DOC-1333): the versions-mode assembly checks out
+          # stable/pinned TAGS in worktrees, and the mode decision diffs against
+          # the base branch — both need more than a depth-1 clone.
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up Hugo
         uses: peaceiris/actions-hugo@v3
@@ -73,7 +86,21 @@ jobs:
       - name: Build dist
         run: |
           start=$(date +%s)
-          make dist
+          # DOC-1333: full assembly only when this PR touches a versioning
+          # surface; the pattern list mirrors what the assembly consumes. The
+          # triple-dot diff is against the merge-base, so it sees exactly the
+          # PR's own changes. LATEST_REF=HEAD so /docs/latest previews THIS
+          # PR's content — that is what a preview is for.
+          MODE=single
+          CHANGED=$(git diff --name-only "origin/${GITHUB_BASE_REF}...HEAD" 2>/dev/null || true)
+          PATTERN='^(versions\.toml$|unionai-docs-infra$|data/version-manifest\.json$|\.github/workflows/)'
+          if echo "$CHANGED" | grep -qE "$PATTERN"; then
+            MODE=versions
+            echo "versioning surfaces changed by this PR:"
+            echo "$CHANGED" | grep -E "$PATTERN" | sed 's/^/  /'
+          fi
+          echo "PR build mode: $MODE"
+          LATEST_REF=HEAD bash unionai-docs-infra/scripts/ci-build-dist.sh "$MODE"
           echo "BUILD_SECONDS=$(( $(date +%s) - start ))" >> "$GITHUB_ENV"
 
       - name: Emit build provenance


### PR DESCRIPTION
Second half of [DOC-1333](https://linear.app/unionai/issue/DOC-1333) (with [infra#197](https://github.com/unionai/unionai-docs-infra/pull/197), merged). Companion PR on `v1` follows.

- **Push deploys** → `ci-build-dist.sh auto` — identical behaviour to the old inline gate, now shared code.
- **PR previews** → `single` by default (cheap, and now a **documented choice** rather than drift); `versions` (full multi-version assembly, ~3× build) when the PR touches `versions.toml`, the `unionai-docs-infra` pointer, `data/version-manifest.json`, or `.github/workflows/`. `LATEST_REF=HEAD`, so `/docs/latest` previews the PR's own content.
- Checkout: `fetch-depth: 0` + `fetch-tags` — the assembly checks out tag worktrees; the mode decision diffs against the base.

**This PR is its own first test**: it touches `.github/workflows/`, so its preview must come up in `versions` mode — real `/docs/latest`, real pins, real `/docs/v2/versions.json`. Verifying that before merge.