### PR TITLE
docsy(v1): shared CI build step + full-fidelity previews for versioning PRs (DOC-1333)

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -111,16 +111,10 @@ jobs:
       - name: Build dist
         run: |
           start=$(date +%s)
-          # Docs versioning (DOC-1245): when versions.toml is present, assemble the
-          # multi-version dist for the v1 line; else the single-version build. Inert
-          # (no-op) until versions.toml is added, so merging this is safe on frozen v1.
-          if [ -f versions.toml ]; then
-            echo "versions.toml present -> multi-version assembly"
-            LATEST_REF=origin/v1 bash unionai-docs-infra/scripts/build_versions.sh
-          else
-            echo "no versions.toml -> single-version build (current behavior)"
-            make dist
-          fi
+          # One shared CI build step (DOC-1333): `auto` = the versions.toml gate,
+          # identical to the previous inline logic. build-pr.yml calls the SAME
+          # script with an explicit mode, so the two build paths cannot drift.
+          LATEST_REF=origin/v1 bash unionai-docs-infra/scripts/ci-build-dist.sh auto
           echo "BUILD_SECONDS=$(( $(date +%s) - start ))" >> "$GITHUB_ENV"
 
       - name: Emit build provenance

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -2,7 +2,7 @@ name: Build PR
 
 # PR-build half of the two-stage preview pipeline (DOC-1228).
 #
-# Runs on `pull_request` and builds the docs via `make dist`, but holds NO
+# Runs on `pull_request` and builds the docs, but holds NO
 # secrets and performs NO deploy. GitHub does not expose repo secrets to
 # pull_request runs from forks, so anything secret-bearing here would fail on
 # fork PRs (it failed external PR #1055). Instead this job just builds and
@@ -13,6 +13,12 @@ name: Build PR
 # The job name is intentionally "Build and deploy docs" — the same name the
 # old single-stage workflow used — so the branch-protection required status
 # check keeps matching by check-run name without any reconfiguration.
+#
+# Build fidelity (DOC-1333): previews default to the cheap SINGLE-VERSION build.
+# A PR touching a versioning surface (versions.toml, the unionai-docs-infra
+# pointer, data/version-manifest.json, .github/workflows/) gets the FULL
+# multi-version assembly so its preview matches production in the dimension
+# under test. Same shared script as the push deploy (ci-build-dist.sh).
 
 on:
   pull_request:
@@ -46,7 +52,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          fetch-depth: 1
+          # Full history + tags (DOC-1333): versions-mode assembly checks out
+          # tag worktrees; the mode decision diffs against the base branch.
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up Hugo
         uses: peaceiris/actions-hugo@v3
@@ -73,7 +82,19 @@ jobs:
       - name: Build dist
         run: |
           start=$(date +%s)
-          make dist
+          # DOC-1333: full assembly only when this PR touches a versioning
+          # surface. LATEST_REF=HEAD is inert on v1 (latest = false) but kept
+          # identical to main so the twin files stay diffable.
+          MODE=single
+          CHANGED=$(git diff --name-only "origin/${GITHUB_BASE_REF}...HEAD" 2>/dev/null || true)
+          PATTERN='^(versions\.toml$|unionai-docs-infra$|data/version-manifest\.json$|\.github/workflows/)'
+          if echo "$CHANGED" | grep -qE "$PATTERN"; then
+            MODE=versions
+            echo "versioning surfaces changed by this PR:"
+            echo "$CHANGED" | grep -E "$PATTERN" | sed 's/^/  /'
+          fi
+          echo "PR build mode: $MODE"
+          LATEST_REF=HEAD bash unionai-docs-infra/scripts/ci-build-dist.sh "$MODE"
           echo "BUILD_SECONDS=$(( $(date +%s) - start ))" >> "$GITHUB_ENV"
 
       - name: Emit build provenance


### PR DESCRIPTION
v1 mirror of [#1334](https://github.com/unionai/unionai-docs/pull/1334) — same infra bump (`67d5415`), same workflow edits (push → `auto`, previews → `single`/`versions` by changed files). Mirrored deliberately: v1's CI lagging main has bitten before (docs#1281).

Like #1334, this PR touches `.github/workflows/` so its own preview self-tests `versions` mode.