### PR TITLE
docsy(v2): memorialize the chrome-promotion policy (DOC-1329)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,11 @@ The repo separates **version-specific content/config** (top level) from **shared
 - `api-packages.toml` — API package registry
 - `content/`, `data/`, `linkmap/`, `include/` — Content and generated data
 
-**`unionai-docs-infra/`** — shared build infrastructure (identical across branches):
+**`unionai-docs-infra/`** — shared build infrastructure (identical across branches).
+**Policy (DOC-1329): content is versioned; chrome is promoted.** Cut tags snapshot content only;
+builds wrap every version tree (latest, stable, all pins) in the infra named by the *branch tip's*
+submodule pointer. Infra/theme changes ship via a pointer bump — never a cut; the pin inside a tag
+is provenance only. Details: `unionai-docs-infra/VERSIONING.md`.
 - `Makefile` — Real build logic (top-level Makefile forwards to this)
 - `hugo.toml`, `hugo.site.toml`, `hugo.ver.toml`, `config.{variant}.toml` — Hugo config
 - `static/` — Shared static assets (CSS, JS, images)

--- a/content/community/contributing-docs/versions.md
+++ b/content/community/contributing-docs/versions.md
@@ -18,6 +18,23 @@ while the URL for version `v1` of the same page is:
 
 `{{< docs_home flyte v1 >}}/community/contributing-docs/versions`
 
+## What a version contains (and what it does not)
+
+A docs version is a snapshot of **content** — the pages, examples and generated API
+reference as they stood against a given SDK release. The site's **look and
+navigation** (the theme, built from the shared `unionai-docs-infra` submodule) is
+*not* part of the snapshot: every published version, however old, is always served
+with the **current** site UI. This is deliberate — the content you are reading has a
+version; the reading experience should always be the best available.
+
+Two practical consequences for contributors:
+
+- **Theme or build-system changes never require a new docs version.** They reach
+  every published version automatically when the infra submodule pointer is bumped
+  on the docs branch.
+- **Content changes reach `latest` immediately** on merge, and reach the stable
+  version at the next cut.
+
 ## Versions are branches
 
 The versioning system is based on long-lived Git branches in the `unionai/unionai-docs` GitHub repository:


### PR DESCRIPTION
Docs-repo half of [infra#213](https://github.com/unionai/unionai-docs-infra/pull/213): shared `CLAUDE.md` + the public contributing page get the policy — *content is versioned; chrome is promoted*. Pointer bumped for infra#213's doc statements. The contributing page's other sections still describe the pre-cut-model era; rewrite tracked separately.