### PR TITLE
docsy(v1): run the redirect unit tests in CI, as main does

### DIFF
--- a/.github/workflows/check-redirects.yml
+++ b/.github/workflows/check-redirects.yml
@@ -46,3 +46,11 @@ jobs:
             echo "::error::Deleted pages are missing redirects. Run 'make check-deleted-pages' for details, then add redirects to unionai-docs-infra/redirects.csv or exclude paths in unionai-docs-infra/.redirects-exclude."
             exit 1
           fi
+
+      - name: Run redirect unit tests
+        run: |
+          # Static redirect suite: CSV invariants + generator logic. Includes
+          # test_no_redirect_chains_within_csv, which gates the CSV against
+          # multi-hop chains (live HTTP tests stay behind --live and don't run).
+          cd unionai-docs-infra
+          uv run --with pytest pytest tests/test_redirects.py -q


### PR DESCRIPTION
Workflow-parity gap found auditing main-vs-v1: v1's `Check Redirects` never ran `tests/test_redirects.py` — the suite that caught the 223 duplicate rows in the DOC-1335 rollout. The tests and the CSV are both shared infra, so this is purely a missing invocation on v1.