### PR TITLE
docsy(v2): retire pins older than stable — serve only latest + stable

### DIFF
--- a/versions.toml
+++ b/versions.toml
@@ -6,8 +6,4 @@
 # latest     = whether this line owns the global /docs/latest URL. Only the
 #              primary line does; a secondary line (v1) sets false.
 stable = "v2.5.16.3"
-enumerated = [
-  "v2.5.16.0",
-  "v2.5.16.1",
-  "v2.5.16.2",
-]
+enumerated = []


### PR DESCRIPTION
Serves only `/docs/latest` and `/docs/v2`. Retires `v2.5.16.0/.1/.2`.

Reasons: Peeter's request; [DOC-1288](https://linear.app/unionai/issue/DOC-1288) file-budget headroom; and it eliminates [DOC-1351](https://linear.app/unionai/issue/DOC-1351) case B (stable → pre-restructure pin 404s).

**Reversible** — tags remain in git; re-add to `enumerated` to serve again.
Paired with the v1 equivalent.