### PR TITLE
docsy(v1): retire pins older than stable — serve only v1 stable

### DIFF
--- a/versions.toml
+++ b/versions.toml
@@ -6,8 +6,5 @@
 # latest     = whether this line owns the global /docs/latest URL. Only the
 #              primary line does; a secondary line (v1) sets false.
 stable = "v1.16.26.2"
-enumerated = [
-  "v1.16.26.0",
-  "v1.16.26.1",
-]
+enumerated = []
 latest = false


### PR DESCRIPTION
Mirrors docs#1371. Retires `v1.16.26.0/.1`; `/docs/v1` (stable `v1.16.26.2`) unaffected. `latest = false` unchanged.

**Reversible** — tags remain in git.