### PR TITLE
docsy(v1): CI parity with main — production-only build-and-deploy, plus markdownlint

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -36,17 +36,18 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
-# Concurrency policy:
-#   - PRs: cancel any in-flight run when a new commit is pushed to the
-#     same PR (only the latest commit's preview matters).
-#   - push to v1: queue in order, don't cancel, so we never leave
-#     production in an inconsistent state mid-deploy.
-#   - workflow_dispatch: own group, distinct from push, so manual
-#     re-runs never block or get blocked by an in-progress production
-#     deploy.
+# Concurrency policy (mirrors main):
+#   - production deploys (push to v1) use one `prod` group, queued in order
+#     (never cancel), so two merges can't race on the single CF Pages project,
+#     and can't race on cutting the same stable tag (the cut runs in-job, so
+#     serializing the job serializes the cut).
+#   - workflow_dispatch: own `manual` group, so manual re-runs never block or
+#     get blocked by an in-progress production deploy.
+# This workflow never runs on `pull_request` (see Triggers above), so there is
+# no PR arm here. PR previews live in build-pr.yml + deploy-pr-preview.yml.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref_name }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && 'manual' || 'prod' }}
+  cancel-in-progress: false
 
 jobs:
   build-and-deploy:
@@ -133,8 +134,8 @@ jobs:
             "workflow_file": ".github/workflows/build-and-deploy.yml",
             "run_id": "${{ github.run_id }}",
             "run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-            "commit": "${{ github.event.pull_request.head.sha || github.sha }}",
-            "ref": "${{ github.head_ref || github.ref_name }}",
+            "commit": "${{ github.sha }}",
+            "ref": "${{ github.ref_name }}",
             "event": "${{ github.event_name }}",
             "built_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           }
@@ -169,32 +170,22 @@ jobs:
         id: branch
         run: |
           # CF Pages branch names: lowercase alphanumeric + hyphens, max 28 chars.
-          #
-          # On pull_request events we prefix the deploy branch with `pr-<num>`.
-          # This both (a) makes each PR's preview alias unique even when two
-          # PRs share a long common branch-name prefix, and (b) guarantees a
-          # PR-event deploy can never sanitize to a production branch name
-          # like `main` or `v1` (e.g. a branch named `main_` would otherwise
-          # sanitize to `main` and overwrite production now that PRs deploy
-          # into the same `docs` Pages project).
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            pr_num="${{ github.event.pull_request.number }}"
-            raw_branch="${{ github.head_ref }}"
-            # Compose `pr-<num>-<branch>` then truncate to 28 chars (CF Pages
-            # limit). Branch portion auto-shrinks as PR numbers grow digits.
-            full=$(printf 'pr-%s-%s' "$pr_num" "$raw_branch" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^a-z0-9]+#-#g' | sed -E 's#^-+|-+$##g')
-            sanitized=$(printf '%s' "$full" | cut -c1-28 | sed -E 's#-+$##g')
-            echo "Source PR #$pr_num branch '$raw_branch' → CF Pages branch: $sanitized"
-          else
-            raw="${{ github.ref_name }}"
-            sanitized=$(echo "$raw" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^a-z0-9]+#-#g' | sed -E 's#^-+|-+$##g' | cut -c1-28)
-            echo "Source branch: $raw → CF Pages branch: $sanitized"
-          fi
+          # Production-only workflow, so `github.ref_name` is always `v1`
+          # (push) or the dispatched ref. The `pr-<num>-` aliasing lives in
+          # deploy-pr-preview.yml, which is what handles PR events.
+          raw="${{ github.ref_name }}"
+          sanitized=$(echo "$raw" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^a-z0-9]+#-#g' | sed -E 's#^-+|-+$##g' | cut -c1-28)
+          echo "Source branch: $raw → CF Pages branch: $sanitized"
           echo "name=$sanitized" >> "$GITHUB_OUTPUT"
 
       - name: Deploy to Cloudflare Pages
         if: success()
         id: deploy
+        # Step-level cap: a normal CF Pages deploy is ~1-3 min. Without this a
+        # hung wrangler upload eats the whole job's timeout-minutes budget
+        # (incl. the build) before failing — observed once at ~26 min on a large
+        # API-docs regen. Fail fast so the deploy can be re-run. See DOC-1229.
+        timeout-minutes: 10
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_PAGES_API_TOKEN }}
@@ -216,25 +207,7 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "- Project: \`docs\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Branch (CF Pages): \`${{ steps.branch.outputs.name }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Commit: \`${{ github.event.pull_request.head.sha || github.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Commit: \`${{ github.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
           if [ -n "${{ steps.deploy.outputs.deployment-url }}" ]; then
             echo "- Deployment URL: ${{ steps.deploy.outputs.deployment-url }}" >> "$GITHUB_STEP_SUMMARY"
           fi
-
-      - name: Post / update preview comment on PR
-        if: success() && github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: gha-build-and-deploy-preview
-          message: |
-            ### GHA build & deploy preview
-
-            Built by `.github/workflows/build-and-deploy.yml` and deployed to the **`docs`** CF Pages project.
-
-            | | |
-            |---|---|
-            | Branch alias | <https://${{ steps.branch.outputs.name }}.docs-dog.pages.dev> |
-            | This commit | ${{ steps.deploy.outputs.deployment-url }} |
-            | Commit SHA | `${{ github.event.pull_request.head.sha }}` |
-
-            Updated automatically on every push.

--- a/.github/workflows/check-markdownlint.yml
+++ b/.github/workflows/check-markdownlint.yml
@@ -1,0 +1,61 @@
+name: Check Markdown Lint
+
+# Markdown style/consistency check (DOC-967).
+#
+# ROLLOUT POSTURE — advisory, changed-files-only.
+# The existing docs corpus predates any linter and will contain many
+# pre-existing violations, so this check is deliberately scoped so it does NOT
+# turn the whole build red on legacy content:
+#   1. It lints ONLY the Markdown files changed in the PR (tj-actions/changed-files),
+#      never the whole tree — untouched legacy pages are never flagged.
+#   2. The config (.markdownlint-cli2.jsonc) disables the rules that a large
+#      Hugo/shortcode docs corpus trips on (line length, inline HTML, etc.).
+#   3. The lint step is `continue-on-error` — findings surface as inline PR
+#      annotations but do NOT fail the check during rollout.
+# TODO(DOC-967): once the corpus is clean, remove `continue-on-error` on the
+# lint step to make this a required, blocking check.
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  markdownlint:
+    name: "Check Markdown Lint"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Full history so changed-files can diff against the PR base.
+          fetch-depth: 0
+
+      - name: Get changed Markdown files
+        id: changed
+        uses: tj-actions/changed-files@v45
+        with:
+          files: |
+            content/**/*.md
+          # Generated API reference, generated Helm-chart reference, and
+          # prds-owned release notes are excluded: they are machine-authored /
+          # owned by another pipeline.
+          files_ignore: |
+            content/api-reference/**
+            content/release-notes/**
+            content/deployment/selfmanaged/helm-chart-reference/**
+
+      - name: Run markdownlint-cli2 on changed files
+        if: steps.changed.outputs.any_changed == 'true'
+        # Advisory during rollout — annotate, don't block. See header TODO.
+        continue-on-error: true
+        uses: DavidAnson/markdownlint-cli2-action@v19
+        with:
+          globs: ${{ steps.changed.outputs.all_changed_files }}
+
+      - name: Report status
+        if: ${{ steps.changed.outputs.any_changed == 'true' }}
+        run: |
+          echo "::notice::markdownlint ran on changed Markdown files (advisory). Run 'npx markdownlint-cli2 \"content/**/*.md\"' locally, or see the annotations above."

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,84 @@
+// markdownlint-cli2 config for the Union.ai / Flyte docs (DOC-967).
+//
+// Tuned PERMISSIVE for an existing Hugo docs corpus: the rules disabled below
+// are the ones a large body of already-published docs (long prose lines, Hugo
+// shortcodes / inline HTML, front matter, GFM callouts) trips on constantly and
+// which are style-preference rather than correctness. Keep the correctness-ish
+// rules (broken emphasis, list indentation, trailing spaces) on.
+//
+// This is the STARTING point. Tighten over time (re-enable a rule, fix the
+// fallout on changed files) rather than flipping everything on at once.
+{
+  "$schema": "https://raw.githubusercontent.com/DavidAnson/markdownlint-cli2/main/schema/markdownlint-cli2-config-schema.json",
+
+  // Lint content only; never the generated API ref, generated Helm-chart
+  // reference, or prds-owned release notes, and not the build infra. (The
+  // workflow also scopes to changed files; this is the belt-and-suspenders for
+  // local `markdownlint-cli2` runs.)
+  "ignores": [
+    "content/api-reference/**",
+    "content/release-notes/**",
+    // Generated from unionai/helm-charts via `make update-helm-docs`; the field
+    // descriptions (incl. any non-descriptive link text) come from upstream.
+    "content/deployment/selfmanaged/helm-chart-reference/**",
+    "node_modules/**",
+    "unionai-docs-infra/**",
+    "unionai-examples/**",
+    "**/*.py",
+    "**/*.ipynb"
+  ],
+
+  "config": {
+    "default": true,
+
+    // MD013 line-length: docs prose uses long, unwrapped lines. Off.
+    "MD013": false,
+
+    // MD033 inline HTML: Hugo shortcodes and raw HTML are used throughout. Off.
+    "MD033": false,
+
+    // MD041 first-line-heading: pages start with YAML front matter / shortcodes,
+    // not an H1. Off.
+    "MD041": false,
+
+    // MD025 single-H1 vs front-matter title: the front matter `title` is the H1,
+    // so don't double-count a body H1.
+    "MD025": { "front_matter_title": "" },
+
+    // MD024 duplicate headings: allow the same heading text under different
+    // parents (common in reference-style docs); only flag true siblings.
+    "MD024": { "siblings_only": true },
+
+    // MD046 code-block-style: mixed indented/fenced blocks exist. Off for now.
+    "MD046": false,
+
+    // MD060 table-column-style: the existing corpus uses compact tables
+    // (`|---|`) throughout; this is a style preference, not correctness. Off
+    // (consistent with the other table/style rules disabled here).
+    "MD060": false,
+
+    // MD040 fenced-code-language: many existing blocks omit a language. Off for
+    // now (re-enable later to encourage syntax highlighting).
+    "MD040": false,
+
+    // MD034 bare-URLs: bare URLs appear in existing content and in shortcodes. Off.
+    "MD034": false,
+
+    // MD029 ordered-list numbering: allow existing `1.`-repeated lists. Off.
+    "MD029": false,
+
+    // MD004 unordered-list-style: content mixes `-` and `*` bullet markers across
+    // (and within) pages; enforcing one marker is churn, not correctness. Off.
+    "MD004": false,
+
+    // MD036 emphasis-as-heading: docs use bold lead-ins that aren't headings. Off.
+    "MD036": false,
+
+    // MD026 trailing punctuation in headings: some headings legitimately end in
+    // `?` or `:`. Off.
+    "MD026": false,
+
+    // MD028 blank line inside blockquote: GFM `> [!NOTE]` callouts trip this. Off.
+    "MD028": false
+  }
+}


### PR DESCRIPTION
CI parity between `v1` and `main`, prompted by DOC-1359.

## The premise of DOC-1359 does not hold

The ticket says a PR against `v1` gets no Cloudflare preview. It does.
[#1377](https://github.com/unionai/unionai-docs/pull/1377), the PR the ticket
cites, got one:

| | |
|---|---|
| Sticky comment | posted 2026-08-04 12:22:10Z, 65s after the build check went green |
| Branch alias | `https://pr-1377-docsy-v1-bump-sideba.docs-dog.pages.dev` |
| Verified | HTTP 200 at `/` and at `/docs/v1/flyte/`, still live |
| Deploy run | [30908709788](https://github.com/unionai/unionai-docs/actions/runs/30908709788), all steps green |

`v1` already carries `build-pr.yml` and `deploy-pr-preview.yml`, and
`deploy-pr-preview.yml` is **byte-identical** to main's.

What made it look otherwise: stage 2 is a detached `workflow_run`, so it never
appears in the PR's checks list and its run is filed under `main`. The only
check on the PR is stage 1, whose last step is `Upload PR dist artifact`. And
v1's `build-and-deploy.yml` still read as if *it* handled PR previews. This PR
fixes that second part; the documentation half is
[unionai-docs-infra#224](https://github.com/unionai/unionai-docs-infra/pull/224).

## Commit 1: make `build-and-deploy.yml` a true mirror of main's

v1's copy still carried `pull_request`-era logic from before DOC-1228 split
previews out. The workflow triggers only on `push: [v1]` and
`workflow_dispatch`, so every bit of it was dead:

* a `Post / update preview comment on PR` step gated on
  `github.event_name == 'pull_request'`;
* a `pull_request` arm in `Sanitize branch name for CF Pages`;
* PR-number-keyed concurrency with `cancel-in-progress` on PR events;
* `github.event.pull_request.head.sha ||` and `github.head_ref ||` fallbacks in
  the build provenance and deploy summary.

Removing it also picks up the one **real** functional lag behind main: the
DOC-1229 step-level `timeout-minutes: 10` on the Cloudflare deploy step, so a
hung `wrangler` upload fails fast instead of consuming the job's whole
30-minute budget.

After this commit the file is line-for-line identical to main's apart from four
intentional differences: `push` branch, `LATEST_REF`, and the two
`build-info.json` paths.

**This does not reintroduce the DOC-1228 fork-PR vulnerability.** It moves in
the safe direction: it removes secret-bearing PR-event code paths from a
production workflow. No `pull_request` trigger is added anywhere, and the
untrusted-build / trusted-deploy split is untouched.

## Commit 2: add the markdownlint check

`check-markdownlint.yml` was the last workflow present on `main` and absent on
`v1` that is not main-specific by design. Copied verbatim along with
`.markdownlint-cli2.jsonc`; neither has a branch reference. Advisory and
non-blocking as on main (changed-files-only, `continue-on-error`), so it
annotates and never turns a v1 PR red.

Drop this commit if you would rather keep the PR to the preview question alone.

## The full main-vs-v1 workflow delta, for the record

**Missing on `v1`, correctly so:**

| File | Why main-only |
|---|---|
| `block-v1-to-main.yml` | guards PRs *into* `main` |
| `check-helm-docs.yml` | v1 has no generated `helm-chart-reference/` tree and no `make check-helm-docs` |
| `generate-helm-docs.yml` | same |

**Missing on `v1`, genuine gap:** `check-markdownlint.yml` (+ `.markdownlint-cli2.jsonc`). Fixed in commit 2.

**Present on both, identical:** `deploy-pr-preview.yml`, `check-dco.yml`, `check-spelling.yml`, `deploy-redirects.yml`.

**Present on both, differing only in the push branch** (`branches: [main]` -> `[v1]`, one line each): `check-api-docs.yml`, `check-generated-content.yml`, `check-images.yml`, `check-jupyter.yml`, `check-links.yml`, `check-llm-bundle-notes.yml`, `check-redirects.yml`.

**Present on both, deliberate v1-line variants:** `docs-cut.yml` (v1 tag naming, `base: v1`, `docsy/v1-cut-*`), `regen-api-docs.yml` (flytekit not flyte, `base: v1`, manual-only because `schedule` / `repository_dispatch` fire from the default branch only), `build-pr.yml` (comment rewording only, no logic difference).

**Present on both, real drift:** `build-and-deploy.yml`. Fixed in commit 1.

## Verification

Verified:

* v1 previews work end to end, on live evidence (table above).
* Every workflow-file difference between the branches is itemized above and
  each was read, not just hashed.
* Both edited/added YAML files parse.
* After commit 1, `build-and-deploy.yml` differs from main's only in the four
  intentional lines (checked with a comment-stripped diff).

**Not verifiable before merge:** `build-and-deploy.yml` only runs on `push: v1`,
so nothing exercises it until this PR merges. Its first real test is that merge.
The risk is bounded: the diff removes dead branches and adds a step timeout, and
the remaining code is what main runs on every merge today.

`check-markdownlint.yml` does run on this PR, so it is exercised here.

Note that this PR touches `.github/workflows/`, which puts `build-pr.yml` into
full multi-version assembly mode (DOC-1333), so its own preview is a
full-fidelity build.

Refs DOC-1359, DOC-1228, DOC-1229, DOC-967.

---

## This PR is its own proof

It is a PR against `v1`, and it got a preview:

| | |
|---|---|
| Branch alias | https://pr-1378-docsy-v1-ci-preview.docs-dog.pages.dev |
| `/docs/v1/flyte/` | 200 |
| `/docs/v1/union/` | 200 |
| `/docs/latest/` | 404, correct (v1 has `latest = false`; v2 owns `/docs/latest`) |
| Build mode | `versions` (full multi-version assembly, as expected for a `.github/workflows/` change) |
| Checks | 11/11 pass, including the newly added `Check Markdown Lint` |

The sticky comment landed roughly a minute after `Build and deploy docs` turned
green. That gap is the whole discoverability problem, and it is what
unionai-docs-infra#224 documents.


---
— docsy · automated docs agent · [DOC-1359](https://linear.app/unionai/issue/DOC-1359/v1-branch-pr-pipeline-has-no-preview-deploy-step-so-v1)