### PR TITLE
docs(ray): document reusable Ray clusters and reuse scopes

### DIFF
--- a/content/integrations/dask/_index.md
+++ b/content/integrations/dask/_index.md
@@ -28,8 +28,10 @@ image = flyte.Image.from_debian_base(name="dask").with_pip_packages("flyteplugin
 ```
 
 {{< variant union >}}
+{{< markdown >}}
 > [!NOTE]
-For self-managed setups, refer to the [setup instructions](../../deployment/selfmanaged/configuration/plugins#dask) to enable the Dask plugin in your data plane.
+> For self-managed setups, refer to the [setup instructions](../../deployment/selfmanaged/configuration/plugins#dask) to enable the Dask plugin in your data plane.
+{{< /markdown >}}
 {{< /variant >}}
 
 ## Configuration

--- a/content/integrations/ray/_index.md
+++ b/content/integrations/ray/_index.md
@@ -103,6 +103,58 @@ ray_config = RayJobConfig(
 )
 ```
 
+{{< variant union >}}
+## Reusable Ray clusters
+
+By default every Ray task pays the full cluster cold-start cost: a new Ray cluster is provisioned for the task and torn down when it finishes. If your workload runs many Ray jobs with the same cluster configuration, you can instead share one long-lived Ray cluster across tasks by attaching a [`ReusePolicy`](../../user-guide/tasks/task-configuration/reusable-containers) to the Ray `TaskEnvironment`:
+
+```python
+import flyte
+from flyteplugins.ray import HeadNodeConfig, RayJobConfig, WorkerNodeConfig
+
+ray_env = flyte.TaskEnvironment(
+    name="ray_env",
+    plugin_config=RayJobConfig(
+        head_node_config=HeadNodeConfig(),
+        worker_node_config=[WorkerNodeConfig(group_name="ray-group", replicas=2)],
+    ),
+    image=image,
+    reusable=flyte.ReusePolicy(
+        replicas=1,     # one shared Ray cluster
+        idle_ttl=300,   # tear the cluster down after 5 minutes of inactivity
+        scope="global",  # share across all runs (see below)
+    ),
+)
+```
+
+The first task creates the shared cluster; once it is ready, every subsequent task with the same environment submits its Ray job directly to it, skipping cluster startup entirely. Each job still runs and reports under its own run identity.
+
+The cluster's identity is derived from the task environment: its name, the Ray configuration, the container image and resources, any pod template, and the reuse policy itself. Tasks with an identical environment share one cluster; changing any of these (for example deploying a new image or code version) creates a fresh cluster rather than reusing a stale one.
+
+### Reuse scope
+
+The `scope` parameter controls how widely the shared cluster is reused:
+
+| Scope | Behavior |
+|-------|----------|
+| `"global"` (default) | One cluster is shared by every run whose tasks use the same environment. The cluster survives across runs until it has been idle for `idle_ttl`. |
+| `"run"` | Reuse is restricted to a single run: each run gets its own shared cluster, and tasks within that run share it. |
+
+```python
+# Each run gets its own Ray cluster, shared by the tasks in that run.
+reusable = flyte.ReusePolicy(replicas=1, idle_ttl=300, scope="run")
+```
+
+### Cleanup
+
+A shared cluster is never deleted when an individual task completes or is aborted — it is shut down automatically after it has been idle (no jobs running against it) for `idle_ttl`.
+
+### Constraints
+
+- `replicas` must be exactly `1` — one shared Ray cluster per environment.
+- `concurrency` must be `1` (the default); Ray itself handles parallelism inside the cluster.
+{{< /variant >}}
+
 ## Examples
 
 The following example shows how to configure Ray in a `TaskEnvironment`. Flyte automatically provisions a Ray cluster for each task using this configuration:

--- a/content/integrations/ray/_index.md
+++ b/content/integrations/ray/_index.md
@@ -154,6 +154,7 @@ A shared cluster is never deleted when an individual task completes or is aborte
 
 - `replicas` must be exactly `1` — one shared Ray cluster per environment.
 - `concurrency` must be `1` (the default); Ray itself handles parallelism inside the cluster.
+{{< /markdown >}}
 {{< /variant >}}
 
 ## Examples

--- a/content/integrations/ray/_index.md
+++ b/content/integrations/ray/_index.md
@@ -133,7 +133,10 @@ ray_env = flyte.TaskEnvironment(
 
 The first task creates the shared cluster; once it is ready, every subsequent task with the same environment submits its Ray job directly to it, skipping cluster startup entirely. Each job still runs and reports under its own run identity.
 
-The cluster's identity is derived from the task environment: its name, the Ray configuration, the container image and resources, any pod template, and the reuse policy itself. Tasks with an identical environment share one cluster; changing any of these (for example deploying a new image or code version) creates a fresh cluster rather than reusing a stale one.
+The cluster's identity is derived from the task environment: its name, the Ray configuration, the container image and resources, any pod template, the security context (service account and secrets), the code bundle, and the reuse policy itself. Tasks with an identical environment share one cluster; changing any of these (for example deploying a new image or code version, or switching service account) creates a fresh cluster rather than reusing a stale one.
+
+> [!NOTE]
+> `ReusePolicy` logs a recommendation to use at least two replicas to avoid starvation. That advice applies to reusable containers, not to reusable Ray clusters, which require exactly one shared cluster and let Ray schedule work across its nodes. You can ignore the warning here.
 
 ### Reuse scope
 
@@ -151,12 +154,13 @@ reusable = flyte.ReusePolicy(replicas=1, idle_ttl=300, scope="run")
 
 ### Cleanup
 
-A shared cluster is never deleted when an individual task completes or is aborted — it is shut down automatically after it has been idle (no jobs running against it) for `idle_ttl`.
+A shared cluster is never deleted when an individual task completes or is aborted. It is shut down automatically after it has been idle (no jobs running against it) for `idle_ttl`.
 
 ### Constraints
 
-- `replicas` must be exactly `1` — one shared Ray cluster per environment.
-- `concurrency` must be `1` (the default); Ray itself handles parallelism inside the cluster.
+- `replicas` must be `1`: one shared Ray cluster per environment. An autoscaling range whose maximum is greater than `1`, such as `(1, 3)`, is rejected.
+- `concurrency` must be `1` (the default). Ray itself handles parallelism inside the cluster.
+- `shutdown_after_job_finishes` and `ttl_seconds_after_finished` must not be set on the `RayJobConfig`. The shared cluster has to outlive the individual jobs that run on it, so `idle_ttl` governs its shutdown instead. The `RayJobConfig` example under [Configuration](#configuration) above sets both, so drop them when you add a reuse policy.
 {{< /markdown >}}
 {{< /variant >}}
 

--- a/content/integrations/ray/_index.md
+++ b/content/integrations/ray/_index.md
@@ -31,8 +31,10 @@ image = (
 ```
 
 {{< variant union >}}
+{{< markdown >}}
 > [!NOTE]
-For self-managed setups, refer to the [setup instructions](../../deployment/selfmanaged//configuration/plugins#ray) to enable the Ray plugin in your data plane.
+> For self-managed setups, refer to the [setup instructions](../../deployment/selfmanaged/configuration/plugins#ray) to enable the Ray plugin in your data plane.
+{{< /markdown >}}
 {{< /variant >}}
 
 ## Configuration

--- a/content/integrations/ray/_index.md
+++ b/content/integrations/ray/_index.md
@@ -107,7 +107,7 @@ ray_config = RayJobConfig(
 
 ## Reusable Ray clusters
 
-By default every Ray task pays the full cluster cold-start cost: a new Ray cluster is provisioned for the task and torn down when it finishes. If your workload runs many Ray jobs with the same cluster configuration, you can instead share one long-lived Ray cluster across tasks by attaching a [`ReusePolicy`](../../user-guide/tasks/task-configuration/reusable-containers) to the Ray `TaskEnvironment`:
+By default, every Ray task pays the full cluster cold-start cost: a new Ray cluster is provisioned for the task and torn down when it finishes. If your workload runs many Ray jobs with the same cluster configuration, you can instead share one long-lived Ray cluster across tasks by attaching a `flyte.ReusePolicy` (see [Reusable containers](../../user-guide/tasks/task-configuration/reusable-containers)) to the Ray `TaskEnvironment`:
 
 ```python
 import flyte

--- a/content/integrations/ray/_index.md
+++ b/content/integrations/ray/_index.md
@@ -104,6 +104,7 @@ ray_config = RayJobConfig(
 ```
 
 {{< variant union >}}
+{{< markdown >}}
 
 ## Reusable Ray clusters
 

--- a/content/integrations/ray/_index.md
+++ b/content/integrations/ray/_index.md
@@ -104,6 +104,7 @@ ray_config = RayJobConfig(
 ```
 
 {{< variant union >}}
+
 ## Reusable Ray clusters
 
 By default every Ray task pays the full cluster cold-start cost: a new Ray cluster is provisioned for the task and torn down when it finishes. If your workload runs many Ray jobs with the same cluster configuration, you can instead share one long-lived Ray cluster across tasks by attaching a [`ReusePolicy`](../../user-guide/tasks/task-configuration/reusable-containers) to the Ray `TaskEnvironment`:

--- a/content/user-guide/tasks/task-configuration/reusable-containers.md
+++ b/content/user-guide/tasks/task-configuration/reusable-containers.md
@@ -68,6 +68,9 @@ Enable container reuse by adding a `ReusePolicy` to your `TaskEnvironment`:
 
 For complete parameter documentation, including accepted types, defaults, capacity math, and lifecycle behavior, see the [`ReusePolicy` API reference](../../../api-reference/flyte-sdk/flyte/reusepolicy).
 
+> [!NOTE]
+> The `scope` parameter, which restricts reuse to a single run, currently applies only to [reusable Ray clusters](../../../integrations/ray/_index#reusable-ray-clusters). A reusable container environment is shared across runs regardless of the value you set.
+
 ## Understanding parameter relationships
 
 The four `ReusePolicy` parameters work together to control different aspects of container management:


### PR DESCRIPTION
## Overview

Documents the new reusable Ray cluster support on the [Ray integration page](https://www.union.ai/docs/v2/union/integrations/ray/) (Union variant only):

- **Reusable Ray clusters**: attaching `reusable=flyte.ReusePolicy(...)` to a Ray `TaskEnvironment` shares one long-lived RayCluster across tasks instead of provisioning a transient cluster per task. Covers how cluster identity is derived (env name, Ray spec, image, resources, pod template, policy) and that identical environments map to the same cluster.
- **Reuse scope**: `scope="global"` (default — one cluster shared across all runs) vs `scope="run"` (each run gets its own shared cluster).
- **Cleanup**: shared clusters are reaped after `idle_ttl` of inactivity, never deleted by individual task completion/abort.
- **Constraints**: `replicas=1`, `concurrency=1` (enforced by the SDK's `RayFunctionTask`).

Semantics verified against the SDK (`flyte._reusable_environment.ReusePolicy`, `flyteplugins/ray/task.py`) and the backend implementation (unionai/cloud `leaseworker/fastray`).

The section is wrapped in `{{< variant union >}}` since reusable Ray clusters are Union-only.