### PR TITLE
docsy(v2): fix workflow_run script injection in deploy-pr-preview (CWE-94)

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -9,6 +9,17 @@ name: Deploy PR preview
 # the untrusted build happens secret-less in build-pr.yml, and this job only
 # ever DOWNLOADS that prebuilt artifact and deploys it — it never checks out
 # or executes untrusted PR code/build scripts with secrets in scope.
+#
+# SECURITY (untrusted DATA, not just untrusted code): pr-meta.json is written
+# by our own build-pr.yml, but every field in it comes from the fork PR
+# (head_ref is the fork's branch name, pr_number / head_sha the PR's), so by
+# the time this trusted job reads it, all three are ATTACKER-CONTROLLED. They
+# must never be interpolated as `${{ }}` into a `run:` script body: GitHub
+# substitutes `${{ }}` into the script TEXT before bash parses it, so a branch
+# named `$(cmd)` would execute here with the Cloudflare secrets in scope.
+# Instead: (1) validate each field and fail closed in "Parse PR metadata",
+# and (2) pass values into later steps via `env:` and reference them quoted —
+# `env:` is not subject to script-text substitution.
 
 on:
   workflow_run:
@@ -48,6 +59,21 @@ jobs:
           pr_number=$(jq -r '.pr_number' pr-meta.json)
           head_sha=$(jq -r '.head_sha' pr-meta.json)
           head_ref=$(jq -r '.head_ref' pr-meta.json)
+          # Every field of pr-meta.json originates in the fork PR, so treat all
+          # three as untrusted and validate BEFORE they reach any later step.
+          # Fail closed: a value that does not match its expected shape aborts
+          # the deploy rather than flowing to a sink. (Git ref names are already
+          # constrained, but the value arrived through an artifact, so we
+          # re-validate here defensively.)
+          if ! printf '%s' "$pr_number" | grep -qE '^[0-9]+$'; then
+            echo "Refusing non-numeric pr_number: $pr_number" >&2; exit 1
+          fi
+          if ! printf '%s' "$head_sha" | grep -qE '^[0-9a-fA-F]{7,40}$'; then
+            echo "Refusing non-hex head_sha: $head_sha" >&2; exit 1
+          fi
+          if ! printf '%s' "$head_ref" | grep -qE '^[A-Za-z0-9._/-]+$'; then
+            echo "Refusing suspicious head_ref: $head_ref" >&2; exit 1
+          fi
           echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
           echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
           echo "head_ref=$head_ref" >> "$GITHUB_OUTPUT"
@@ -55,6 +81,13 @@ jobs:
 
       - name: Sanitize branch name for CF Pages
         id: branch
+        # Untrusted values reach this step via env:, NOT via ${{ }} interpolation
+        # into the script text. A branch named `$(cmd)` therefore lands in
+        # "$RAW_BRANCH" as literal data and is never executed. See the SECURITY
+        # note at the top of this file.
+        env:
+          PR_NUM: ${{ steps.meta.outputs.pr_number }}
+          RAW_BRANCH: ${{ steps.meta.outputs.head_ref }}
         run: |
           # CF Pages branch names: lowercase alphanumeric + hyphens, max 28 chars.
           #
@@ -62,11 +95,9 @@ jobs:
           # (a) makes each PR's preview alias unique even when two PRs share a
           # long common branch-name prefix, and (b) guarantees a PR deploy can
           # never sanitize to a production branch name like `main` or `v1`.
-          pr_num="${{ steps.meta.outputs.pr_number }}"
-          raw_branch="${{ steps.meta.outputs.head_ref }}"
-          full=$(printf 'pr-%s-%s' "$pr_num" "$raw_branch" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^a-z0-9]+#-#g' | sed -E 's#^-+|-+$##g')
+          full=$(printf 'pr-%s-%s' "$PR_NUM" "$RAW_BRANCH" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^a-z0-9]+#-#g' | sed -E 's#^-+|-+$##g')
           sanitized=$(printf '%s' "$full" | cut -c1-28 | sed -E 's#-+$##g')
-          echo "Source PR #$pr_num branch '$raw_branch' → CF Pages branch: $sanitized"
+          echo "Source PR #$PR_NUM branch '$RAW_BRANCH' → CF Pages branch: $sanitized"
           echo "name=$sanitized" >> "$GITHUB_OUTPUT"
 
       - name: Deploy to Cloudflare Pages
@@ -79,6 +110,8 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_PAGES_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # branch is steps.branch.outputs.name — already sanitized to
+          # [a-z0-9-], max 28 chars, so it cannot inject into this command.
           # --commit-dirty: the prebuilt dist contains regenerated tracked
           # files, so wrangler would otherwise warn about a dirty tree. The
           # warning is noise here.
@@ -86,14 +119,21 @@ jobs:
 
       - name: Deploy summary
         if: success()
+        # Values via env: rather than ${{ }} in the script text (defense in
+        # depth — head_sha is validated hex and CF_BRANCH is sanitized, but they
+        # still originate from the untrusted artifact).
+        env:
+          CF_BRANCH: ${{ steps.branch.outputs.name }}
+          HEAD_SHA: ${{ steps.meta.outputs.head_sha }}
+          DEPLOY_URL: ${{ steps.deploy.outputs.deployment-url }}
         run: |
           echo "## Deployment" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "- Project: \`docs\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Branch (CF Pages): \`${{ steps.branch.outputs.name }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Commit: \`${{ steps.meta.outputs.head_sha }}\`" >> "$GITHUB_STEP_SUMMARY"
-          if [ -n "${{ steps.deploy.outputs.deployment-url }}" ]; then
-            echo "- Deployment URL: ${{ steps.deploy.outputs.deployment-url }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Branch (CF Pages): \`$CF_BRANCH\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Commit: \`$HEAD_SHA\`" >> "$GITHUB_STEP_SUMMARY"
+          if [ -n "$DEPLOY_URL" ]; then
+            echo "- Deployment URL: $DEPLOY_URL" >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Post / update preview comment on PR
@@ -102,7 +142,9 @@ jobs:
         with:
           header: gha-build-and-deploy-preview
           # workflow_run runs detached from any PR, so the comment target must
-          # be named explicitly via `number`.
+          # be named explicitly via `number`. These values render as comment
+          # DATA (an action input), not a shell script, and pr_number is
+          # validated numeric above.
           number: ${{ steps.meta.outputs.pr_number }}
           message: |
             ### GHA build & deploy preview


### PR DESCRIPTION
## Security fix — `workflow_run` script injection (CWE-94)

Closes a High-severity command-injection in the two-stage docs preview pipeline, reported via the security inbox and verified against the live workflows.

### The defect
`deploy-pr-preview.yml` runs on `workflow_run`, i.e. the **trusted** base-repo context with repository secrets in scope. It downloads the `pr-dist` artifact built by the untrusted fork build and reads `pr-meta.json`, then interpolated a fork-controlled field straight into a `run:` script:

```yaml
raw_branch="${{ steps.meta.outputs.head_ref }}"
```

GitHub substitutes `${{ }}` into the **script text** before bash parses it, so a fork PR whose branch is named `$(cmd)` executes `cmd` in the trusted job — with `CLOUDFLARE_PAGES_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, and `GITHUB_TOKEN` (pull-requests: write) available. That Cloudflare token is the **same one `build-and-deploy.yml` uses to publish production docs**, so this is code-exec → control of `web-docs.union.ai` and `www.union.ai/docs/`.

The `sed` sanitizer ran one line **after** the vulnerable assignment, so it never protected the sink. The `pr-meta.json` file is written by our own workflow, but every field originates in the fork, so it is untrusted **data**.

Reachability is proven end-to-end: PR #1301 (a first-time outside contributor's fork PR) ran the full build → trusted-deploy path and produced the `pr-1301-setup-doc-fixes` preview alias — the sanitized form of the same value injected one line earlier.

### The fix (this PR)
1. **Validate + fail closed** — `pr_number`, `head_sha`, `head_ref` are checked against strict patterns in *Parse PR metadata*; a non-conforming value aborts the deploy before reaching any sink.
2. **`env:` instead of `${{ }}` in `run:` bodies** — artifact-derived values are passed through `env:` and referenced quoted. `env:` values are not subject to script-text substitution, so a `$(cmd)` branch name is inert data.

Fork-PR previews still work: the untrusted-build / trusted-deploy split is unchanged; only the trusted job's data handling is hardened.

Verified: the payload `$(echo${IFS}'$(id>marker)')` (a legal git ref) fires against the old logic and is both (a) rejected by validation and (b) inert under the new `env:` handling.

### Follow-ups (not in this PR)
- **Rotate `CLOUDFLARE_PAGES_API_TOKEN`** and split the preview token from the production-publish token (human / Cloudflare action).
- Optional hardening: put fork-originated deploys behind an `environment:` with required reviewers.
- Interim: set the repo to "Require approval for all outside collaborators" so one approved PR doesn't permanently un-gate an account.

Companion fix on `v1`: (linked below).

🤖 Generated with [Claude Code](https://claude.com/claude-code)