### PR TITLE
docsy(v2): require reviewer approval for fork-originated preview deploys

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -20,6 +20,11 @@ name: Deploy PR preview
 # Instead: (1) validate each field and fail closed in "Parse PR metadata",
 # and (2) pass values into later steps via `env:` and reference them quoted —
 # `env:` is not subject to script-text substitution.
+#
+# Defense in depth: fork-originated previews additionally pass through the
+# `fork_gate` job, which requires a maintainer to approve the `fork-preview-deploy`
+# environment before the secret-bearing `deploy` job runs. Same-repo previews
+# skip that gate. See the `fork_gate` job below.
 
 on:
   workflow_run:
@@ -37,10 +42,38 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
+  # Approval gate for FORK-originated previews only (DOC-1395 defense in depth).
+  #
+  # This job carries no secrets and does nothing but exist — its only purpose is
+  # to reference the `fork-preview-deploy` environment, whose required-reviewer
+  # protection rule pauses it until a maintainer approves. The secret-bearing
+  # `deploy` job `needs:` it, so for a fork PR the Cloudflare token is never in
+  # scope until a human has signed off on that specific run. The `if:` fires
+  # ONLY when the triggering PR came from a fork (head repo != base repo), so
+  # same-repo (docsy / member) previews skip this job and deploy with no
+  # friction. The code-level fix (validate + `env:`) already closes the
+  # injection; this makes a fork deploy additionally require human sign-off.
+  fork_gate:
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_repository.full_name != github.repository }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: fork-preview-deploy
+    steps:
+      - name: Approved
+        run: echo "Fork-originated preview deploy approved by a required reviewer."
+
   deploy:
-    # Only deploy for successful PR builds. workflow_run fires for every
-    # completion; gate on the originating event + a green build.
-    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    # Runs after fork_gate. Gate on the originating event + a green build, AND
+    # on fork_gate having either SUCCEEDED (fork PR, approved) or been SKIPPED
+    # (same-repo PR, no approval needed). `!cancelled()` lets this job evaluate
+    # even though a skipped `needs` job would otherwise short-circuit it; a
+    # REJECTED fork_gate resolves to 'failure', so the deploy is skipped.
+    needs: [fork_gate]
+    if: >-
+      ${{ !cancelled()
+      && github.event.workflow_run.event == 'pull_request'
+      && github.event.workflow_run.conclusion == 'success'
+      && (needs.fork_gate.result == 'success' || needs.fork_gate.result == 'skipped') }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
 


### PR DESCRIPTION
## Defense in depth for DOC-1395 — require approval for fork-originated preview deploys

Follows the code-level injection fix (#1388/#1389). That fix closed the `workflow_run` script injection; this adds a human-approval gate so a **fork-originated** preview deploy cannot put the Cloudflare token in scope without a maintainer signing off on that specific run. Same-repo (docsy/member) previews are unaffected.

### How it works
- New **`fork_gate`** job references the protected **`fork-preview-deploy`** environment (required reviewer: `ppiegaze`, `can_admins_bypass=false`). Its `if:` fires **only** when the run came from a fork (`github.event.workflow_run.head_repository.full_name != github.repository`). It holds no secrets — its sole purpose is to trigger the environment's required-reviewer pause.
- The secret-bearing **`deploy`** job now `needs: [fork_gate]` and runs when `fork_gate` **succeeded** (fork PR, approved) **or was skipped** (same-repo PR). `!cancelled()` lets the deploy evaluate past a skipped need; a **rejected** gate resolves to `failure`, so the deploy is skipped.

### Behavior
| PR origin | `fork_gate` | Approval needed? | Deploy |
|---|---|---|---|
| Same-repo (docsy/member) | skipped | no | runs immediately |
| Fork, approved | success | yes (reviewer) | runs after approval |
| Fork, rejected | failure | — | skipped, no deploy |

The `fork-preview-deploy` environment was created out-of-band **before** this merges, so the workflow can't auto-create it unprotected.

### Not exercisable by this PR
`deploy-pr-preview.yml` runs from the default branch under `workflow_run`, so the gate takes effect only after merge; the first fork PR afterward exercises it. Validated here by YAML parse + expression review.

v1 companion: #1391 (pending number).

🤖 Generated with [Claude Code](https://claude.com/claude-code)