### PR TITLE
docsy(v2): remove fork-preview approval gate; keep injection fix

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -20,11 +20,6 @@ name: Deploy PR preview
 # Instead: (1) validate each field and fail closed in "Parse PR metadata",
 # and (2) pass values into later steps via `env:` and reference them quoted —
 # `env:` is not subject to script-text substitution.
-#
-# Defense in depth: fork-originated previews additionally pass through the
-# `fork_gate` job, which requires a maintainer to approve the `fork-preview-deploy`
-# environment before the secret-bearing `deploy` job runs. Same-repo previews
-# skip that gate. See the `fork_gate` job below.
 
 on:
   workflow_run:
@@ -42,38 +37,10 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
-  # Approval gate for FORK-originated previews only (DOC-1395 defense in depth).
-  #
-  # This job carries no secrets and does nothing but exist — its only purpose is
-  # to reference the `fork-preview-deploy` environment, whose required-reviewer
-  # protection rule pauses it until a maintainer approves. The secret-bearing
-  # `deploy` job `needs:` it, so for a fork PR the Cloudflare token is never in
-  # scope until a human has signed off on that specific run. The `if:` fires
-  # ONLY when the triggering PR came from a fork (head repo != base repo), so
-  # same-repo (docsy / member) previews skip this job and deploy with no
-  # friction. The code-level fix (validate + `env:`) already closes the
-  # injection; this makes a fork deploy additionally require human sign-off.
-  fork_gate:
-    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_repository.full_name != github.repository }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    environment: fork-preview-deploy
-    steps:
-      - name: Approved
-        run: echo "Fork-originated preview deploy approved by a required reviewer."
-
   deploy:
-    # Runs after fork_gate. Gate on the originating event + a green build, AND
-    # on fork_gate having either SUCCEEDED (fork PR, approved) or been SKIPPED
-    # (same-repo PR, no approval needed). `!cancelled()` lets this job evaluate
-    # even though a skipped `needs` job would otherwise short-circuit it; a
-    # REJECTED fork_gate resolves to 'failure', so the deploy is skipped.
-    needs: [fork_gate]
-    if: >-
-      ${{ !cancelled()
-      && github.event.workflow_run.event == 'pull_request'
-      && github.event.workflow_run.conclusion == 'success'
-      && (needs.fork_gate.result == 'success' || needs.fork_gate.result == 'skipped') }}
+    # Only deploy for successful PR builds. workflow_run fires for every
+    # completion; gate on the originating event + a green build.
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
 


### PR DESCRIPTION
## Remove the fork-preview approval gate (keep the injection fix)

Reverts the `fork_gate` approval job added in #1390. The environment gate held **every** fork-originated preview until a maintainer approved the deploy — which delayed outside contributors from seeing their own previews. That friction isn't worth it: the point of fork previews is that a contributor can see their change rendered.

**This does not reopen the vulnerability.** The DOC-1395 code fix stays in place: `pr-meta.json` fields are validated and fail closed in *Parse PR metadata*, and routed into later steps via `env:` instead of `${{ }}` interpolation into `run:` script text. That is what actually closed the injection; the gate was defense-in-depth on top. A payload branch name is still rejected and inert.

After this merges, the `deploy-pr-preview.yml` job structure returns to the single `deploy` job, and the `fork-preview-deploy` environment (no longer referenced) is deleted.

v1 companion: #1393 (pending number).

🤖 Generated with [Claude Code](https://claude.com/claude-code)