### PR TITLE
docs: fix the MCP stdio commands and scope remote deployment to Union

### DIFF
--- a/content/api-reference/agent-plugins.md
+++ b/content/api-reference/agent-plugins.md
@@ -150,8 +150,9 @@ is duplicated between them.
 moment you install, with no corpus to download and no `uv` required. Your search queries
 do leave your machine.
 
-`flyte-cluster` runs on your machine. It is the SDK's own `flyte-mcp` entry point,
-fetched from PyPI at launch:
+`flyte-cluster` runs on your machine. It is the SDK's own `flyte-mcp` entry point. In
+Claude Code and Codex the harness runs it for you; `uvx` fetches it from PyPI at each
+launch. This is the command:
 
 ```bash
 uvx --from "flyte[mcp]>=2.5.18" flyte-mcp --transport stdio \
@@ -186,12 +187,6 @@ takes a few lines.
 
 `flyte-docs`:
 
-```toml
-# Codex: ~/.codex/config.toml
-[mcp_servers.flyte-docs]
-url = "https://flyte-mcp.apps.demo.hosted.unionai.cloud/flyte-mcp/mcp"
-```
-
 ```json
 // opencode: opencode.json
 { "mcp": { "flyte-docs": { "type": "remote",
@@ -206,17 +201,13 @@ mcp_servers:
     url: "https://flyte-mcp.apps.demo.hosted.unionai.cloud/flyte-mcp/mcp"
 ```
 
-pi uses the same `mcpServers` shape in `~/.pi/agent/mcp.json`.
+```json
+// pi: ~/.pi/agent/mcp.json
+{ "mcpServers": { "flyte-docs": { "type": "http",
+  "url": "https://flyte-mcp.apps.demo.hosted.unionai.cloud/flyte-mcp/mcp" } } }
+```
 
 `flyte-cluster`:
-
-```toml
-# Codex: ~/.codex/config.toml
-[mcp_servers.flyte-cluster]
-command = "uvx"
-args = ["--from", "flyte[mcp]>=2.5.18", "flyte-mcp", "--transport", "stdio",
-        "--tool-groups", "task,run,action,logs,app,trigger,project,secret,condition,identity"]
-```
 
 ```json
 // opencode: opencode.json
@@ -234,6 +225,19 @@ mcp_servers:
     args: ["--from", "flyte[mcp]>=2.5.18", "flyte-mcp", "--transport", "stdio",
            "--tool-groups", "task,run,action,logs,app,trigger,project,secret,condition,identity"]
 ```
+
+```json
+// pi: ~/.pi/agent/mcp.json
+{ "mcpServers": { "flyte-cluster": {
+  "command": "uvx",
+  "args": ["--from", "flyte[mcp]>=2.5.18", "flyte-mcp", "--transport", "stdio",
+           "--tool-groups",
+           "task,run,action,logs,app,trigger,project,secret,condition,identity"] } } }
+```
+
+If you would rather configure Claude Code or Codex globally instead of through the
+plugin, the same two entries go in their own config files: `.mcp.json` for Claude Code,
+`[mcp_servers.<name>]` in `~/.codex/config.toml` for Codex.
 
 ### Changing what is served
 

--- a/content/api-reference/agent-plugins.md
+++ b/content/api-reference/agent-plugins.md
@@ -14,31 +14,30 @@ clusters, grounded in the Flyte SDK, the documentation, and (optionally) your ow
 cluster.
 
 It's harness-agnostic: the same skills run in **Claude Code, Codex, Hermes,
-OpenCode, Pi, and other agent harnesses**. In Claude Code the bundled MCP servers
-are wired up for you automatically; in other harnesses you configure them manually.
+OpenCode, Pi, and other agent harnesses**. Claude Code and Codex wire up the
+bundled MCP servers for you; in other harnesses you configure them manually.
 
 ## Compatibility
 
-| Harness | Skills | MCP servers |
-|---------|--------|-------------|
-| Claude Code | All | Both, configured automatically |
-| Codex | All | Both, configured automatically |
-| Hermes | Per-skill | Manual setup |
-| OpenCode | All | Manual setup |
-| Pi | All | Manual setup |
+The skills are plain [Agent Skills](https://agentskills.io) (`SKILL.md` plus YAML
+frontmatter), so they load in any harness that supports the standard. The MCP servers
+are declared in the plugin's `.mcp.json`, which only some harnesses read.
 
-Support extends to other harnesses that load agent skills and MCP servers; see the
-repository README for the current list and per-harness setup notes.
+| Harness | Skills | MCP servers | Version pinning |
+|---------|--------|-------------|-----------------|
+| Claude Code | All 20 | Both, automatically | Yes — git ref |
+| Codex CLI | All 20 | Both, automatically | Yes — `--ref` |
+| Hermes | Per-skill | Manual | No — default branch only |
+| opencode | All 20 | Manual | Yes — tag/branch/commit |
+| pi | All 20 | Manual | Yes — tag/commit |
 
-> [!NOTE]
-> This is a community/open-source toolkit maintained in the
-> [`flyteorg/flyte-agent-plugins`](https://github.com/flyteorg/flyte-agent-plugins)
-> repository. See the repository README for the authoritative, up-to-date list of
-> harnesses, skills, tools, and installation options.
+Claude Code reads `.mcp.json` by convention; Codex is pointed at the same file by
+`.codex-plugin/plugin.json`. The other three install the skills only — you can still
+add the servers by hand, and [the snippets are below](#adding-the-mcp-servers-manually).
 
 ## Installation
 
-In Claude Code, add the marketplace and install the `flyte` plugin:
+### Claude Code
 
 ```bash
 /plugin marketplace add flyteorg/flyte-agent-plugins
@@ -51,12 +50,45 @@ To pin a version, add the marketplace from a git reference:
 /plugin marketplace add https://github.com/flyteorg/flyte-agent-plugins.git#<tag-or-branch>
 ```
 
-Installing the plugin makes all of the skills available. In Claude Code and Codex
-it also wires up both bundled MCP servers automatically: each reads the same
-`.mcp.json`, and neither server needs a path expanded or a checkout on disk. In
-other harnesses (Hermes, OpenCode, Pi, …), point the harness at the same
-repository to load the skills, then configure the MCP servers manually — see the
-repository README for per-harness instructions.
+### Codex CLI
+
+```bash
+codex plugin marketplace add flyteorg/flyte-agent-plugins   # or --ref <tag-or-branch>
+```
+
+Then install the plugin from `/plugins` inside Codex. Both MCP servers come with it.
+
+### Hermes
+
+Hermes installs one skill at a time, from the default branch only:
+
+```bash
+hermes skills install flyteorg/flyte-agent-plugins/plugins/flyte/skills/<skill-name>
+```
+
+`hermes skills check` and `hermes skills update` refresh what you have installed.
+
+### opencode
+
+opencode discovers `SKILL.md` folders in `.opencode/skills/` (project) and
+`~/.config/opencode/skills/` (global). The [`skills` CLI](https://github.com/vercel-labs/skills)
+reads this repository's marketplace manifest:
+
+```bash
+npx skills add flyteorg/flyte-agent-plugins          # interactive selection
+npx skills add flyteorg/flyte-agent-plugins@<ref>    # pin a tag/branch/commit
+```
+
+You can also copy a skill folder directly into the skills directory.
+
+### pi
+
+pi reads the `pi.skills` manifest in the repository's `package.json`:
+
+```bash
+pi install https://github.com/flyteorg/flyte-agent-plugins        # default branch
+pi install git:github.com/flyteorg/flyte-agent-plugins@<tag>      # pinned
+```
 
 ## Skills
 
@@ -105,22 +137,113 @@ migrating from Flyte 1, and deploying Flyte clusters.
 
 ## MCP servers
 
-The plugin bundles two [MCP](https://modelcontextprotocol.io) servers that give
-an assistant grounded knowledge of Flyte and, optionally, control over your
-cluster.
+The plugin bundles two [MCP](https://modelcontextprotocol.io) servers, split so nothing
+is duplicated between them.
 
-| Server | Tools | Requirements |
-|--------|-------|--------------|
-| `flyte-docs` | Search tools over the Flyte SDK examples, documentation, and `llms.txt` | None — hosted by Union |
-| `flyte-cluster` | Control-plane tools for running tasks, managing executions, and handling apps | `uv` + an authenticated Flyte CLI login |
+| Server | Transport | Tools | Needs |
+|--------|-----------|-------|-------|
+| `flyte-docs` | Hosted HTTP | 3 search tools — Flyte SDK examples, docs examples, `llms.txt` | Nothing |
+| `flyte-cluster` | Local stdio | 29 control-plane tools — tasks, runs, actions, logs, apps, triggers, projects, secrets, conditions, identity | `uv`; a Flyte login for the tools to return data |
 
-The hosted `flyte-docs` server works immediately. The `flyte-cluster` server
-operates on the cluster your Flyte CLI is logged into; set
-`FLYTE_MCP_LOCAL_SEARCH=1` to run search locally instead of sending queries
-externally.
+### What each one does with your data
+
+`flyte-docs` is read-only, unauthenticated, and **operated by Union**. Search works the
+moment you install, with no corpus to download and no `uv` required. Your search queries
+do leave your machine.
+
+`flyte-cluster` runs **on your machine**. It is the SDK's own `flyte-mcp` entry point,
+fetched from PyPI at launch:
+
+```bash
+uvx --from "flyte[mcp]>=2.5.18" flyte-mcp --transport stdio \
+  --tool-groups task,run,action,logs,app,trigger,project,secret,condition,identity
+```
+
+Calls go straight from your machine to your control plane, so no cluster data passes
+through anything Union operates.
+
+Two details in that command are deliberate:
+
+- **`>=2.5.18`** is the first release that caps its `mcp` dependency below 2.0. Below it,
+  the server fails at import.
+- **The `search` groups are excluded.** `flyte-docs` already serves them hosted, and
+  enabling them here clones roughly 120 MB into `~/.flyte/mcp` on first launch.
+
+If you would rather send nothing out at all, drop `flyte-docs` and add `search` to the
+`flyte-cluster` groups. You then trade the hosted lookup for that local corpus.
+
+### A cluster is optional
+
+`flyte-cluster` is tenant-agnostic: it uses the SDK's normal config discovery, so it acts
+on whichever control plane your `flyte` CLI is authenticated against. It **starts even with
+no Flyte config at all** — the tools register either way and fail only when called. The
+plugin is therefore useful while you are still deploying your first cluster.
+
+### Adding the MCP servers manually
+
+Hermes, opencode, and pi support MCP; the plugin simply does not configure it for them.
+Both servers are portable — one is a URL, the other needs no checkout or path — so wiring
+them up is a few lines.
+
+**`flyte-docs`:**
+
+```toml
+# Codex — ~/.codex/config.toml
+[mcp_servers.flyte-docs]
+url = "https://flyte-mcp.apps.demo.hosted.unionai.cloud/flyte-mcp/mcp"
+```
+
+```json
+// opencode — opencode.json
+{ "mcp": { "flyte-docs": { "type": "remote",
+  "url": "https://flyte-mcp.apps.demo.hosted.unionai.cloud/flyte-mcp/mcp",
+  "enabled": true } } }
+```
+
+```yaml
+# Hermes — ~/.hermes/config.yaml
+mcp_servers:
+  flyte-docs:
+    url: "https://flyte-mcp.apps.demo.hosted.unionai.cloud/flyte-mcp/mcp"
+```
+
+pi uses the same `mcpServers` shape in `~/.pi/agent/mcp.json`.
+
+**`flyte-cluster`:**
+
+```toml
+# Codex — ~/.codex/config.toml
+[mcp_servers.flyte-cluster]
+command = "uvx"
+args = ["--from", "flyte[mcp]>=2.5.18", "flyte-mcp", "--transport", "stdio",
+        "--tool-groups", "task,run,action,logs,app,trigger,project,secret,condition,identity"]
+```
+
+```json
+// opencode — opencode.json
+{ "mcp": { "flyte-cluster": { "type": "local", "enabled": true,
+  "command": ["uvx", "--from", "flyte[mcp]>=2.5.18", "flyte-mcp", "--transport", "stdio",
+              "--tool-groups",
+              "task,run,action,logs,app,trigger,project,secret,condition,identity"] } } }
+```
+
+```yaml
+# Hermes — ~/.hermes/config.yaml
+mcp_servers:
+  flyte-cluster:
+    command: "uvx"
+    args: ["--from", "flyte[mcp]>=2.5.18", "flyte-mcp", "--transport", "stdio",
+           "--tool-groups", "task,run,action,logs,app,trigger,project,secret,condition,identity"]
+```
+
+### Changing what is served
+
+Edit `args` in the plugin's `.mcp.json` — or in your own config above — to pass
+`--tool-groups`, `--tools`, or `--read-only`. Scope the server to one project and domain
+with the `FLYTE_MCP_PROJECT` and `FLYTE_MCP_DOMAIN` environment variables.
 
 > [!TIP]
-> The `flyte-cluster` server is the same set of Flyte control-plane tools you can
-> expose yourself with a `FlyteMCPAppEnvironment`. See
-> [Flyte MCP server](../../user-guide/agents/build-mcp/flyte_mcp_server) for how to build
-> and scope your own Flyte MCP server.
+> `flyte-cluster` exposes the same Flyte control-plane tools you can serve yourself with a
+> `FlyteMCPAppEnvironment`. See
+> [Flyte MCP server](../../user-guide/agents/build-mcp/flyte_mcp_server) for the full tool
+> reference, tool groups, and allowlists.

--- a/content/api-reference/agent-plugins.md
+++ b/content/api-reference/agent-plugins.md
@@ -6,16 +6,15 @@ variants: +flyte +union
 
 # Flyte agent plugins
 
-[`flyte-agent-plugins`](https://github.com/flyteorg/flyte-agent-plugins) is an
-**agent harness plugin for Flyte** — a portable bundle of **agent skills** and two
-**MCP servers** that teach an AI coding agent to scaffold workflows, build and serve
-apps, run and inspect executions, migrate Flyte 1 code to Flyte 2, and deploy Flyte
-clusters, grounded in the Flyte SDK, the documentation, and (optionally) your own
-cluster.
+[`flyte-agent-plugins`](https://github.com/flyteorg/flyte-agent-plugins) bundles agent
+skills and two MCP servers for Flyte. Install it and your coding agent can scaffold
+workflows, build and serve apps, run and inspect executions, migrate Flyte 1 code to
+Flyte 2, and deploy clusters, grounded in the Flyte SDK, the documentation, and
+optionally your own cluster.
 
-It's harness-agnostic: the same skills run in **Claude Code, Codex, Hermes,
-OpenCode, Pi, and other agent harnesses**. Claude Code and Codex wire up the
-bundled MCP servers for you; in other harnesses you configure them manually.
+The same skills run in Claude Code, Codex, Hermes, opencode, pi, and any other harness
+that supports agent skills. Claude Code and Codex wire up the MCP servers for you;
+elsewhere you add them by hand.
 
 ## Compatibility
 
@@ -25,15 +24,15 @@ are declared in the plugin's `.mcp.json`, which only some harnesses read.
 
 | Harness | Skills | MCP servers | Version pinning |
 |---------|--------|-------------|-----------------|
-| Claude Code | All 20 | Both, automatically | Yes — git ref |
-| Codex CLI | All 20 | Both, automatically | Yes — `--ref` |
-| Hermes | Per-skill | Manual | No — default branch only |
-| opencode | All 20 | Manual | Yes — tag/branch/commit |
-| pi | All 20 | Manual | Yes — tag/commit |
+| Claude Code | All 20 | Both, automatically | Yes, git ref |
+| Codex CLI | All 20 | Both, automatically | Yes, `--ref` |
+| Hermes | Per-skill | Manual | No, default branch only |
+| opencode | All 20 | Manual | Yes, tag/branch/commit |
+| pi | All 20 | Manual | Yes, tag/commit |
 
 Claude Code reads `.mcp.json` by convention; Codex is pointed at the same file by
-`.codex-plugin/plugin.json`. The other three install the skills only — you can still
-add the servers by hand, and [the snippets are below](#adding-the-mcp-servers-manually).
+`.codex-plugin/plugin.json`. The other three install the skills only. You can still add
+the servers by hand; [the snippets are below](#adding-the-mcp-servers-manually).
 
 ## Installation
 
@@ -105,8 +104,8 @@ migrating from Flyte 1, and deploying Flyte clusters.
 | `flyte-sdk-run` | Run workflows, inspect runs and actions, retrieve logs and outputs, and manage the run lifecycle. |
 | `flyte-sdk-eval` | Build evaluation harnesses and unit tests to validate correctness and performance early. |
 | `flyte-sdk-optimize` | Improve performance via task granularity, caching, and resource tuning using run metadata. |
-| `flyte-sdk-app` | Build and serve apps — FastAPI, Streamlit, vLLM, SGLang, WebSocket, and browser apps. |
-| `flyte-sdk-agent` | Build durable agents — ReAct, Plan-and-Execute, LangGraph, PydanticAI, memory, and MCP tools. |
+| `flyte-sdk-app` | Build and serve apps: FastAPI, Streamlit, vLLM, SGLang, WebSocket, and browser apps. |
+| `flyte-sdk-agent` | Build durable agents: ReAct, Plan-and-Execute, LangGraph, PydanticAI, memory, and MCP tools. |
 | `flyte-sdk-data` | Author data-engineering patterns: ETL, data-quality checks, fan-out/map tasks, and dynamic workflows. |
 | `flyte-sdk-ml` | Author ML workloads: training, hyperparameter optimization, evaluation, and batch/real-time inference. |
 
@@ -125,15 +124,15 @@ migrating from Flyte 1, and deploying Flyte clusters.
 
 | Skill | What it helps with |
 |-------|--------------------|
-| `flyte-deploy-aws` | Deploy a Flyte v2 cluster on AWS from scratch — EKS + S3 + RDS, behind an ALB, with optional TLS and SSO. |
+| `flyte-deploy-aws` | Deploy a Flyte v2 cluster on AWS from scratch: EKS + S3 + RDS, behind an ALB, with optional TLS and SSO. |
 | `deploy-flyte-kind` | Deploy a Flyte stack on a local [kind](https://kind.sigs.k8s.io/) cluster with hosted PostgreSQL and object storage. |
 | `deploy-flyte-kind-vm` | Provision a host (local or a cloud VM) and run the kind-based Flyte deployment on it. |
 | `start-dex-local` | Stand up [Dex](https://dexidp.io/) as an in-cluster OIDC provider to test authentication locally. |
 
 > [!NOTE]
-> The deployment skills target self-hosted, open-source Flyte — provisioning your
-> own EKS or kind cluster. They're most useful for evaluation and self-managed
-> deployments; on a fully managed offering, cluster provisioning is handled for you.
+> The deployment skills target self-hosted, open-source Flyte: they provision your own
+> EKS or kind cluster. On a managed offering Union runs the cluster for you, so these
+> skills are mainly useful for evaluation and self-managed deployments.
 
 ## MCP servers
 
@@ -142,16 +141,16 @@ is duplicated between them.
 
 | Server | Transport | Tools | Needs |
 |--------|-----------|-------|-------|
-| `flyte-docs` | Hosted HTTP | 3 search tools — Flyte SDK examples, docs examples, `llms.txt` | Nothing |
-| `flyte-cluster` | Local stdio | 29 control-plane tools — tasks, runs, actions, logs, apps, triggers, projects, secrets, conditions, identity | `uv`; a Flyte login for the tools to return data |
+| `flyte-docs` | Hosted HTTP | 3 search tools over Flyte SDK examples, docs examples, `llms.txt` | Nothing |
+| `flyte-cluster` | Local stdio | 29 control-plane tools: tasks, runs, actions, logs, apps, triggers, projects, secrets, conditions, identity | `uv`; a Flyte login for the tools to return data |
 
 ### What each one does with your data
 
-`flyte-docs` is read-only, unauthenticated, and **operated by Union**. Search works the
+`flyte-docs` is read-only, unauthenticated, and operated by Union. Search works the
 moment you install, with no corpus to download and no `uv` required. Your search queries
 do leave your machine.
 
-`flyte-cluster` runs **on your machine**. It is the SDK's own `flyte-mcp` entry point,
+`flyte-cluster` runs on your machine. It is the SDK's own `flyte-mcp` entry point,
 fetched from PyPI at launch:
 
 ```bash
@@ -162,46 +161,46 @@ uvx --from "flyte[mcp]>=2.5.18" flyte-mcp --transport stdio \
 Calls go straight from your machine to your control plane, so no cluster data passes
 through anything Union operates.
 
-Two details in that command are deliberate:
+Two things in that command matter:
 
-- **`>=2.5.18`** is the first release that caps its `mcp` dependency below 2.0. Below it,
-  the server fails at import.
-- **The `search` groups are excluded.** `flyte-docs` already serves them hosted, and
-  enabling them here clones roughly 120 MB into `~/.flyte/mcp` on first launch.
+- `>=2.5.18` is the first release that caps its `mcp` dependency below 2.0. Below it the
+  server fails at import.
+- The `search` groups are left out. `flyte-docs` already serves them hosted, and enabling
+  them here clones roughly 120 MB into `~/.flyte/mcp` on first launch.
 
-If you would rather send nothing out at all, drop `flyte-docs` and add `search` to the
-`flyte-cluster` groups. You then trade the hosted lookup for that local corpus.
+To send nothing out at all, drop `flyte-docs` and add `search` to the `flyte-cluster`
+groups. You trade the hosted lookup for the local corpus.
 
 ### A cluster is optional
 
 `flyte-cluster` is tenant-agnostic: it uses the SDK's normal config discovery, so it acts
-on whichever control plane your `flyte` CLI is authenticated against. It **starts even with
-no Flyte config at all** — the tools register either way and fail only when called. The
-plugin is therefore useful while you are still deploying your first cluster.
+on whichever control plane your `flyte` CLI is authenticated against. It starts even with
+no Flyte config: the tools register either way and fail only when called. So the plugin
+still helps while you are deploying your first cluster.
 
 ### Adding the MCP servers manually
 
-Hermes, opencode, and pi support MCP; the plugin simply does not configure it for them.
-Both servers are portable — one is a URL, the other needs no checkout or path — so wiring
-them up is a few lines.
+Hermes, opencode, and pi support MCP; the plugin does not configure it for them. Both
+servers are portable: one is a URL, the other needs no checkout or path. Wiring them up
+takes a few lines.
 
-**`flyte-docs`:**
+`flyte-docs`:
 
 ```toml
-# Codex — ~/.codex/config.toml
+# Codex: ~/.codex/config.toml
 [mcp_servers.flyte-docs]
 url = "https://flyte-mcp.apps.demo.hosted.unionai.cloud/flyte-mcp/mcp"
 ```
 
 ```json
-// opencode — opencode.json
+// opencode: opencode.json
 { "mcp": { "flyte-docs": { "type": "remote",
   "url": "https://flyte-mcp.apps.demo.hosted.unionai.cloud/flyte-mcp/mcp",
   "enabled": true } } }
 ```
 
 ```yaml
-# Hermes — ~/.hermes/config.yaml
+# Hermes: ~/.hermes/config.yaml
 mcp_servers:
   flyte-docs:
     url: "https://flyte-mcp.apps.demo.hosted.unionai.cloud/flyte-mcp/mcp"
@@ -209,10 +208,10 @@ mcp_servers:
 
 pi uses the same `mcpServers` shape in `~/.pi/agent/mcp.json`.
 
-**`flyte-cluster`:**
+`flyte-cluster`:
 
 ```toml
-# Codex — ~/.codex/config.toml
+# Codex: ~/.codex/config.toml
 [mcp_servers.flyte-cluster]
 command = "uvx"
 args = ["--from", "flyte[mcp]>=2.5.18", "flyte-mcp", "--transport", "stdio",
@@ -220,7 +219,7 @@ args = ["--from", "flyte[mcp]>=2.5.18", "flyte-mcp", "--transport", "stdio",
 ```
 
 ```json
-// opencode — opencode.json
+// opencode: opencode.json
 { "mcp": { "flyte-cluster": { "type": "local", "enabled": true,
   "command": ["uvx", "--from", "flyte[mcp]>=2.5.18", "flyte-mcp", "--transport", "stdio",
               "--tool-groups",
@@ -228,7 +227,7 @@ args = ["--from", "flyte[mcp]>=2.5.18", "flyte-mcp", "--transport", "stdio",
 ```
 
 ```yaml
-# Hermes — ~/.hermes/config.yaml
+# Hermes: ~/.hermes/config.yaml
 mcp_servers:
   flyte-cluster:
     command: "uvx"
@@ -238,7 +237,7 @@ mcp_servers:
 
 ### Changing what is served
 
-Edit `args` in the plugin's `.mcp.json` — or in your own config above — to pass
+Edit `args` in the plugin's `.mcp.json`, or in your own config above, to pass
 `--tool-groups`, `--tools`, or `--read-only`. Scope the server to one project and domain
 with the `FLYTE_MCP_PROJECT` and `FLYTE_MCP_DOMAIN` environment variables.
 

--- a/content/api-reference/agent-plugins.md
+++ b/content/api-reference/agent-plugins.md
@@ -22,7 +22,7 @@ are wired up for you automatically; in other harnesses you configure them manual
 | Harness | Skills | MCP servers |
 |---------|--------|-------------|
 | Claude Code | All | Both, configured automatically |
-| Codex | All | Manual setup |
+| Codex | All | Both, configured automatically |
 | Hermes | Per-skill | Manual setup |
 | OpenCode | All | Manual setup |
 | Pi | All | Manual setup |
@@ -51,11 +51,12 @@ To pin a version, add the marketplace from a git reference:
 /plugin marketplace add https://github.com/flyteorg/flyte-agent-plugins.git#<tag-or-branch>
 ```
 
-Installing the plugin makes all of the skills available and, in Claude Code,
-wires up both bundled MCP servers automatically. In other harnesses (Codex,
-Hermes, OpenCode, Pi, …), point the harness at the same repository to load the
-skills, then configure the MCP servers manually — see the repository README for
-per-harness instructions.
+Installing the plugin makes all of the skills available. In Claude Code and Codex
+it also wires up both bundled MCP servers automatically: each reads the same
+`.mcp.json`, and neither server needs a path expanded or a checkout on disk. In
+other harnesses (Hermes, OpenCode, Pi, …), point the harness at the same
+repository to load the skills, then configure the MCP servers manually — see the
+repository README for per-harness instructions.
 
 ## Skills
 

--- a/content/user-guide/agents/build-mcp/_index.md
+++ b/content/user-guide/agents/build-mcp/_index.md
@@ -32,7 +32,9 @@ All MCP app environments expose the same HTTP endpoints:
 The fastest way to try Flyte MCP is locally (no deployment needed):
 
 ```bash
-uvx --from "flyte[mcp]" flyte-mcp
+uvx --from "flyte[mcp]>=2.5.18" flyte-mcp --transport stdio
 ```
+
+`--transport stdio` is required when a client launches the server as a subprocess. The CLI defaults to `streamable-http`, which starts an HTTP listener instead.
 
 For client setup, tool selection, allowlists, and remote deployment, see [Flyte MCP server](./flyte_mcp_server).

--- a/content/user-guide/agents/build-mcp/flyte_mcp_server.md
+++ b/content/user-guide/agents/build-mcp/flyte_mcp_server.md
@@ -6,7 +6,7 @@ variants: +flyte +union
 
 # Flyte MCP server
 
-`FlyteMCPAppEnvironment` exposes {{< key product_name >}} operations as standardized [MCP](https://modelcontextprotocol.io) tools, so AI assistants and LLM clients can drive your cluster programmatically: running tasks, monitoring runs, managing apps and triggers, building images, running UV scripts, and searching the SDK and docs.
+`FlyteMCPAppEnvironment` exposes {{< key product_name >}} operations as standardized [MCP](https://modelcontextprotocol.io) tools, so AI assistants and LLM clients can drive your cluster programmatically: running tasks, monitoring runs, reading logs, inspecting actions, managing apps and triggers, and searching the SDK and docs.
 
 Unlike [`MCPAppEnvironment`](./mcp_server), where you supply your own tools, this environment ships a curated set of Flyte tools out of the box. You decide which of them to expose and what they're allowed to touch.
 
@@ -78,10 +78,10 @@ The server starts even when no Flyte config is present. In that case the tools f
 
 Once running, register it with your client as a **stdio** transport: the client manages the process lifetime. See the [connecting a client](#connecting-a-client) section below.
 
-### Deploying remotely
-
 {{< variant union >}}
 {{< markdown >}}
+### Deploying remotely
+
 Deploy a `FlyteMCPAppEnvironment` as a long-running app to get a stable, shared HTTP endpoint:
 
 ```python
@@ -97,24 +97,11 @@ See [Serve and deploy apps](../../apps/serve-and-deploy-apps/_index) for how dep
 {{< /markdown >}}
 {{< /variant >}}
 
-{{< variant flyte >}}
-{{< markdown >}}
-Deploying the server as a long-running app requires Union.ai apps, which open-source Flyte does not provide. Use the [local stdio mode](#running-locally-with-uvx) instead — it exposes the same tools.
-{{< /markdown >}}
-{{< /variant >}}
-
 ## Basic example
 
 A server with **all** tools enabled. The environment definition is the same for both modes — only the last step differs, since `flyte.serve` deploys it as an app:
 
 {{< code file="/unionai-examples/v2/user-guide/build-mcp/flyte_mcp_app.py" fragment=flyte-mcp-all-tools lang=python >}}
-
-{{< variant flyte >}}
-{{< markdown >}}
-> [!NOTE]
-> The `flyte.serve` and `activate` calls at the end of this example deploy the server as an app, which requires Union.ai. On open-source Flyte, the `FlyteMCPAppEnvironment` above is still what you configure — you run it with the [`flyte-mcp` CLI over stdio](#running-locally-with-uvx) instead of deploying it.
-{{< /markdown >}}
-{{< /variant >}}
 
 The default mount path is `/flyte-mcp`, so with the default `streamable-http` transport the MCP endpoint is `/flyte-mcp/mcp`.
 
@@ -132,7 +119,7 @@ Tools are organized into groups. Pass `tool_groups` to enable only the groups yo
 ```python
 mcp_env = FlyteMCPAppEnvironment(
     name="restricted-mcp",
-    tool_groups=["task", "run", "script"],  # Only these groups
+    tool_groups=["task", "run", "logs"],  # Only these groups
 )
 ```
 
@@ -141,11 +128,15 @@ mcp_env = FlyteMCPAppEnvironment(
 | `all` | All tools (default when both `tool_groups` and `tools` are omitted) | Trusted local development |
 | `core` | No tools (only HTTP routes) | Health-check-only / building up explicitly |
 | `task` | `run_task`, `get_task`, `list_tasks` | Launching and inspecting tasks |
-| `run` | `get_run`, `get_run_io`, `abort_run`, `list_runs`, `wait_for_run` | Monitoring and controlling runs |
-| `app` | `get_app`, `activate_app`, `deactivate_app` | Managing deployed apps |
-| `trigger` | `activate_trigger`, `deactivate_trigger` | Managing triggers |
-| `build` | `build_image` | Building container images remotely |
-| `script` | `build_uv_script_image_remote`, `run_uv_script_remote`, `flyte_uv_script_format`, `flyte_uv_script_example` | Running standalone UV scripts |
+| `run` | `get_run`, `get_run_io`, `abort_run`, `list_runs`, `wait_for_run`, `rerun_run` | Monitoring and controlling runs |
+| `action` | `list_actions`, `get_action`, `abort_action` | Debugging a run step by step: phases, attempts, failure details, timing |
+| `logs` | `get_logs` | Reading task logs |
+| `app` | `get_app`, `list_apps`, `activate_app`, `deactivate_app` | Managing deployed apps |
+| `trigger` | `list_triggers`, `get_trigger`, `activate_trigger`, `deactivate_trigger` | Managing triggers |
+| `project` | `list_projects`, `get_project` | Discovering projects and domains |
+| `secret` | `list_secrets`, `create_secret`, `delete_secret` | Managing secrets (names only — values are never returned) |
+| `condition` | `list_conditions`, `signal_condition` | Answering human-in-the-loop gates |
+| `identity` | `whoami` | Confirming which identity and org the server is acting as |
 | `search` | `search_flyte_sdk_examples`, `search_flyte_docs_examples`, `search_full_docs` | Grounding answers in SDK/docs |
 
 ### 2. Individual tools
@@ -231,16 +222,10 @@ claude mcp add --transport stdio flyte-mcp -- \
 
 `--transport stdio` appears twice on purpose. The first tells Claude Code how to talk to the server; the second tells the server which transport to serve. Without the second, the server starts an HTTP listener and the connection fails.
 
-### Claude Code: remote (HTTP)
-
-{{< variant flyte >}}
-{{< markdown >}}
-Remote servers require Union.ai apps. Use the stdio setup above.
-{{< /markdown >}}
-{{< /variant >}}
-
 {{< variant union >}}
 {{< markdown >}}
+### Claude Code: remote (HTTP)
+
 For a deployed server with a public URL:
 
 ```bash
@@ -268,16 +253,10 @@ OpenCode spawns the `uvx` command for you:
 }
 ```
 
-### OpenCode: remote
-
-{{< variant flyte >}}
-{{< markdown >}}
-Remote servers require Union.ai apps. Use the local setup above.
-{{< /markdown >}}
-{{< /variant >}}
-
 {{< variant union >}}
 {{< markdown >}}
+### OpenCode: remote
+
 ```json
 {
   "$schema": "https://opencode.ai/config.json",
@@ -308,24 +287,35 @@ Remote servers require Union.ai apps. Use the local setup above.
 
 | Tool | Group | Description |
 |------|-------|-------------|
-| `run_task` | `task` | Run a task with inputs; returns run URL and name |
-| `get_task` | `task` | Get task metadata (type, required args, cache settings) |
-| `list_tasks` | `task` | List tasks in a project/domain |
-| `get_run` | `run` | Get run status by name |
-| `wait_for_run` | `run` | Poll until a run completes |
-| `get_run_io` | `run` | Get a run's inputs and outputs |
-| `abort_run` | `run` | Abort a running run |
-| `list_runs` | `run` | List runs for a task |
-| `get_app` | `app` | Get app metadata |
+| `run_task` | `task` | Run a task |
+| `get_task` | `task` | Get task details |
+| `list_tasks` | `task` | List tasks |
+| `get_run` | `run` | Get a run |
+| `get_run_io` | `run` | Get run inputs and outputs |
+| `abort_run` | `run` | Abort a run |
+| `list_runs` | `run` | List runs |
+| `wait_for_run` | `run` | Wait for a run to finish |
+| `rerun_run` | `run` | Re-run a prior run |
+| `list_actions` | `action` | List the actions of a run |
+| `get_action` | `action` | Get action details and timing |
+| `abort_action` | `action` | Abort a single action |
+| `get_logs` | `logs` | Read action logs |
+| `get_app` | `app` | Get an app |
+| `list_apps` | `app` | List apps |
 | `activate_app` | `app` | Activate an app |
 | `deactivate_app` | `app` | Deactivate an app |
+| `list_triggers` | `trigger` | List triggers |
+| `get_trigger` | `trigger` | Get a trigger |
 | `activate_trigger` | `trigger` | Activate a trigger |
 | `deactivate_trigger` | `trigger` | Deactivate a trigger |
-| `build_image` | `build` | Build a container image remotely |
-| `build_uv_script_image_remote` | `script` | Build a UV script image remotely |
-| `run_uv_script_remote` | `script` | Run a UV script remotely |
-| `flyte_uv_script_format` | `script` | Get the UV script template format |
-| `flyte_uv_script_example` | `script` | Get a UV script example |
+| `list_projects` | `project` | List projects |
+| `get_project` | `project` | Get a project |
+| `list_secrets` | `secret` | List secret names |
+| `create_secret` | `secret` | Create a secret |
+| `delete_secret` | `secret` | Delete a secret |
+| `list_conditions` | `condition` | List the conditions of a run |
+| `signal_condition` | `condition` | Signal a waiting condition |
+| `whoami` | `identity` | Show the caller's identity |
 | `search_flyte_sdk_examples` | `search` | Search Flyte SDK examples |
-| `search_flyte_docs_examples` | `search` | Search Union examples |
-| `search_full_docs` | `search` | Search the full documentation |
+| `search_flyte_docs_examples` | `search` | Search Flyte docs examples |
+| `search_full_docs` | `search` | Search the full Flyte docs |

--- a/content/user-guide/agents/build-mcp/flyte_mcp_server.md
+++ b/content/user-guide/agents/build-mcp/flyte_mcp_server.md
@@ -37,26 +37,51 @@ There are two ways to run a Flyte MCP server, suited to different stages:
 
 | Mode | When to use |
 |------|-------------|
-| **Local (stdio)** | Local development and quick experiments. The client launches the server as a subprocess on your machine, using your local Flyte config. |
-| **Remote (HTTP)** | Shared or production use. The server runs as a deployed app with a stable, authenticated URL that any client can connect to. |
+| **Local (stdio)** | One user on one machine. The client launches the server as a subprocess, using your local Flyte config and your existing login. Nothing is deployed, and no data leaves your machine. |
+| **Remote (HTTP)** | A whole team, or a client that cannot launch a subprocess (a browser-based assistant, for example). The server runs as a deployed app with a stable, authenticated URL. |
+
+Prefer stdio unless you need one of the two things only HTTP gives you: a single shared server that nobody has to install, or a URL for a client that has no local process.
+
+{{< variant flyte >}}
+{{< markdown >}}
+> [!NOTE] Remote deployment is not available here
+> Deploying the server as a long-running app requires Union.ai apps, which open-source Flyte does not provide. Use the local stdio mode below. Everything else on this page — tool groups, individual tools, and allowlists — applies to both modes.
+{{< /markdown >}}
+{{< /variant >}}
 
 ### Running locally with `uvx`
 
 The `flyte[mcp]` extra ships a `flyte-mcp` CLI entrypoint. Run it with [`uvx`](https://docs.astral.sh/uv/guides/tools/) (no global install required):
 
 ```bash
-uvx --from "flyte[mcp]" flyte-mcp
+uvx --from "flyte[mcp]>=2.5.18" flyte-mcp --transport stdio
 ```
 
 `uvx` downloads `flyte[mcp]` into an isolated environment, runs `flyte-mcp`, and exits cleanly when you're done. The server reads your active Flyte config (the same one used by the `flyte` CLI or `flyte.init_from_config()`), so whichever project and cluster you're pointed at is what the tools operate on.
 
+Two parts of that command matter:
+
+- **`--transport stdio` is required.** The CLI defaults to `streamable-http`, which starts an HTTP listener instead of speaking JSON-RPC on stdin and stdout. A client that launches the process expecting stdio will not connect without this flag.
+- **`>=2.5.18` is the minimum version.** It is the first release that constrains its `mcp` dependency below 2.0. Earlier versions resolve `mcp` 2.0.0, which removed the module the server imports, and the server exits at startup reporting `mcp is not installed`.
+
 > [!TIP]
-> Pin to a specific SDK version: `uvx --from "flyte[mcp]==2.4.0" flyte-mcp`
+> Pin to an exact version instead of a floor: `uvx --from "flyte[mcp]==2.5.18" flyte-mcp --transport stdio`
+
+The server starts even when no Flyte config is present. In that case the tools fail when the assistant calls them, rather than the server failing to start.
+
+> [!NOTE] Skip the search corpus
+> The three `search_*` tools grep a local copy of the Flyte SDK examples, the docs examples, and `llms.txt`. Enabling them makes the CLI clone roughly 120 MB into `~/.flyte/mcp` on first launch. Pass `--tool-groups` without `search` to skip it:
+> ```bash
+> uvx --from "flyte[mcp]>=2.5.18" flyte-mcp --transport stdio \
+>   --tool-groups task,run,action,logs,app,trigger,project,secret,condition,identity
+> ```
 
 Once running, register it with your client as a **stdio** transport: the client manages the process lifetime. See the [connecting a client](#connecting-a-client) section below.
 
 ### Deploying remotely
 
+{{< variant union >}}
+{{< markdown >}}
 Deploy a `FlyteMCPAppEnvironment` as a long-running app to get a stable, shared HTTP endpoint:
 
 ```python
@@ -66,13 +91,30 @@ handle.activate(wait=True)
 print(f"MCP endpoint: {handle.endpoint}/flyte-mcp/mcp")
 ```
 
+The app is deployed into **your own tenant**, so the server sits in the same trust domain as the data it reads: run metadata, logs, and task inputs and outputs stay inside your account. Set `requires_auth=True` and the endpoint sits behind your organization's SSO, so each call runs as the person driving the agent, with their own permissions.
+
 See [Serve and deploy apps](../../apps/serve-and-deploy-apps/_index) for how deployment, activation, and scaling work in general.
+{{< /markdown >}}
+{{< /variant >}}
+
+{{< variant flyte >}}
+{{< markdown >}}
+Deploying the server as a long-running app requires Union.ai apps, which open-source Flyte does not provide. Use the [local stdio mode](#running-locally-with-uvx) instead — it exposes the same tools.
+{{< /markdown >}}
+{{< /variant >}}
 
 ## Basic example
 
-This deploys a remote server with **all** tools enabled:
+A server with **all** tools enabled. The environment definition is the same for both modes — only the last step differs, since `flyte.serve` deploys it as an app:
 
 {{< code file="/unionai-examples/v2/user-guide/build-mcp/flyte_mcp_app.py" fragment=flyte-mcp-all-tools lang=python >}}
+
+{{< variant flyte >}}
+{{< markdown >}}
+> [!NOTE]
+> The `flyte.serve` and `activate` calls at the end of this example deploy the server as an app, which requires Union.ai. On open-source Flyte, the `FlyteMCPAppEnvironment` above is still what you configure — you run it with the [`flyte-mcp` CLI over stdio](#running-locally-with-uvx) instead of deploying it.
+{{< /markdown >}}
+{{< /variant >}}
 
 The default mount path is `/flyte-mcp`, so with the default `streamable-http` transport the MCP endpoint is `/flyte-mcp/mcp`.
 
@@ -183,11 +225,22 @@ This example combines tool groups, an allowlist, search paths, and instructions 
 Registers the `flyte-mcp` process as a locally managed stdio server. Claude Code starts and stops the `uvx` process automatically:
 
 ```bash
-claude mcp add --transport stdio flyte-mcp -- uvx --from "flyte[mcp]" flyte-mcp
+claude mcp add --transport stdio flyte-mcp -- \
+  uvx --from "flyte[mcp]>=2.5.18" flyte-mcp --transport stdio
 ```
+
+`--transport stdio` appears twice on purpose. The first tells Claude Code how to talk to the server; the second tells the server which transport to serve. Without the second, the server starts an HTTP listener and the connection fails.
 
 ### Claude Code: remote (HTTP)
 
+{{< variant flyte >}}
+{{< markdown >}}
+Remote servers require Union.ai apps. Use the stdio setup above.
+{{< /markdown >}}
+{{< /variant >}}
+
+{{< variant union >}}
+{{< markdown >}}
 For a deployed server with a public URL:
 
 ```bash
@@ -195,6 +248,8 @@ claude mcp add --transport http \
   --header "Authorization: Bearer $TOKEN" \
   flyte-mcp-remote https://<YOUR_HOST>/flyte-mcp/mcp
 ```
+{{< /markdown >}}
+{{< /variant >}}
 
 ### OpenCode: local
 
@@ -206,7 +261,7 @@ OpenCode spawns the `uvx` command for you:
   "mcp": {
     "flyte-mcp": {
       "type": "local",
-      "command": ["uvx", "--from", "flyte[mcp]", "flyte-mcp"],
+      "command": ["uvx", "--from", "flyte[mcp]>=2.5.18", "flyte-mcp", "--transport", "stdio"],
       "enabled": true
     }
   }
@@ -215,6 +270,14 @@ OpenCode spawns the `uvx` command for you:
 
 ### OpenCode: remote
 
+{{< variant flyte >}}
+{{< markdown >}}
+Remote servers require Union.ai apps. Use the local setup above.
+{{< /markdown >}}
+{{< /variant >}}
+
+{{< variant union >}}
+{{< markdown >}}
 ```json
 {
   "$schema": "https://opencode.ai/config.json",
@@ -230,6 +293,8 @@ OpenCode spawns the `uvx` command for you:
   }
 }
 ```
+{{< /markdown >}}
+{{< /variant >}}
 
 ## Best practices
 

--- a/content/user-guide/agents/build-mcp/flyte_mcp_server.md
+++ b/content/user-guide/agents/build-mcp/flyte_mcp_server.md
@@ -10,15 +10,14 @@ variants: +flyte +union
 
 Unlike [`MCPAppEnvironment`](./mcp_server), where you supply your own tools, this environment ships a curated set of Flyte tools out of the box. You decide which of them to expose and what they're allowed to touch.
 
-> [!TIP] Prefer a prebuilt plugin?
-> If you just want these Flyte tools available in your AI coding agent without
-> building a server yourself, [`flyte-agent-plugins`](https://github.com/flyteorg/flyte-agent-plugins) —
-> a portable agent harness plugin for Claude Code, Codex, OpenCode, and other
-> harnesses — bundles a ready-to-use `flyte-cluster` MCP server (the same
-> control-plane tools) plus a hosted `flyte-docs` search server. See
-> [Flyte agent plugins](../../../api-reference/agent-plugins) for details. Build your
-> own `FlyteMCPAppEnvironment` (below) when you need to scope, allowlist, or deploy
-> a shared server.
+> [!TIP] There is a prebuilt plugin
+> [`flyte-agent-plugins`](https://github.com/flyteorg/flyte-agent-plugins) ships these same
+> control-plane tools as a `flyte-cluster` MCP server, plus a hosted `flyte-docs` search
+> server. Claude Code and Codex wire up both for you; Hermes, opencode, and pi take a few
+> lines of config. See [Flyte agent plugins](../../../api-reference/agent-plugins).
+>
+> Build your own `FlyteMCPAppEnvironment` below when you need to scope the tools,
+> allowlist resources, or deploy a shared server.
 
 ## When to use it
 


### PR DESCRIPTION
## Two bugs that stopped the documented setup from working

**1. Every stdio example was missing `--transport stdio` on the server side.**

The CLI defaults to `streamable-http`. The documented command therefore started an HTTP
listener while the client waited on stdin/stdout, so the connection never came up. Confirmed
locally — the bare command prints `Started server process` and `StreamableHTTP session manager`.

Affected the quickstart, the main page, the Claude Code example, and the OpenCode example.

**2. The version tip pinned a release that now fails at startup.**

The page suggested `flyte[mcp]==2.4.0`. That release does not constrain its `mcp` dependency, so
it resolves `mcp` 2.0.0, which removed `mcp.server.fastmcp`. The server exits reporting
`mcp is not installed` — misleading, since `mcp` *is* installed, just incompatible. `2.5.18` is
the first release carrying the cap, so that is now the documented floor.

## Two things that surprise people

- Enabling the `search_*` tools makes the CLI clone roughly 120 MB into `~/.flyte/mcp` on first
  launch. Documented, with the `--tool-groups` line that skips it.
- The server starts fine with no Flyte config; the tools fail when called rather than the server
  failing to start.

## Remote deployment is Union-only

Deploying the server as a long-running app uses Union.ai apps, which open-source Flyte does not
provide. The remote deployment section, both remote client setups, and the `flyte.serve` lines
in the included examples are now scoped with `{{< variant >}}`.

Everything else — the stdio path, tool groups, individual tools, allowlists — applies to both
variants and is unchanged.

Note this contradicts how the rest of the apps documentation is marked (`variants: +flyte +union`
throughout `content/user-guide/apps/`). Those pages are out of scope here, but they may deserve
the same treatment.

## Verification

Built both variants with the pinned Hugo 0.161.1:

| Variant | Union-only caveats | Remote client sections |
|---|---|---|
| flyte | 3 | hidden |
| union | 0 | shown |

Both builds are clean. (Note: building with Hugo < 0.156 fails on `hugo.Data` in
`version-footer.html` — unrelated to this change, but it will bite anyone with an older local
Hugo.)