### PR TITLE
docsy(v2): Ray reusable clusters, missing constraints and cross-links

### DIFF
--- a/content/integrations/dask/_index.md
+++ b/content/integrations/dask/_index.md
@@ -28,8 +28,10 @@ image = flyte.Image.from_debian_base(name="dask").with_pip_packages("flyteplugin
 ```
 
 {{< variant union >}}
+{{< markdown >}}
 > [!NOTE]
-For self-managed setups, refer to the [setup instructions](../../deployment/selfmanaged/configuration/plugins#dask) to enable the Dask plugin in your data plane.
+> For self-managed setups, refer to the [setup instructions](../../deployment/selfmanaged/configuration/plugins#dask) to enable the Dask plugin in your data plane.
+{{< /markdown >}}
 {{< /variant >}}
 
 ## Configuration

--- a/content/integrations/ray/_index.md
+++ b/content/integrations/ray/_index.md
@@ -133,7 +133,10 @@ ray_env = flyte.TaskEnvironment(
 
 The first task creates the shared cluster; once it is ready, every subsequent task with the same environment submits its Ray job directly to it, skipping cluster startup entirely. Each job still runs and reports under its own run identity.
 
-The cluster's identity is derived from the task environment: its name, the Ray configuration, the container image and resources, any pod template, and the reuse policy itself. Tasks with an identical environment share one cluster; changing any of these (for example deploying a new image or code version) creates a fresh cluster rather than reusing a stale one.
+The cluster's identity is derived from the task environment: its name, the Ray configuration, the container image and resources, any pod template, the security context (service account and secrets), the code bundle, and the reuse policy itself. Tasks with an identical environment share one cluster; changing any of these (for example deploying a new image or code version, or switching service account) creates a fresh cluster rather than reusing a stale one.
+
+> [!NOTE]
+> `ReusePolicy` logs a recommendation to use at least two replicas to avoid starvation. That advice applies to reusable containers, not to reusable Ray clusters, which require exactly one shared cluster and let Ray schedule work across its nodes. You can ignore the warning here.
 
 ### Reuse scope
 
@@ -151,12 +154,13 @@ reusable = flyte.ReusePolicy(replicas=1, idle_ttl=300, scope="run")
 
 ### Cleanup
 
-A shared cluster is never deleted when an individual task completes or is aborted — it is shut down automatically after it has been idle (no jobs running against it) for `idle_ttl`.
+A shared cluster is never deleted when an individual task completes or is aborted. It is shut down automatically after it has been idle (no jobs running against it) for `idle_ttl`.
 
 ### Constraints
 
-- `replicas` must be exactly `1` — one shared Ray cluster per environment.
-- `concurrency` must be `1` (the default); Ray itself handles parallelism inside the cluster.
+- `replicas` must be `1`: one shared Ray cluster per environment. An autoscaling range whose maximum is greater than `1`, such as `(1, 3)`, is rejected.
+- `concurrency` must be `1` (the default). Ray itself handles parallelism inside the cluster.
+- `shutdown_after_job_finishes` and `ttl_seconds_after_finished` must not be set on the `RayJobConfig`. The shared cluster has to outlive the individual jobs that run on it, so `idle_ttl` governs its shutdown instead. The `RayJobConfig` example under [Configuration](#configuration) above sets both, so drop them when you add a reuse policy.
 {{< /markdown >}}
 {{< /variant >}}
 

--- a/content/user-guide/tasks/task-configuration/reusable-containers.md
+++ b/content/user-guide/tasks/task-configuration/reusable-containers.md
@@ -68,6 +68,9 @@ Enable container reuse by adding a `ReusePolicy` to your `TaskEnvironment`:
 
 For complete parameter documentation, including accepted types, defaults, capacity math, and lifecycle behavior, see the [`ReusePolicy` API reference](../../../api-reference/flyte-sdk/flyte/reusepolicy).
 
+> [!NOTE]
+> The `scope` parameter, which restricts reuse to a single run, currently applies only to [reusable Ray clusters](../../../integrations/ray/_index#reusable-ray-clusters). A reusable container environment is shared across runs regardless of the value you set.
+
 ## Understanding parameter relationships
 
 The four `ReusePolicy` parameters work together to control different aspects of container management:


### PR DESCRIPTION
Follow-up to #1385 (based on `kevin/ray-reusable-clusters`, so this targets that branch and will retarget to `main` once #1385 merges).

#1385's prose checks out against the SDK and the backend. These are the gaps a verification pass found.

## The page contradicts itself on `RayJobConfig`

flyteorg/flyte-sdk#1388 makes `shutdown_after_job_finishes` and `ttl_seconds_after_finished` hard `BadConfiguration` errors when a reuse policy is set: the shared cluster has to outlive the individual jobs, so `idle_ttl` governs shutdown instead.

The `RayJobConfig` example under **Configuration** on this same page sets **both**. Copy that example, add `reusable=` per the new section, and it raises. Added to Constraints with an explicit pointer back to the example.

Note #1388 merged after #1385's head commit and is not in a released tag yet (`v2.5.18` predates it). The guidance is correct either way: on 2.5.18 the two fields are silently ignored rather than rejected.

## Other corrections

- **`replicas` precision.** `RayFunctionTask.__post_init__` checks `reusable.max_replicas != 1`, so `replicas=(1, 1)` is accepted and an autoscaling range like `(1, 3)` is what gets rejected. "Must be exactly 1" reads as if a literal is required.
- **Cluster identity was incomplete.** `leaseworker/fastray` `GetClusterName` also hashes the security context (service account, secrets) and the code bundle URI. A service-account change forking the cluster is surprising enough to name.
- **Spurious warning.** `ReusePolicy.__post_init__` logs "It is recommended to use a minimum of 2 replicas, to avoid starvation" whenever `max_replicas == 1 and concurrency == 1` — precisely the configuration the Ray plugin requires. Every reader following this page sees it, so the page now says to ignore it. Arguably the SDK should suppress this for plugins that constrain replicas; raising that separately.
- **`scope` cross-link.** `ReusePolicy.scope` is exposed on the shared SDK dataclass but `GetScope()` is read only by `fastray`; `fasttask` has no reference to it, and its environment identity is org/project/domain/name/version with no run component. So `scope` is Ray-only today. Rather than document it on the reusable containers page as a general parameter, that page now cross-links here and states the limitation, since the API reference will surface `scope` with a generic description after the next regen.
- **Style.** Two em-dashes replaced per the house style guide.
- **Dask.** `content/integrations/dask/_index.md` had the identical malformed `> [!NOTE]` callout that #1385 fixed for Ray (missing `>` continuation, missing `{{< markdown >}}` wrapper), so it was rendering as a plain paragraph. Same one-line fix.

## Verification

`make check-links` clean on both variants (it caught a `_index` anchor convention miss, fixed). markdownlint and cspell clean on all three files. Built both variants locally: the Constraints list, both new callouts and the Dask callout render correctly, and the Flyte variant correctly excludes the Union-gated additions.

## Separate: not reachable in production yet

Not addressed here, flagging for the merge decision on #1385. `fastray` is the backend for this feature and is enabled on dogfood, canary and the two demo tenants only (unionai/cloud#17456, "Enable Fast ray for the internal clusters"). Of the production data planes with `ray` enabled, none have `fastray`. With it disabled the plain OSS ray plugin handles the task and `reuse_policy` is ignored, so a customer following this page gets ordinary per-task clusters and no error. Worth confirming the rollout plan before this goes live.

Docs ticket: DOC-1372.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
