### PR TITLE
docsy(v2): CI guard so search-benchmark labels cannot rot silently

### DIFF
--- a/.github/workflows/check-search-labels.yml
+++ b/.github/workflows/check-search-labels.yml
@@ -9,7 +9,10 @@ on:
   pull_request:
     paths:
       - 'content/**'
-      - 'unionai-docs-infra/tools/algolia_indexer/queries.judged.json'
+      # The answer key lives inside the submodule, so from this repo it only
+      # ever changes as a pointer bump -- a path inside unionai-docs-infra/
+      # can never match here.
+      - 'unionai-docs-infra'
   push:
     branches: [main]
 
@@ -23,6 +26,14 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: 'true'
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
 
       - name: Validate benchmark labels resolve to real pages
         run: make check-search-labels

--- a/.github/workflows/check-search-labels.yml
+++ b/.github/workflows/check-search-labels.yml
@@ -1,0 +1,35 @@
+name: Check Search Benchmark Labels
+
+# The search-quality benchmark (DOC-1397) scores search against an answer key
+# of real content URLs. A PR that renames or deletes a labelled page rots that
+# key silently -- the next eval then reports a ranking regression that is
+# really labelling decay. Catch it here instead, at the PR that caused it.
+
+on:
+  pull_request:
+    paths:
+      - 'content/**'
+      - 'unionai-docs-infra/tools/algolia_indexer/queries.judged.json'
+  push:
+    branches: [main]
+
+jobs:
+  check-search-labels:
+    name: "Check Search Benchmark Labels"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: 'true'
+
+      - name: Validate benchmark labels resolve to real pages
+        run: make check-search-labels
+
+      - name: Report status
+        if: ${{ failure() }}
+        run: |
+          echo "::error::A page referenced by the search-quality benchmark no longer exists."
+          echo "::error::If you renamed or removed a page, update the ideal URL(s) in"
+          echo "::error::unionai-docs-infra/tools/algolia_indexer/queries.judged.json to match."


### PR DESCRIPTION
Adds a CI check so the search-quality benchmark's answer key cannot decay unnoticed. Part of **DOC-1397**; the benchmark itself comes from **DOC-1286**.

## The problem

The benchmark scores search against an answer key of real content URLs. Rename or delete a labelled page today and nothing complains — the damage surfaces later as a phantom "ranking regression" at the next eval, long after the PR that caused it, and by then the benchmark has quietly stopped measuring anything real.

## What this does

Runs `make check-search-labels` on PRs touching `content/`. Pure path existence, no network, so it is cheap enough to run every time. On failure it names the file to update rather than leaving the author to work it out.

## ⚠️ Depends on unionai-docs-infra#230

The `check-search-labels` make target and `check_labels.py` live in the infra submodule. **This will fail until infra#230 merges and the submodule pointer is bumped** — hence draft. Merge order: infra#230 → submodule bump → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)