### PR TITLE
docsy(v2): fetch tags in the regen workflow so the folded cut computes z correctly

### DIFF
--- a/.github/workflows/regen-api-docs.yml
+++ b/.github/workflows/regen-api-docs.yml
@@ -51,6 +51,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: "true"
+          # fetch-depth: 0 -- the "Fold version promotion" step below runs
+          # manifest.py, whose z computation derives the next cut from the
+          # EXISTING v<x.y.z>.* tags. A shallow clone fetches no tags, so
+          # existing_z comes back empty and manifest.py proposes z=0 -- a tag
+          # that may already exist and may have been deliberately withdrawn.
+          # That is exactly what #1406 did: it proposed re-cutting v2.5.18.0
+          # (three tags into the 2.5.18 line) which would have restored the
+          # yanked flyteplugins 2.5.19 reference to production stable.
+          # docs-cut.yml already sets this for the same reason; this workflow
+          # folds a cut too and needs the same visibility.
+          fetch-depth: 0
 
       # Mint a short-lived installation token for the docsy-bot App so the draft
       # PR triggers CI (and is attributed to the bot). Skipped until the App


### PR DESCRIPTION
Fixes the defect behind #1406, which **must not be merged as it stands**.

## The bug

`regen-api-docs.yml` checks out shallow (no `fetch-depth`), so **no tags exist in the workspace**. Its *Fold version promotion* step then runs `manifest.py`, whose z computation is:

```python
def existing_z(sdk_version):
    out = _git("tag", "--list", f"v{sdk_version}.*") or ""
```

With no tags that returns empty, so `compute_next_version` takes the `if not zs` branch and yields `z=0, cut_kind="sdk-release"` — *the first cut against that SDK version* — no matter how many cuts already exist.

## What it produced live

The 2.5.18 line already has tags `v2.5.18.0`, `.1`, `.2`, and stable is `v2.5.18.2`. #1406 proposed:

```
stable:      v2.5.18.2  ->  v2.5.18.0
enumerated:  + v2.5.18.2          (current stable demoted)
manifest:    z=2 -> z=0, cut_kind manual -> sdk-release, existing_z [0,1] -> []
```

`v2.5.18.0` still carries the `flyteplugins-*` **2.5.19** API reference — verified: `agents/core/_index.md` reads `version: 2.5.19` at that tag. It was rolled back precisely because those releases are being yanked. Merging #1406 would have restored a yanked API surface to production stable and deleted the comment block recording why three tags were withdrawn.

## Why it stayed hidden

The only previous fold (#1373) was *legitimately* `z=0` — the first cut against 2.5.19 — so an empty `existing_z` happened to be the right answer. The bug only surfaces on the second cut against a given SDK version.

## The fix

`docs-cut.yml` already sets `fetch-depth: 0` with the comment *"need all tags for the z computation"*. This workflow folds a cut too and needs the same visibility. One line, plus a comment so it does not get dropped again.

## Note on #1406

The bot reuses a fixed branch (`docsy/api-ref-refresh-auto`), so once this merges the next scheduled run force-pushes and **corrects #1406 in place**. Until then it is a live hazard: non-draft, green, and wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)