### PR TITLE
docsy(v1): withhold the v1 line from search deliberately (DOC-1291)

### DIFF
--- a/versions.toml
+++ b/versions.toml
@@ -5,6 +5,18 @@
 #              enumerated -- no byte-identical duplicate tree.
 # latest     = whether this line owns the global /docs/latest URL. Only the
 #              primary line does; a secondary line (v1) sets false.
+# indexed    = whether this line's stable tree is search-indexed. Defaults true
+#              (the stable tree is normally the line's one canonical surface).
 stable = "v1.16.26.2"
 enumerated = []
 latest = false
+# The v1 line is withheld from search so Google consolidates on v2 (DOC-1291).
+# This was already the effective state, but only by accident: the Pages
+# preview-alias emitted X-Robots-Tag: noindex (DOC-1332) while this build emitted
+# <meta name="robots" content="index,follow">, so the two directives contradicted
+# each other and the more restrictive one happened to win. Setting this makes the
+# meta tag agree, so the line stays out of the index even if that header changes.
+# Note v1 is ACTIVE, not frozen -- it still takes flytekit 1.x releases and new
+# cuts. This withholds it from Google; it stays reachable by direct link and by
+# on-site search.
+indexed = false


### PR DESCRIPTION
Sets `indexed = false` so this line's stable tree is built noindex, and bumps the infra pointer to the commit that teaches `build_versions.sh` to honour it.

## Why

`/docs/v1` has been serving two contradictory directives:

```
x-robots-tag: noindex                        ← HTTP header
<meta name="robots" content="index,follow">  ← this build
```

The line stays out of Google only because conflicting robots directives resolve to **the most restrictive one**, and because that header exists at all — which is an **accident**. Nothing in either repo asked for it; it is a side effect of the Pages preview-alias behaviour recorded in DOC-1332. If that changes, the only surviving directive is `index,follow` and v1 becomes indexable overnight.

Setting `indexed = false` makes the meta tag agree with the intent. Settles **DOC-1291** and **DOC-1320 step 3**.

v1 is **active, not frozen** — it still takes flytekit 1.x releases and new cuts. This withholds it from Google only; it stays reachable by direct link and on-site search.

## The pointer bump is not optional, and it is not small

`indexed = false` is inert on v1's pinned infra (`a88e846`), which predates the `LINE_INDEXED` logic. There is no way to make v1 noindex without advancing the pointer, and v1 is **10 infra commits behind**, so the bump necessarily brings them all. Stating what rides along rather than letting it land silently:

| Commit | What | v1 effect |
|---|---|---|
| `fbb9730` | the `indexed` / X-Robots-Tag change | **the point of this PR** |
| `cbb8069` #225 | deterministic heading anchors | **real** |
| `4e58846` #222 | absolute sitemap `<loc>` | **real** |
| `cfc4358` #224 | infra README only | inert |
| `0b425f5` #228 | llms.txt root lift | inert for v1 |
| `2d3e784` #234 | variants frontmatter collision | regen-time only |
| `96f5dbd` `c3f1ebc` `c1bf978` `3eabec1` `900636f` | api_generator fixes | regen-time only |

The two with real effect are both improvements and both low risk on a noindexed line:

- **#225** stops v1 heading anchors moving between deploys (they become `#operator` rather than a build-varying placeholder; #1380 is the content half that makes them readable)
- **#222** makes v1's sitemaps valid and drops the URLs that 404 — and those sitemaps stay unadvertised either way per the DOC-1291 decision

The api_generator fixes only take effect when v1 regenerates its API reference, which this PR does not do.

## What to check on the preview

- `/docs/v1/union/` → `<meta name="robots" content="noindex,nofollow">`
- `dist/_headers` → an `X-Robots-Tag: noindex` block for `/docs/v1/*`
- v1 sitemaps valid (absolute `<loc>`, no scaffold) — a side effect of #222 riding along

## Merge order

The pointer targets `fbb9730`, a branch commit on **infra#236**, so the preview can be checked. Re-point at infra `main` once #236 merges, then merge this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)