### PR TITLE
docsy(v1): cut v1.16.26.3 — readable heading anchors reach /docs/v1

### DIFF
--- a/data/version-manifest.json
+++ b/data/version-manifest.json
@@ -1,11 +1,12 @@
 {
-  "docs_version": "1.16.26.2",
-  "tag": "v1.16.26.2",
-  "z": 2,
+  "docs_version": "1.16.26.3",
+  "tag": "v1.16.26.3",
+  "z": 3,
   "cut_kind": "manual",
   "existing_z": [
     0,
-    1
+    1,
+    2
   ],
   "sdk": "1.16.26",
   "sdk_on_pypi": "true",
@@ -15,15 +16,15 @@
       "flytekit": "1.16.26",
       "union": "0.1.203",
       "examples": "d09852bdfeb7848b5d774e4db7b5240cac5b8617",
-      "content": "2a4fc3bd6d97763542871f9612a834ef40e7c215",
-      "infra": "906d3939a98a3907537c44b0a4a95681799d89e2"
+      "content": "f2783cd7b8802c37c60d6d61d016fe63136918ea",
+      "infra": "42e060111fd1890fd5292aab3097c4aefa92fcf5"
     },
     "flyte": {
       "flytekit": "1.16.26",
       "backend": "v1.16.8",
       "examples": "d09852bdfeb7848b5d774e4db7b5240cac5b8617",
-      "content": "2a4fc3bd6d97763542871f9612a834ef40e7c215",
-      "infra": "906d3939a98a3907537c44b0a4a95681799d89e2"
+      "content": "f2783cd7b8802c37c60d6d61d016fe63136918ea",
+      "infra": "42e060111fd1890fd5292aab3097c4aefa92fcf5"
     }
   }
 }

--- a/versions.toml
+++ b/versions.toml
@@ -7,8 +7,14 @@
 #              primary line does; a secondary line (v1) sets false.
 # indexed    = whether this line's stable tree is search-indexed. Defaults true
 #              (the stable tree is normally the line's one canonical surface).
-stable = "v1.16.26.2"
+stable = "v1.16.26.3"
 enumerated = []
+# v1.16.26.2 is deliberately not enumerated. It documents exactly the same
+# product state as .3 (flytekit 1.16.26, union 0.1.203); .3 only makes heading
+# anchors readable (DOC-1357). Serving it would add a near-duplicate tree for no
+# reader benefit. Same rule applied to v2.5.18.2 on main: a pinned version earns
+# its place by documenting a distinct product state, not by having once been
+# stable.
 latest = false
 # The v1 line is withheld from search so Google consolidates on v2 (DOC-1291).
 # This was already the effective state, but only by accident: the Pages


### PR DESCRIPTION
Promotes stable `v1.16.26.2 → v1.16.26.3` so the DOC-1357 content fix (#1380) reaches the served v1 tree.

Same two-step as v2: #1380 put the layout safety net into production via the infra bump, which stopped anchor ids moving immediately — but the readable form lives in *content*, and content is versioned, so `/docs/v1` needs a cut to pick it up.

**v1 was the larger half:** 94 headings across 50 pages, and 162 of the 186 pages that differed between two identical builds. The `check-determinism` workflow now runs on this line and passed on #1380 — the assertion that would have failed on v1 before the fix.

## Also now live on v1, from the same infra bump

| | |
|---|---|
| `indexed = false` | stable tree built noindex, so the meta robots tag stops contradicting the `X-Robots-Tag` header v1 relied on by accident (DOC-1291 / DOC-1332) |
| `_headers` X-Robots-Tag | covers the non-HTML files a meta tag cannot reach — `llms.txt`, `sitemap.xml`, `page.md` |
| valid sitemaps | absolute `<loc>`, unpublished pages dropped (infra#222) |

## Notes

**`v1.16.26.2` is deliberately not enumerated.** It documents the same product state as `.3` (flytekit 1.16.26, union 0.1.203) and differs only in anchor form, so serving it would add a near-duplicate tree for no reader benefit. Same rule applied to `v2.5.18.2` on main.

**`versions.toml` edited by hand**, not via `manifest.py --promote` — promote rewrites the file and would drop `latest` and `indexed`, which is exactly how the first v1 cut lost `latest = false` (DOC-1330). Asserted both survive parsing.

`manifest.py` resolved `v1.16.26.3` independently (manual; z=3, existing z=`[0,1,2]`).

## After this

A single Algolia reindex across all four trees, then unpause the crawler. The paused run is holding a partial temporary index; the live index is untouched and still serving pre-fix anchors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)