### PR TITLE
docsy(v2): push the search index after each production deploy

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -203,6 +203,20 @@ jobs:
           # GITHUB_SHA env var.
           command: pages deploy ./dist --project-name=docs --branch=${{ steps.branch.outputs.name }} --commit-dirty=true
 
+      - name: Update search index
+        # After the deploy, not before: the index should describe what is now
+        # served. Scoped to the slices THIS branch built (main: v2 + latest;
+        # v1 branch: v1), so the two lines cannot clobber each other's records.
+        #
+        # Skips itself when the secret is absent, so forks and any repo without
+        # Algolia credentials still deploy normally.
+        if: success() && github.event_name == 'push'
+        timeout-minutes: 15
+        env:
+          ALGOLIA_DOCS_2_APPLICATION_ID: ${{ secrets.ALGOLIA_DOCS_2_APPLICATION_ID }}
+          ALGOLIA_DOCS_2_WRITE_API_KEY: ${{ secrets.ALGOLIA_DOCS_2_WRITE_API_KEY }}
+        run: make index-search
+
       - name: Deploy summary
         if: success()
         run: |


### PR DESCRIPTION
Wires the build-time search indexer into the deploy, so the index stops depending on someone running it by hand. Part of **DOC-1286**.

## Why

The index is generated from `dist/`, so today it only updates when run manually — and goes stale the moment anyone cuts a version. This repo cuts every ~1.3 days, and a cut is exactly when search matters most: the new stable's content is live and unsearchable until someone remembers.

## Behaviour

- **After** the Cloudflare deploy, not before — the index should describe what is now served.
- **`push` events only**, so PR previews cannot write to the production index.
- **Scoped to the slices this branch built** — `main` carries v2 + latest, the `v1` branch carries v1. Neither can clobber the other's records; `replace_all_objects` is deliberately never used for the same reason.
- **Skips itself without credentials**, so forks and any repo lacking Algolia secrets still deploy normally.
- 15-minute step cap, matching the existing deploy-step convention.

## Secrets needed

| secret | notes |
|---|---|
| `ALGOLIA_DOCS_2_APPLICATION_ID` | app `42EK9RXSGL` (`unionai-docs-2`) |
| `ALGOLIA_DOCS_2_WRITE_API_KEY` | **scoped write key** — `addObject`/`deleteObject`/`editSettings` on the `union` index. **Not** an admin key. |

Index *settings* are deliberately **not** applied here — that's a separate `make index-search-settings`. A deploy that also rewrote settings would silently revert any dashboard tuning done while diagnosing a relevance problem.

## Dependencies

- **unionai-docs-infra#247** provides the `index-search` target. This fails until that merges and the submodule pointer is bumped — hence draft.
- The `v1` branch needs the same step to keep the v1 slices fresh. v1 CI has historically lagged `main` (the go-live cut lesson), so that's a deliberate follow-up rather than an assumption.

Merge order: infra#247 → submodule bump → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)