### PR TITLE
docsy(v1): push the search index after each production deploy

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -200,6 +200,20 @@ jobs:
           # GITHUB_SHA env var.
           command: pages deploy ./dist --project-name=docs --branch=${{ steps.branch.outputs.name }} --commit-dirty=true
 
+      - name: Update search index
+        # After the deploy, not before: the index should describe what is now
+        # served. Scoped to the slices THIS branch built -- v1 only -- so main
+        # (v2 + latest) and this branch cannot clobber each other's records.
+        #
+        # Skips itself when the secret is absent, so forks and any repo without
+        # Algolia credentials still deploy normally.
+        if: success() && github.event_name == 'push'
+        timeout-minutes: 15
+        env:
+          ALGOLIA_DOCS_2_APPLICATION_ID: ${{ secrets.ALGOLIA_DOCS_2_APPLICATION_ID }}
+          ALGOLIA_DOCS_2_WRITE_API_KEY: ${{ secrets.ALGOLIA_DOCS_2_WRITE_API_KEY }}
+        run: make index-search
+
       - name: Deploy summary
         if: success()
         run: |

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ TARGETS := usage help clean clean-generated base dist variant dev serve \
 	update-examples init-examples check-jupyter check-images validate-urls \
 	url-stats llm-docs update-redirects dry-run-redirects deploy-redirects \
 	check-deleted-pages check-links check-generated-content check-api-docs \
-	check-llm-bundle-notes update-api-docs check-helm-docs update-helm-docs
+	check-llm-bundle-notes update-api-docs check-helm-docs update-helm-docs \
+	index-search index-search-settings check-search-labels
 
 # Guard: fail fast if the infra submodule is not initialized.
 .PHONY: _check-infra


### PR DESCRIPTION
The v1 half of the deploy-time index push. Mirrors **unionai-docs#1423** (main). Part of **DOC-1286**.

## Why v1 needs its own step

Per-line scoping means each branch pushes only what it builds: `main` carries v2 + latest, this branch carries v1. Neither can touch the other's records, and `replace_all_objects` is never used for the same reason.

So without this step, **v1 records only update when someone runs the indexer by hand** — and v1 is not a frozen line. It cuts roughly every 3 days and accounts for **23,309 of 44,331 records**, over half the index.

## Behaviour

Identical to the main step apart from the scoping comment: after the Cloudflare deploy, `push` events only, 15-minute cap, skips itself when `ALGOLIA_DOCS_2_WRITE_API_KEY` is absent.

## Dependencies

- **unionai-docs-infra#247** provides the `index-search` target, reaching this branch via the submodule pointer. Fails until that merges and the pointer is bumped — hence draft.
- Needs the same two secrets as #1423: `ALGOLIA_DOCS_2_APPLICATION_ID` and a **scoped write key** (`addObject`/`deleteObject`/`editSettings` on `union`), never an admin key.

⚠️ **v1 CI has historically lagged main** — the go-live cut found v1 mirroring content but not workflows, which red-failed the cut PRs (fixed in docs#1281). This PR exists so that gap does not repeat for the index push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)