### PR TITLE
docsy(v2): forward the search-index targets through the delegator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ TARGETS := usage help clean clean-generated base dist variant dev serve \
 	url-stats llm-docs update-redirects dry-run-redirects deploy-redirects \
 	check-deleted-pages check-links check-generated-content check-api-docs \
 	check-llm-bundle-notes update-api-docs \
-	check-helm-docs update-helm-docs generate-helm-docs
+	check-helm-docs update-helm-docs generate-helm-docs \
+	index-search index-search-settings check-search-labels
 
 # Guard: fail fast if the infra submodule is not initialized.
 .PHONY: _check-infra


### PR DESCRIPTION
Fixes `main`, red since #1423.

The root `Makefile` is a thin delegator with an **explicit** target allowlist. Its own comment explains why it cannot be a pattern rule:

> These must be listed explicitly because Make's % pattern rule won't match targets that correspond to existing files/directories (e.g., dist/).

`index-search` was added to `unionai-docs-infra/Makefile` but never named here, so CI's bare `make index-search` from the repo root failed:

```
make: *** No rule to make target 'index-search'.  Stop.
```

**Not user-facing.** The index step runs *after* the Cloudflare deploy, so the site published normally; only the job went red (and `Deploy summary` was skipped).

Forwards all three search targets rather than only the failing one, so #1399 (`check-search-labels`) does not repeat this. #1425 needs the same one-line change on `v1`.

Verified locally: bare `make index-search` now resolves and reaches the credential skip guard; `make -n check-search-labels` resolves.

---
— docsy · automated docs agent · [DOC-1286](https://linear.app/unionai/issue/DOC-1286)