### PR TITLE
docsy(v2): correct personnel-access and support-access claims in the security section

### DIFF
--- a/content/security/_index.md
+++ b/content/security/_index.md
@@ -28,7 +28,9 @@ The control plane holds orchestration metadata only (run IDs, schedules, phase t
 **[Identity and access](./identity-and-access/_index)**
 Authentication is done via OIDC/SSO, API keys, and service accounts.
 Role-based access control enforces least-privilege.
-Union.ai personnel cannot access customer data or secrets.
+No customer data transits Union.ai's control plane, and secret values cannot be read back through the API.
+Union.ai personnel who hold a role in a customer's tenant see what that role authorizes, served from the customer's data plane and subject to the same RBAC and audit logging as any other user.
+See [Human access controls](./identity-and-access/human-access) for what that access covers in each deployment model.
 
 **[Compliance and governance](./compliance/_index)**
 Union.ai is SOC 2 Type II certified for Security, Availability, and Processing Integrity, with practices aligned to ISO 27001 and CIS benchmarks.

--- a/content/security/identity-and-access/human-access.md
+++ b/content/security/identity-and-access/human-access.md
@@ -8,27 +8,25 @@ variants: -flyte +union
 
 ## Self-managed
 
-In self-managed deployments, Union.ai personnel access only the Union.ai-hosted control plane infrastructure. They have zero access to the customer's data plane. This access uses standard OIDC/SSO and RBAC.
+In self-managed deployments, Union.ai personnel have no infrastructure access to the customer's data plane: no IAM roles, no VPN, no SSH keys, and no `kubectl` access. They operate only the Union.ai-hosted control plane. Application-level access to the tenant is a separate matter, covered under [Customer-side support access](#customer-side-support-access) below.
 
 ## BYOC
 
 In BYOC deployments, Union.ai personnel additionally have authenticated Kubernetes cluster access for operational purposes: upgrades, node pool provisioning, Helm chart updates, health monitoring, and troubleshooting. This access uses cloud-native private connectivity (PrivateLink/PSC) and is scoped to Kubernetes cluster management. All cluster management actions are logged.
 
-## Customer-side support access (optional)
+## Customer-side support access
 
-Separately from BYOC Kubernetes cluster management, Union.ai offers an optional support service where customers can grant Union.ai staff access to the customer's tenant for troubleshooting. This is available for both self-managed and BYOC deployments.
+Separately from BYOC Kubernetes cluster management, Union.ai support staff hold an identity in the customer's tenant so that they can troubleshoot. This applies to both self-managed and BYOC deployments.
 
-When requested, Union.ai support personnel are granted access through the same RBAC framework used by the customer's own users. The customer creates a role binding for Union.ai staff, scoped to the specific projects, domains, and permission level appropriate for the troubleshooting engagement. This access can be time-limited so that it expires automatically after the support engagement concludes.
-
-This service is entirely optional. Customers must explicitly request it and configure the RBAC grants themselves. Union.ai staff cannot self-provision this access. The access is subject to the same authentication (OIDC/SSO), authorization (RBAC policies), and audit logging as any other user in the customer's organization.
+Support staff are granted access through the same RBAC framework that governs the customer's own users: an identity in the tenant, bound to a policy that determines what they can do. The access is subject to the same authentication (OIDC/SSO), authorization (RBAC policies), and audit logging as any other user in the customer's organization. Customers can list every identity-to-policy assignment in their organization, including any held by Union.ai staff, with `flyte get assignment`.
 
 This is distinct from BYOC Kubernetes cluster management access (described above), which is infrastructure-level access for platform operations. Customer-side support access operates at the application level: viewing runs, inspecting logs, diagnosing task failures, and reviewing configuration. It does not grant Kubernetes cluster access, IAM role access, or direct access to the customer's cloud account.
 
 ## Access scope
 
-When Union.ai personnel are granted access to a customer's tenant (in BYOC, or via the optional support service in self-managed), they *can*: view orchestration metadata, view logs relayed through the tunnel, perform administrative operations as authorized by the customer's RBAC policy, and (in BYOC) manage the Kubernetes cluster.
+When Union.ai personnel hold a role in a customer's tenant (in BYOC, or through support access in self-managed), they *can*: view orchestration metadata, view whatever their role authorizes in the console and CLI (including run inputs and outputs, logs, code bundles, and reports), perform administrative operations as authorized by the customer's RBAC policy, and (in BYOC) manage the Kubernetes cluster.
 
-They *cannot*: read secret values (the API is write-only), access bulk data in customer object stores (presigned URLs are per-request and not retained), or access the customer's cloud account, IAM roles, object stores, secrets backends, container registries, or log aggregators. Customer data never transits Union.ai's control plane in any form, so personnel with control plane infrastructure access cannot observe customer data even in flight; every customer-data request is served from the data plane through the Direct-to-Data-Plane tunnel, with authentication and RBAC enforced inside the customer's cluster.
+They *cannot*: read secret values (the API is write-only), or reach the customer's cloud account, IAM roles, object stores, secrets backends, container registries, or log aggregators directly. Every request for run data follows the same authenticated, RBAC-gated path as any other user's: the data plane issues a per-request presigned URL, which is not retained. Customer data never transits Union.ai's control plane in any form, so personnel with control plane infrastructure access cannot observe customer data even in flight; every customer-data request is served from the data plane through the Direct-to-Data-Plane tunnel, with authentication and RBAC enforced inside the customer's cluster.
 
 All access by Union.ai personnel is authenticated and logged with caller identity, operation performed, and timestamp.
 
@@ -36,7 +34,7 @@ All access by Union.ai personnel is authenticated and logged with caller identit
 
 ### Human access controls
 
-**Reviewer focus:** Confirm that Union.ai personnel access is appropriately scoped for each deployment model and that no path exists to access customer data or secrets.
+**Reviewer focus:** Confirm that Union.ai personnel access is appropriately scoped for each deployment model, that every grant is visible and auditable, and that no path exists to read secret values or to reach the customer's cloud account directly.
 
 **How to verify:**
 
@@ -60,14 +58,16 @@ BYOC:
 
 Customer-side support access:
 
-1. Confirm that no Union.ai support user exists in the customer's tenant unless explicitly provisioned by the customer.
-
-2. If support access has been granted, verify the RBAC binding:
+1. List every identity-to-policy assignment in the organization, which is where any Union.ai staff access appears:
 
    ```bash
-   flyte get policy
+   flyte get assignment
    ```
 
-   The Union.ai support user should appear with the scoped role and time limit configured by the customer.
+2. Inspect the policy each assignment names, to see exactly which actions it permits and which projects and domains it covers:
 
-3. After the time limit expires, repeat the query. The binding should no longer be active.
+   ```bash
+   flyte get policy <name>
+   ```
+
+3. Review the audit log for requests made by those identities. Every request is logged with caller identity, operation performed, and timestamp.

--- a/content/security/identity-and-access/human-access.md
+++ b/content/security/identity-and-access/human-access.md
@@ -8,7 +8,7 @@ variants: -flyte +union
 
 ## Self-managed
 
-In self-managed deployments, Union.ai personnel have no infrastructure access to the customer's data plane: no IAM roles, no VPN, no SSH keys, and no `kubectl` access. They operate only the Union.ai-hosted control plane. Application-level access to the tenant is a separate matter, covered under [Customer-side support access](#customer-side-support-access) below.
+In self-managed deployments, Union.ai personnel have no infrastructure access to the customer's data plane: no IAM roles, no VPN, and no SSH keys. They operate only the Union.ai-hosted control plane. Application-level access to the tenant is a separate matter, covered under [Customer-side support access](#customer-side-support-access) below.
 
 ## BYOC
 
@@ -38,7 +38,7 @@ All access by Union.ai personnel is authenticated and logged with caller identit
 
 **How to verify:**
 
-Self-managed: Union.ai has no IAM roles, no VPN, no SSH keys, and no kubectl access to the customer's cluster. Every channel between Union.ai and the customer is initiated *from* the customer's data plane. Union.ai cannot initiate connections *to* the customer's infrastructure under any tier.
+Self-managed: Union.ai has no IAM roles, no VPN, and no SSH keys for the customer's cluster. Every channel between Union.ai and the customer is initiated *from* the customer's data plane. Union.ai cannot initiate connections *to* the customer's infrastructure under any tier.
 
 BYOC:
 

--- a/content/security/identity-and-access/rbac.md
+++ b/content/security/identity-and-access/rbac.md
@@ -63,6 +63,6 @@ Union.ai enforces least privilege across all components. IAM roles on the data p
    flyte get policy
    ```
 
-6. For Union.ai employee access: the customer creates an RBAC policy for Union.ai support, scoped to viewer only and time-limited.
+6. For Union.ai employee access, list every identity-to-policy assignment in the organization with `flyte get assignment` and inspect the named policies. See [Human access controls](./human-access).
 
 This verification is fully self-service.


### PR DESCRIPTION
Corrects two of the three accuracy problems Ray Valencia raised in
[#team-docs](https://unionai.slack.com/archives/C01R4HFGR2T/p1786570525821129) on 2026-08-12, corroborated in
[#project-zero-trust](https://unionai.slack.com/archives/C0AQ0ULLKDL/p1786546808527469). Tracked as
[DOC-1424](https://linear.app/unionai/issue/DOC-1424).

Shalabh escalated this on 2026-08-13: *"Manas is concerned about our security posture and the team wants to
confirm the above before we point them to these docs."* These pages are live and are being cited into a
customer conversation right now.

## What this PR changes

### 1. `/security/` — the personnel-access overclaim

The index defines customer data to include workflow inputs and outputs, code bundles, logs and reports, then
asserts **"Union.ai personnel cannot access customer data or secrets."** Two separable claims are collapsed
there. Verified against `unionai/cloud@origin/main` (fetched 2026-08-14, `64ebb646`):

| Claim | Verdict | Evidence |
|---|---|---|
| Customer data does not transit the control plane | **True** | unchanged in this PR |
| Secret values cannot be read back | **True** | `idl/secret/proxy/definition.proto` — `Secret` carries `secret_id` + `SecretMetadata` only, no value field. `GetSecret` cannot return one. |
| Personnel cannot *view* customer data | **False as an absolute** | `shared_service/authorization/roles.go` — both `ROLE_TYPE_ADMIN` and `ROLE_TYPE_SUPPORT` carry `ACTION_VIEW_FLYTE_EXECUTIONS`. A holder of either sees run inputs and outputs, logs and reports in the console. |

The blurb now states the two true claims and describes the viewing surface accurately.

### 2. `/security/identity-and-access/human-access/` — support access framed as opt-in

Three sentences on this page are falsified by the shipped provisioning path:

- *"Customers must explicitly request it and configure the RBAC grants themselves"* and *"Union.ai staff
  cannot self-provision this access"* — `cli/uctl-admin/cmd/create/authorization.go` calls
  `GetUnionOktaUsers` at organization creation, which for a customer tenant resolves the **Union support
  staff** Okta group (`cli/uctl-admin/cmd/shared/authorization.go:532`, `shared_service/identity/utils.go`),
  and then assigns those users a policy via `AddAuthorizedOktaUsers`. Union provisions this; the customer
  neither requests nor configures it.
- *"This access can be time-limited so that it expires automatically after the support engagement
  concludes"* — `idl/authorizer/payload.proto` `AssignIdentityRequest` has fields `organization`, `identity`
  and a `role_id`/`policy_id` oneof. **There is no expiry, TTL or duration anywhere in the assignment API.**
  The two verification steps built on that time limit could never pass.

This PR removes the unsupportable absolutes and describes only the mechanism that is verified: an identity
in the tenant, bound to a policy, under the same authn, RBAC and audit logging as any other user. It
replaces the broken verification steps with `flyte get assignment` (documented in
`api-reference/flyte-cli.md`: "Without --user-subject, --creds-subject, or --email, lists all assignments")
followed by `flyte get policy <name>`.

**It deliberately does not assert the replacement policy.** "On by default, with the ability to opt out at
any time" is the reframing Ray floated, and neither he nor this PR can confirm a broad opt-out exists. See
the blocking questions below.

### 3. `/security/architecture/sovereign-data-plane/` — untouched, on purpose

Not in this PR. It needs a product and messaging decision, not a wording fix. Findings and options are in
[DOC-1424](https://linear.app/unionai/issue/DOC-1424).

## Review disposition and the open questions

EngHabu reviewed on 2026-08-19 and requested one change: drop the `no kubectl access` claim, because
opt-in support access to a cluster's Kubernetes API is being built and is not out yet. Applied in
`c3b9bdb`, in both places the page asserted it (the Self-managed lead and the self-managed
verification step). IAM roles, VPN and SSH keys are unchanged, and no other change was requested.

The claim was accurate at `unionai/cloud@fd0d5c53`: no shipped path grants Union personnel `kubectl`
against a self-managed customer data plane. The in-flight work is real and unmerged, in
`unionai/cloud` PRs [#17454](https://github.com/unionai/cloud/pull/17454) and
[#17607](https://github.com/unionai/cloud/pull/17607)
to [#17611](https://github.com/unionai/cloud/pull/17611): an in-cluster agent that fronts the API
server on a tailnet, off by default per cluster, with its own connection records. So the claim was
dropped for durability, not because it is false today.

The three questions that previously gated this draft are now tracked as their own tickets, so they no
longer hold the correction back. Each is about what the page could say **next**. Nothing in this PR
depends on their answers, and the text here asserts nothing they could falsify.

| | Question | Tracked at | State |
|---|---|---|---|
| 1 | What policy do Union support staff hold in a production customer tenant? `StaffPolicyName` (`cli/uctl-admin/cmd/shared/authorization.go:398`) returns admin outside staging. | [DOC-1487](https://linear.app/unionai/issue/DOC-1487/confirm-what-policy-union-support-staff-hold-in-a-production-customer) | Blocked (`eng-dep`) |
| 2 | Does a broad opt-out exist beyond the code viewer? | [DOC-1488](https://linear.app/unionai/issue/DOC-1488/confirm-whether-a-broad-customer-opt-out-from-union-support-staff) | Blocked (`eng-dep`) |
| 3 | Should the page disclose that the console hides support staff from the member list? | [DOC-1489](https://linear.app/unionai/issue/DOC-1489/decide-whether-the-security-docs-should-disclose-that-the-console) | Needs Scoping |

@EngHabu and @katrina: questions 1 and 2 are for you, on those tickets rather than here.

## Not changed, but flagged

`rbac.md` says Union.ai provides **three** user-assignable roles. `IsInternalSystemRole`
(`shared_service/authorization/roles.go`) hides only `cluster-manager`, `system-provisioned-access` and
`tenant-manager`, which leaves `support` and `flyte-project-admin-manager` user-visible. I did not edit the
role table because I could not verify what the console actually offers a customer admin.

---
— docsy · automated docs agent · [DOC-1424](https://linear.app/unionai/issue/DOC-1424)

