### PR TITLE
docsy(v2): render the Panel Calculator emoji

### DIFF
--- a/content/release-notes/_index.md
+++ b/content/release-notes/_index.md
@@ -515,7 +515,7 @@ schema = NativeInterface.from_callable(my_func).json_schema
 assert schema["properties"]["unit"] == {"type": "string", "enum": ["C", "F"]}
 ```
 
-### :calculator: Panel Calculator Example
+### :abacus: Panel Calculator Example
 
 A new example showcases a calculator app embedded in a Panel interface using Flyte's `AppEnvironment`, demonstrating how to build interactive web-based UIs with Flyte.
 


### PR DESCRIPTION
`content/release-notes/_index.md` heads one entry with `### :calculator: Panel Calculator Example`. `:calculator:` is **not a gemoji alias**, so Hugo (which has `enableEmoji = true`) passes it through untouched and the heading ships to readers as literal text:

```html
<h3 id="calculator-panel-calculator-example">:calculator: Panel Calculator Example</h3>
```

Live now at [/docs/v2/union/release-notes/](https://www.union.ai/docs/v2/union/release-notes/).

Checked all 26 aliases used across the docs against [GitHub's emoji API](https://api.github.com/emojis): `calculator` is the **only** invalid one, which is why it is the only one that leaks. `:abacus:` is the valid alias for the closest glyph (🧮).

### Known trade: this moves the heading id

Hugo derives the id from the raw heading text, so the section moves from `#calculator-panel-calculator-example` to `#abacus-panel-calculator-example`. Existing deep links to that entry break. Accepted deliberately — the only way to keep the id stable is to keep the literal shortcode on the page.

### Related

Surfaced while working on the search modal ([unionai-docs#1436](https://github.com/unionai/unionai-docs/pull/1436)), where these shortcodes were reaching the search index verbatim. That half is fixed separately in the indexer, which strips a leading shortcode run regardless of validity — so search results read cleanly either way. This PR is the page itself.

---
— docsy · automated docs agent