### PR TITLE
docsy(v2): give each docs line its own production deploy queue

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -40,14 +40,33 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 # Concurrency policy:
-#   - production deploys (push to main) use one `prod` group, queued in order
-#     (never cancel), so two merges can't race on the single CF Pages project —
-#     and, crucially, can't race on cutting the same stable tag (the cut runs
-#     in-job, so serializing the job serializes the cut).
+#   - production deploys use one `prod` group PER LINE, queued in order (never
+#     cancel), so two merges on the same line can't race on the CF Pages
+#     project — and, crucially, can't race on cutting the same stable tag (the
+#     cut runs in-job, so serializing the job serializes the cut).
 #   - workflow_dispatch: own `manual` group, so manual re-runs never block or
 #     get blocked by an in-progress production deploy.
+#
+# `github.ref_name` is what makes the group per-line, and it is not cosmetic.
+# This policy was written when main was the only branch that deployed, so one
+# global `prod` group was the same thing as one group per line. Go-live
+# (DOC-1245) made `v1` a deploying line too and nothing revisited the group,
+# which left main and v1 sharing one queue.
+#
+# The failure that produces is silent. `cancel-in-progress: false` protects a
+# RUNNING job, but GitHub still evicts a PENDING one when a newer run joins the
+# group — newest wins. So a v1 deploy queued behind a main deploy is discarded
+# the moment any second main deploy arrives, and it reports `cancelled`, not
+# `failure`: nothing turns red and nobody is told. Observed 2026-08-18, where
+# v1's deploy queued at 10:20:02 and was evicted at 10:20:17 by a main deploy
+# created one second earlier; the v1 line silently did not ship.
+#
+# Same-line eviction stays, deliberately. Two pushes to the same branch are
+# ordered, so the newer commit already contains the older one and superseding
+# is correct. Only CROSS-line eviction is wrong, and that is exactly what
+# keying on the ref removes.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && 'manual' || 'prod' }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && 'manual' || 'prod' }}-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -45,7 +45,10 @@ env:
 #     project — and, crucially, can't race on cutting the same stable tag (the
 #     cut runs in-job, so serializing the job serializes the cut).
 #   - workflow_dispatch: own `manual` group, so manual re-runs never block or
-#     get blocked by an in-progress production deploy.
+#     get blocked by an in-progress production deploy. The ref suffix applies to
+#     this arm too, so manual runs are per-line as well -- a manual v1 deploy
+#     cannot evict a manual main one, which is the same guarantee `prod` gets and
+#     the reason the suffix is unconditional rather than applied to `prod` only.
 #
 # `github.ref_name` is what makes the group per-line, and it is not cosmetic.
 # This policy was written when main was the only branch that deployed, so one
@@ -53,11 +56,16 @@ env:
 # (DOC-1245) made `v1` a deploying line too and nothing revisited the group,
 # which left main and v1 sharing one queue.
 #
-# The failure that produces is silent. `cancel-in-progress: false` protects a
-# RUNNING job, but GitHub still evicts a PENDING one when a newer run joins the
-# group — newest wins. So a v1 deploy queued behind a main deploy is discarded
-# the moment any second main deploy arrives, and it reports `cancelled`, not
-# `failure`: nothing turns red and nobody is told. Observed 2026-08-18, where
+# The failure that produces is silent, and it follows documented behaviour
+# rather than a quirk: `cancel-in-progress: false` protects a RUNNING job, but
+# per GitHub's concurrency docs, "any existing pending job or workflow in the
+# same concurrency group will be canceled and the new queued job or workflow
+# will take its place" — newest wins, cancellation setting notwithstanding.
+# https://docs.github.com/en/actions/using-jobs/using-concurrency
+#
+# So a v1 deploy queued behind a main deploy is discarded the moment any second
+# main deploy arrives, and it reports `cancelled`, not `failure`: nothing turns
+# red and nobody is told. Observed 2026-08-18, where
 # v1's deploy queued at 10:20:02 and was evicted at 10:20:17 by a main deploy
 # created one second earlier; the v1 line silently did not ship.
 #


### PR DESCRIPTION
`main` and `v1` share one `prod` concurrency group, so a v1 production deploy is **silently discarded** whenever a second main deploy arrives while it is queued.

## What happens

```yaml
group: ${{ github.workflow }}-${{ ... && 'manual' || 'prod' }}   # no ref component
cancel-in-progress: false
```

`cancel-in-progress: false` protects a **running** job, but GitHub still evicts a **pending** one when a newer run joins the group — newest wins. Since `main` and `v1` are in the same group, a queued v1 deploy loses to any main deploy that arrives after it.

The eviction reports **`cancelled`, not `failure`**. Nothing turns red, no notification fires, and the branch simply does not ship.

## Observed today

| time | run | outcome |
|---|---|---|
| 10:19:32 | main — [#1444](https://github.com/unionai/unionai-docs/pull/1444) | in progress |
| 10:20:02 | **v1** — [#1443](https://github.com/unionai/unionai-docs/pull/1443) | queued |
| 10:20:16 | main — [#1441](https://github.com/unionai/unionai-docs/pull/1441) | queued |
| 10:20:17 | **v1** | **cancelled — evicted** |

v1 did not deploy. Its Ask AI corpus repair (`flatten_for_retrieval`, infra#254) therefore did not happen either. It needed a manual re-run, which only occurred because the run list was being read for an unrelated reason.

## Why the policy was right when written

It predates go-live. Main was the only branch that deployed, so one global `prod` group **was** one group per line. [DOC-1245](https://linear.app/unionai/issue/DOC-1245) made `v1` a deploying line and nothing revisited the group.

This plausibly explains how v1's submodule pointer drifted 6 commits behind `main` with no failure ever surfacing.

## The fix

Key the group on `github.ref_name`, restoring the original intent.

**Same-line eviction is kept deliberately.** Two pushes to one branch are ordered, so the newer commit already contains the older and superseding is correct — that behaviour is load-bearing for the in-job stable-tag cut. Only *cross-line* eviction is wrong, and keying on the ref removes exactly that.

The `manual` (workflow_dispatch) arm gets the same treatment, so a manual v1 deploy cannot evict a manual main deploy either.

## Note on v1

`v1` carries its own copy of this workflow and needs the same change — filed separately, since it is a different branch. Until both land the two lines are in *different* groups anyway (one keyed by ref, one not), so the collision is gone as soon as this merges; the v1 PR is for consistency, not correctness.

Verified: the file still parses, one job, both triggers intact.

---
— docsy · automated docs agent