### PR TITLE
docsy(v1): give each docs line its own production deploy queue

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -42,7 +42,10 @@ env:
 #     and can't race on cutting the same stable tag (the cut runs in-job, so
 #     serializing the job serializes the cut).
 #   - workflow_dispatch: own `manual` group, so manual re-runs never block or
-#     get blocked by an in-progress production deploy.
+#     get blocked by an in-progress production deploy. The ref suffix applies to
+#     this arm too, so manual runs are per-line as well -- a manual v1 deploy
+#     cannot evict a manual main one, which is the same guarantee `prod` gets and
+#     the reason the suffix is unconditional rather than applied to `prod` only.
 # This workflow never runs on `pull_request` (see Triggers above), so there is
 # no PR arm here. PR previews live in build-pr.yml + deploy-pr-preview.yml.
 #
@@ -51,8 +54,12 @@ env:
 # reading as though it owned its own queue, and together they formed one shared
 # queue for two lines. "Mirrors main" was the trap, not the safeguard.
 #
-# The failure that produced is silent: `cancel-in-progress: false` protects a
-# RUNNING job, but GitHub evicts a PENDING one when a newer run joins the group.
+# The failure that produced is silent, and it is documented behaviour rather
+# than a quirk: `cancel-in-progress: false` protects a RUNNING job, but per
+# GitHub's concurrency docs, "any existing pending job or workflow in the same
+# concurrency group will be canceled and the new queued job or workflow will
+# take its place" -- newest wins, cancellation setting notwithstanding.
+# https://docs.github.com/en/actions/using-jobs/using-concurrency
 # So a v1 deploy queued behind a main deploy was discarded the moment a second
 # main deploy arrived, reporting `cancelled` rather than `failure` -- nothing
 # turned red and this line simply did not ship. Observed 2026-08-18.

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -37,16 +37,27 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 # Concurrency policy (mirrors main):
-#   - production deploys (push to v1) use one `prod` group, queued in order
-#     (never cancel), so two merges can't race on the single CF Pages project,
+#   - production deploys use one `prod` group PER LINE, queued in order (never
+#     cancel), so two merges on this line can't race on the CF Pages project,
 #     and can't race on cutting the same stable tag (the cut runs in-job, so
 #     serializing the job serializes the cut).
 #   - workflow_dispatch: own `manual` group, so manual re-runs never block or
 #     get blocked by an in-progress production deploy.
 # This workflow never runs on `pull_request` (see Triggers above), so there is
 # no PR arm here. PR previews live in build-pr.yml + deploy-pr-preview.yml.
+#
+# `github.ref_name` is what makes the group per-line. Without it this file and
+# main's evaluate to the SAME group string -- both said "one prod group", each
+# reading as though it owned its own queue, and together they formed one shared
+# queue for two lines. "Mirrors main" was the trap, not the safeguard.
+#
+# The failure that produced is silent: `cancel-in-progress: false` protects a
+# RUNNING job, but GitHub evicts a PENDING one when a newer run joins the group.
+# So a v1 deploy queued behind a main deploy was discarded the moment a second
+# main deploy arrived, reporting `cancelled` rather than `failure` -- nothing
+# turned red and this line simply did not ship. Observed 2026-08-18.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && 'manual' || 'prod' }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && 'manual' || 'prod' }}-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
Mirror of [#1445](https://github.com/unionai/unionai-docs/pull/1445) for the v1 line.

## The trap

Both branches carry their own copy of this workflow, and both said the same thing:

- main: *"production deploys (push to **main**) use one `prod` group"*
- v1: *"Concurrency policy (**mirrors main**) — production deploys (push to **v1**) use one `prod` group"*

Each file reads as though it owns its own queue. But the expression is identical on both branches and contains no ref component, so both evaluate to the **same group string** — one shared queue for two independent lines. "Mirrors main" was the trap, not the safeguard.

## The silent failure

`cancel-in-progress: false` protects a **running** job. GitHub still evicts a **pending** one when a newer run joins the group. A v1 deploy queued behind a main deploy is therefore discarded as soon as a second main deploy arrives — reporting **`cancelled`, not `failure`**, so nothing turns red and no one is told the line did not ship.

Observed 2026-08-18: this line's deploy queued at 10:20:02 and was evicted at 10:20:17, silently skipping the Ask AI corpus repair it was carrying ([#1443](https://github.com/unionai/unionai-docs/pull/1443)).

## Correctness note

Once [#1445](https://github.com/unionai/unionai-docs/pull/1445) merges the collision is already gone, because main's group gains a ref component and v1's does not — different strings, different queues. **This PR is for consistency, not correctness**, and so that the next person reading either file finds a policy that is true rather than one that happens to work.

Same-line eviction is kept deliberately: two pushes to one branch are ordered, so the newer commit already contains the older. Only cross-line eviction was ever wrong.

Verified: the file still parses; one job, both triggers intact.

---
— docsy · automated docs agent