### PR TITLE
docsy(v2): default pool & queue are now soft-deletable (cloud #17725/#17726)

### DIFF
--- a/content/user-guide/cluster-workload-management/cluster-pools.md
+++ b/content/user-guide/cluster-workload-management/cluster-pools.md
@@ -236,14 +236,22 @@ before running it.
 
 ## Delete a pool
 
-The `default` pool cannot be deleted. A custom pool can be deleted only when it
-contains **no clusters and no queues**; otherwise the request is rejected. Empty
-the pool first:
+A pool can be deleted only when it is **empty** — it contains no clusters and no
+live queues; otherwise the request is rejected. (A queue that is itself
+soft-deleted doesn't block the deletion, but it can only be restored once the
+pool is.) Empty the pool first:
 
 1. Delete the member [clusters](./clusters#delete-a-cluster). Deleting a cluster
    also deletes its [co-named queue](./clusters#the-co-named-queue), so the
    queues that came with the clusters go with them.
 2. [Delete](./queues#delete-a-queue) any queue you created in the pool yourself.
+
+The `default` pool follows the same rules: it can be deleted once emptied, which
+additionally means [draining and deleting](./queues#delete-a-queue) the org-wide
+`default` queue that lives in it — nothing is deleted on the pool's behalf.
+While the `default` pool is deleted, registering a cluster without naming a pool
+is rejected instead of falling back to it: name a pool explicitly, or undelete
+`default` first.
 
 {{< tabs "delete-cluster-pool" >}}
 {{< tab "CLI" >}}

--- a/content/user-guide/cluster-workload-management/cluster-pools.md
+++ b/content/user-guide/cluster-workload-management/cluster-pools.md
@@ -238,8 +238,8 @@ before running it.
 
 A pool can be deleted only when it is **empty** — it contains no clusters and no
 live queues; otherwise the request is rejected. (A queue that is itself
-soft-deleted doesn't block the deletion, but it can only be restored once the
-pool is.) Empty the pool first:
+soft-deleted doesn't block the deletion, but it can only be restored after the
+pool has been restored.) Empty the pool first:
 
 1. Delete the member [clusters](./clusters#delete-a-cluster). Deleting a cluster
    also deletes its [co-named queue](./clusters#the-co-named-queue), so the

--- a/content/user-guide/cluster-workload-management/clusters.md
+++ b/content/user-guide/cluster-workload-management/clusters.md
@@ -24,7 +24,10 @@ the commands or Python calls here to manage the control-plane record.
 ## Register a cluster
 
 If you omit the pool, the cluster is registered into the `default` pool. To use a
-custom pool, create that pool first.
+custom pool, create that pool first. One edge case: if the `default` pool has
+been [deleted](./cluster-pools#delete-a-pool), registering without a pool is
+rejected rather than falling back to it — name a pool explicitly, or undelete
+`default`.
 
 {{< tabs "register-cluster" >}}
 {{< tab "CLI" >}}
@@ -89,10 +92,13 @@ queue setup:
 flyte.with_runcontext(queue="prod-us-east-1").run(main)
 ```
 
-Registration additionally ensures the org-wide `default` queue exists. The
-`default` queue lives in the `default` pool with the `*` selector, so it routes
-to every healthy, enabled cluster in the `default` pool: a cluster registered
-there joins it automatically, while a cluster in any other pool never does.
+Registration additionally ensures the org-wide `default` queue exists — unless
+that queue has been deliberately [deleted](./queues#delete-a-queue): nothing
+re-creates a soft-deleted `default` queue (or pool) implicitly; `flyte undelete`
+is the only way back. The `default` queue lives in the `default` pool with the
+`*` selector, so it routes to every healthy, enabled cluster in the `default`
+pool: a cluster registered there joins it automatically, while a cluster in any
+other pool never does.
 
 Both are ordinary queues — they appear in `flyte get queue` (a co-named queue is
 flagged there as **cluster-managed**), carry the same

--- a/content/user-guide/cluster-workload-management/queues.md
+++ b/content/user-guide/cluster-workload-management/queues.md
@@ -84,8 +84,9 @@ your part:
 
 - The org-wide **`default`** queue, in the `default` pool with the `*` selector.
   Anything that doesn't explicitly target a queue goes here. (If the `default`
-  queue is [drained](#drain-and-reactivate-a-queue), untargeted submissions are
-  rejected until it is reactivated.)
+  queue is [drained](#drain-and-reactivate-a-queue) or
+  [deleted](#delete-a-queue), untargeted submissions are rejected until it is
+  reactivated or restored.)
 - A **co-named queue** for every cluster: registering a cluster creates a queue
   with the *same name as the cluster*, in that cluster's pool, whose selector
   names that one cluster explicitly rather than using `*`. Register
@@ -267,6 +268,12 @@ flyte get queue --deleted
 `--watch` renders live progress bars for run concurrency, action concurrency, and
 depth, so you can see a queue filling up or draining in real time.
 
+Fetching a queue **by name** works even after it has been
+[deleted](#delete-a-queue): `flyte get queue <name>` returns the soft-deleted
+queue carrying its deletion time instead of failing, so a queue that an old run
+once targeted stays inspectable. Only the listing hides deleted queues, unless
+you pass `--deleted`.
+
 {{< /markdown >}}
 {{< /tab >}}
 {{< tab "Programmatic" >}}
@@ -284,7 +291,13 @@ for queue in Queue.listall(state="draining"):
 
 queue = Queue.get("gpu-queue")
 print(queue.to_dict())
+```
 
+`Queue.get` works even on a [deleted](#delete-a-queue) queue: it returns the
+soft-deleted queue carrying its deletion time instead of failing, while
+`Queue.listall` hides deleted queues.
+
+```python
 metrics = Queue.details("gpu-queue")
 print(metrics)
 ```
@@ -433,18 +446,28 @@ be `drained` before it can be [deleted](#delete-a-queue) or
 cluster can be [deleted](./clusters#delete-a-cluster) or
 [moved](./clusters#move-a-cluster-to-a-different-pool).
 
-The `default` queue can be drained like any other — since it cannot be deleted,
-draining is how you stop scheduling on it. One guard applies to any queue: a
-queue configured as the default run queue (`run.default_queue`) in your
-organization's settings cannot be drained until that setting points elsewhere.
+The `default` queue can be drained like any other — draining is how you stop
+scheduling on it, and the prerequisite for [deleting it](#delete-a-queue). One
+guard applies to any queue: a queue configured as the default run queue
+(`run.default_queue`) in your organization's settings — at any scope — cannot
+be drained or deleted until those settings are updated or unset.
 
 ## Delete a queue
 
 A queue must be **drained** before it can be deleted; deleting an `active` or
-`draining` queue is rejected. The `default` queue cannot be deleted — drain it
-instead. A cluster's [co-named queue](./clusters#the-co-named-queue) can be
-deleted on its own while the cluster lives, and is deleted automatically when
-its [cluster is deleted](./clusters#delete-a-cluster).
+`draining` queue is rejected. A queue referenced as the default run queue
+(`run.default_queue`) in settings at any scope cannot be deleted until those
+settings are updated or unset. A cluster's
+[co-named queue](./clusters#the-co-named-queue) can be deleted on its own while
+the cluster lives, and is deleted automatically when its
+[cluster is deleted](./clusters#delete-a-cluster).
+
+The `default` queue is no exception: drain it, then delete it, like any other
+queue — deleting it is also how the `default` pool is emptied of live queues so
+that [the pool itself can be deleted](./cluster-pools#delete-a-pool). While the
+`default` queue is deleted, submissions that name no queue and have no
+`run.default_queue` setting to fall back on are rejected at creation. Nothing
+re-creates it implicitly; `flyte undelete queue default` brings it back.
 
 {{< tabs "delete-queue" >}}
 {{< tab "CLI" >}}
@@ -475,11 +498,13 @@ Queue.undelete("gpu-queue")   # restore a deleted queue
 {{< /tab >}}
 {{< /tabs >}}
 
-Deletion is a **soft delete**: the queue disappears from `flyte get queue`, but
-its name stays reserved and it can be restored with `flyte undelete queue
-<name>`. Undeleting requires the queue's pool and its pinned clusters to still
-be live, and the restored queue comes back `drained` —
-[reactivate it](#drain-and-reactivate-a-queue) to resume routing.
+Deletion is a **soft delete**: the queue disappears from the `flyte get queue`
+listing and is no longer scheduled on, but its name stays reserved, and fetching
+it by name still works — `flyte get queue <name>` and `Queue.get` return the
+deleted queue carrying its deletion time (see [Inspect queues](#inspect-queues)).
+Restore it with `flyte undelete queue <name>`. Undeleting requires the queue's
+pool and its pinned clusters to still be live, and the restored queue comes back
+`drained` — [reactivate it](#drain-and-reactivate-a-queue) to resume routing.
 
 ## Move work to another pool
 

--- a/content/user-guide/cluster-workload-management/queues.md
+++ b/content/user-guide/cluster-workload-management/queues.md
@@ -86,7 +86,8 @@ your part:
   Anything that doesn't explicitly target a queue goes here. (If the `default`
   queue is [drained](#drain-and-reactivate-a-queue) or
   [deleted](#delete-a-queue), untargeted submissions are rejected until it is
-  reactivated or restored.)
+  active again — a restored queue comes back `drained`, so after an undelete it
+  must also be reactivated.)
 - A **co-named queue** for every cluster: registering a cluster creates a queue
   with the *same name as the cluster*, in that cluster's pool, whose selector
   names that one cluster explicitly rather than using `*`. Register


### PR DESCRIPTION
## What changed

Syncs `content/user-guide/cluster-workload-management/` with the latest backend API (cloud IDL through `e65d00e80e` / `089a043deb`) and the [flyteplugins-union v0.7.2](https://github.com/unionai/flyteplugins-union/releases/tag/v0.7.2) release:

- **`default` queue is now deletable** like any other queue (drain → delete). While deleted, submissions that name no queue and have no `run.default_queue` fallback are rejected at creation; nothing re-creates it implicitly — `flyte undelete queue default` brings it back. (`queues.md`)
- **`default` pool is now deletable** once emptied, which additionally requires draining and deleting its `default` queue — nothing is deleted on the pool's behalf. While the pool is deleted, `flyte create cluster` without `--pool` is rejected instead of falling back to it. (`cluster-pools.md`, `clusters.md`)
- **`run.default_queue` settings guard** now documented as blocking both drain *and* delete, at any settings scope (was documented as an org-level drain-only guard). (`queues.md`)
- **Pool-delete precondition** refined to "no clusters and no *live* queues": soft-deleted queues don't block pool deletion, but can only be undeleted once the pool is. (`cluster-pools.md`)
- **Soft-deleted queues stay fetchable by name**: `flyte get queue <name>` / `Queue.get` return the deleted queue carrying its deletion time instead of failing; only listings hide deleted queues unless `--deleted` is passed. (`queues.md`)
- Cluster registration's "ensures the `default` queue exists" claim qualified: a deliberately soft-deleted `default` queue/pool is never resurrected implicitly. (`clusters.md`)

## Not in this PR

`content/api-reference/flyte-cli.md` still carries the old generated help text ("The reserved 'default' pool/queue cannot be deleted"); it refreshes via the automated API-docs regeneration pipeline once it picks up flyteplugins-union v0.7.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQdACnhbap1e5ioTw857tF