### PR TITLE
docsy(v2): lead devbox config with the flyte create config --devbox shortcut

### DIFF
--- a/content/user-guide/get-started/run-modes/running-devbox.md
+++ b/content/user-guide/get-started/run-modes/running-devbox.md
@@ -89,6 +89,14 @@ The first start may take a few minutes while Docker images are downloaded.
 Create a config file that points to the devbox:
 
 ```bash
+flyte create config --devbox
+```
+
+This creates `.flyte/config.yaml` configured to talk to your local devbox cluster.
+
+The `--devbox` flag requires flyte 2.6.1 or later. It is a shortcut for the explicit form, which you need on earlier versions:
+
+```bash
 flyte create config \
     --endpoint localhost:30080 \
     --project flytesnacks \
@@ -97,7 +105,13 @@ flyte create config \
     --insecure
 ```
 
-This creates `.flyte/config.yaml` configured to talk to your local devbox cluster.
+Both forms write the same config file. One difference: in an interactive terminal the explicit form offers to reuse a Docker login as your image registry, while `--devbox` skips that prompt, because the devbox pushes to its own in-cluster registry.
+
+`--devbox` cannot be combined with `--endpoint`, but you can still override the project and domain alongside it:
+
+```bash
+flyte create config --devbox --project my-project --domain staging
+```
 
 ## Run a workflow on the devbox
 


### PR DESCRIPTION
Leads the get-started devbox "Configure" section with the `flyte create config --devbox` shortcut that flyte-sdk 2.6.1 added, keeps the explicit long form as the pre-2.6.1 equivalent, and version-gates the flag inline.

DOC-1442, from the `docsy:api-surface-delta` label on the 2.6.1 API-reference regen (#1442). The `--devbox` flag was the entire material delta in that regen.

### Code verification (against the released 2.6.1 wheel, not the generated reference page)

Run with `uv run --isolated --with 'flyte==2.6.1'`:

| Claim | Result |
| --- | --- |
| `--devbox` expands to `--endpoint localhost:30080 --insecure --project flytesnacks --domain development --builder local` | Confirmed. `flyte create config --devbox` and the long form write a **byte-identical** `config.yaml`. |
| Mutually exclusive with `--endpoint` | Confirmed. `--devbox --endpoint foo:1234` raises `UsageError: --devbox already implies --endpoint localhost:30080; pass one or the other.` |
| `--project` / `--domain` still overridable | Confirmed. `--devbox --project myproj --domain staging` writes `project: myproj`, `domain: staging`. |

Source: `src/flyte/cli/_create.py` @ `v2.6.1` (the `if devbox:` branch, ~L513). Absent at `v2.6.0` (0 occurrences), so 2.6.1 is the correct floor. flyte 2.6.1 published to PyPI 2026-08-17.

### Two things the code corrected

1. **The ticket said readers overriding `--project`/`--domain` still need the long form.** They do not: those flags ride alongside `--devbox`. The page now shows `flyte create config --devbox --project my-project --domain staging` instead of pointing overriders at the long form.
2. **`--devbox` is not a pure alias.** `_create.py` gates the interactive Docker-registry inference on `not devbox`, so in a terminal the explicit form offers to reuse a Docker login as the image registry and `--devbox` does not. The page notes this in one sentence, since it is the only place the two forms actually diverge.

### Version gating

Followed the existing site convention rather than inventing a mechanism: inline prose, "The `--devbox` flag requires flyte 2.6.1 or later." That is the same shape already used for the sibling `flyte create config --registry` flag in `content/user-guide/tasks/task-configuration/container-images.md` (L312) and `running-remote.md` (L128). There is no version-gating shortcode in `unionai-docs-infra/layouts/shortcodes/`. The long form stays on the page as the runnable path for anyone on 2.6.0 or earlier, so no reader is handed a command they cannot run.

### Checked and deliberately not changed

- **The per-command example lower on the page** (`flyte --endpoint … --insecure --builder local run …`). Verified: `--devbox` exists only on `flyte create config`. Neither the root `flyte` group nor `flyte run` has it. Correct as-is.
- **`content/user-guide/get-started/run-modes/_index.md`** contains `localhost:30080`, but as a UI URL in a comparison table, not as an `--endpoint` value. No change needed.
- **The `v1` line.** Zero devbox content; its only `flyte create config` mention is an unrelated remote-builder snippet. Not affected.

`--endpoint localhost:30080` appears in exactly one non-generated file, this one, so no other page needs the same treatment.

### Style

Drafted prose clears style-spec §4a (no em-dashes) and §8 (no AI-tell vocabulary). No low-tier editorial flags to itemize.

---
— docsy · automated docs agent · [DOC-1442](https://linear.app/unionai/issue/DOC-1442/narrative-impact-flyte-create-config-devbox-supersedes-the-long-form)
