### PR TITLE
docsy(v2): Artifacts user-guide section

### DIFF
--- a/content/user-guide/_index.md
+++ b/content/user-guide/_index.md
@@ -71,6 +71,22 @@ Durable, self-healing agents built from tasks and apps, with sandboxing and MCP.
 
 {{< markdown >}}
 
+## Artifacts
+
+Name and version the datasets and models your tasks produce, and trace where they came from.
+
+{{< /markdown >}}
+
+{{< grid >}}
+
+{{< link-card target="artifacts" icon="box-seam" title="Artifacts" >}}
+Register task outputs and uploads as named, versioned artifacts, trigger runs on new versions, mount them into apps, and trace lineage.
+{{< /link-card >}}
+
+{{< /grid >}}
+
+{{< markdown >}}
+
 ## Access and identity
 
 How to authenticate and manage user permissions on your Union cluster.

--- a/content/user-guide/advanced-project/_index.md
+++ b/content/user-guide/advanced-project/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Advanced project
-weight: 10
+weight: 11
 variants: +flyte +union
 mermaid: true
 llm_readable_bundle: true

--- a/content/user-guide/agents/_index.md
+++ b/content/user-guide/agents/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Agents
-weight: 4
+weight: 5
 variants: +flyte +union
 ---
 

--- a/content/user-guide/apps/serve-and-deploy-apps/prefetching-models.md
+++ b/content/user-guide/apps/serve-and-deploy-apps/prefetching-models.md
@@ -103,7 +103,7 @@ Then run the CLI command:
 ```bash
 flyte prefetch hf-model meta-llama/Llama-2-70b-hf \
     --shard-config shard_config.yaml \
-    --accelerator L40s:8 \
+    --gpu L40s:8 \
     --hf-token-key HF_TOKEN
 ```
 
@@ -131,8 +131,10 @@ flyte prefetch hf-model <repo> \
     --hf-token-key HF_TOKEN \
     --cpu 4 \
     --mem 16Gi \
-    --ephemeral-storage 100Gi \
-    --accelerator L40s:4 \
+    --disk 100Gi \
+    --gpu L40s:4 \
+    --shm auto \
+    --raw-data-path s3://my-bucket/models \
     --shard-config shard_config.yaml
 ```
 
@@ -141,6 +143,20 @@ flyte prefetch hf-model <repo> \
 Here's a complete example of prefetching and using a model:
 
 {{< code file="/unionai-examples/v2/user-guide/serve-and-deploy-apps/prefetch_examples.py" fragment=complete-example lang=python >}}
+
+{{< variant union >}}
+{{< markdown >}}
+
+## Prefetched models are artifacts
+
+A successful prefetch registers the weights as a versioned model artifact, with the
+Hugging Face commit as its version and the repo README as its model card. For what
+that means for the registry, how to retrieve a prefetched model by name or by source
+repo, and how it appears in lineage, see
+[Prefetch Hugging Face models](../../artifacts/prefetch-models).
+
+{{< /markdown >}}
+{{< /variant >}}
 
 ## Best practices
 

--- a/content/user-guide/artifacts/_index.md
+++ b/content/user-guide/artifacts/_index.md
@@ -55,7 +55,7 @@ Union records who produced each artifact version and which tasks, triggers, and 
 The unit of work that produces and consumes artifacts.
 {{< /link-card >}}
 
-{{< link-card target="../apps" icon="rocket" title="Apps" >}}
+{{< link-card target="../apps" icon="window" title="Apps" >}}
 Long-running services that serve the models and datasets artifacts hold.
 {{< /link-card >}}
 

--- a/content/user-guide/artifacts/_index.md
+++ b/content/user-guide/artifacts/_index.md
@@ -1,0 +1,62 @@
+---
+title: Artifacts
+weight: 4
+variants: -flyte +union
+---
+
+# Artifacts
+
+An artifact is a named, versioned reference to an object in storage. Instead of remembering which bucket path holds last week's training set, you register the output under a name, and downstream tasks, triggers, and apps refer to it by that name.
+
+Your data path does not change. Files, directories, and dataframes are offloaded to object storage exactly as before. An artifact adds a name, a version, and a record of where it came from. Registering under the same name again creates a new version, and Union records which run produced each version and which tasks and apps consume it, so you can trace a deployed model back to the dataset it was trained on.
+
+Any `flyte.io.File`, `flyte.io.Dir`, or `flyte.io.DataFrame` can become an artifact. The most common way is to wrap a task's return value:
+
+```python
+@env.task(produces_artifacts=True)
+async def train() -> File:
+    weights = await File.from_local("model.pt")
+    return artifacts.new(weights, artifacts.Metadata(name="trained-model"))
+```
+
+{{< grid >}}
+
+{{< link-card target="task-outputs" icon="box-seam" title="Task outputs as artifacts" >}}
+Wrap a task's return value with `flyte.artifacts.new()` to register it as a named, versioned artifact with metadata and a model or data card.
+{{< /link-card >}}
+
+{{< link-card target="publish-artifacts" icon="cloud-upload" title="Publish your own artifacts" >}}
+Upload existing datasets and model weights from anywhere with `Artifact.create` or `flyte create artifact`, recording where they came from.
+{{< /link-card >}}
+
+{{< link-card target="prefetch-models" icon="download" title="Prefetch Hugging Face models" >}}
+Pull model weights from the Hugging Face Hub into your own storage as a model artifact, versioned by commit, with the model card attached.
+{{< /link-card >}}
+
+{{< link-card target="artifact-triggers" icon="lightning-charge" title="Trigger on new versions" >}}
+Run a task automatically whenever a new version of an artifact lands, using `flyte.OnArtifact`. It fires no matter who published the version.
+{{< /link-card >}}
+
+{{< link-card target="artifacts-in-apps" icon="window" title="Use artifacts in apps" >}}
+Mount model weights and datasets into serving apps with `flyte.app.ArtifactValue`, resolved and pinned at deploy time.
+{{< /link-card >}}
+
+{{< link-card target="lineage" icon="diagram-3" title="Automatic lineage tracking" >}}
+Union records who produced each artifact version and which tasks, triggers, and apps depend on it, and shows the graph in the UI.
+{{< /link-card >}}
+
+{{< /grid >}}
+
+## Related
+
+{{< grid >}}
+
+{{< link-card target="../tasks" icon="gear" title="Tasks" >}}
+The unit of work that produces and consumes artifacts.
+{{< /link-card >}}
+
+{{< link-card target="../apps" icon="rocket" title="Apps" >}}
+Long-running services that serve the models and datasets artifacts hold.
+{{< /link-card >}}
+
+{{< /grid >}}

--- a/content/user-guide/artifacts/artifact-triggers.md
+++ b/content/user-guide/artifacts/artifact-triggers.md
@@ -1,0 +1,52 @@
+---
+title: Trigger on new versions
+weight: 4
+variants: -flyte +union
+---
+
+# Trigger on new versions
+
+An artifact trigger runs a task automatically whenever a new version of a named artifact lands. Use it to validate every new model, retrain when a dataset is refreshed, or kick off batch inference when fresh data arrives.
+
+A trigger is a `flyte.Trigger` whose `automation` is `flyte.OnArtifact`. The `flyte.TriggeredArtifact` sentinel marks which task input receives the new version:
+
+```python
+import flyte
+from flyte.io import File
+
+env = flyte.TaskEnvironment(name="validation")
+
+retrain = flyte.Trigger(
+    name="retrain-on-new-model",
+    automation=flyte.OnArtifact(name="customer_model"),
+    inputs={"model": flyte.TriggeredArtifact, "threshold": 0.5},
+    description="Validate every new customer_model version",
+)
+
+
+@env.task(triggers=(retrain,))
+async def validate(model: File, threshold: float = 0.5) -> str:
+    ...
+```
+
+Deploy the environment to register the trigger:
+
+```bash
+flyte deploy validation.py env
+```
+
+From then on, every new version of `customer_model` in the task's project and domain starts a run of `validate`, with the new version bound to the `model` input. The task body sees an ordinary `File` or `Dir` and needs no artifact-specific code.
+
+## What counts as a new version
+
+The trigger fires no matter how the version was published: a task output wrapped with `flyte.artifacts.new()`, an upload through `flyte.remote.Artifact.create()` or `flyte create artifact`, or a Hugging Face prefetch. This makes triggers a clean handoff point between external processes and your pipelines: a partner drops a dataset, publishes it as an artifact, and your processing task starts on its own.
+
+By default any new version fires the trigger. Pass `version=` to `flyte.OnArtifact` to fire only when that exact version is published.
+
+## Rules
+
+* At most one input can be `flyte.TriggeredArtifact`.
+* `flyte.TriggeredArtifact` requires the automation to be `flyte.OnArtifact`.
+* `flyte.TriggerTime` cannot be combined with `flyte.OnArtifact`; it is for schedule triggers.
+
+All other inputs must have values in the trigger definition or defaults on the task, the same as [schedule triggers](../tasks/task-configuration/triggers).

--- a/content/user-guide/artifacts/artifacts-in-apps.md
+++ b/content/user-guide/artifacts/artifacts-in-apps.md
@@ -1,0 +1,42 @@
+---
+title: Use artifacts in apps
+weight: 5
+variants: -flyte +union
+---
+
+# Use artifacts in apps
+
+A serving app usually needs model weights or reference data on disk before it starts. Instead of baking them into the image or downloading them in startup code, declare an artifact as an app parameter and Union mounts it for you.
+
+`flyte.app.ArtifactValue` names the artifact, and the parameter's `mount` says where its contents appear in the container:
+
+```python
+import flyte
+import flyte.app
+
+env = flyte.AppEnvironment(
+    name="classifier-api",
+    resources=flyte.Resources(cpu="2", memory="8Gi"),
+    parameters=[
+        flyte.app.Parameter(
+            name="model",
+            value=flyte.app.ArtifactValue(name="trained-model", type="directory"),
+            mount="/tmp/model",
+        )
+    ],
+)
+```
+
+The app code reads `/tmp/model` like any local directory. Only `flyte.io.File` and `flyte.io.Dir` artifacts can be app parameters; set `type` to `"file"` or `"directory"` to match.
+
+The prebuilt serving environments accept an `ArtifactValue` directly. For example, the vLLM and SGLang app environments take one as `model_path`, which pairs naturally with [prefetched Hugging Face models](prefetch-models).
+
+## Versions are pinned at deploy time
+
+The artifact is resolved when the app is deployed. If you leave out `version`, the latest version at deploy time is chosen and pinned, so a new version published later does not swap weights under a running app. Redeploy to move to the newer version, or pass an explicit `version=` to stay on a known one.
+
+Union records exactly which artifact version each app deployment resolved, so the artifact's [lineage view](lineage) shows every app serving it.
+
+## Apps can publish artifacts too
+
+An app endpoint can call `flyte.remote.Artifact.create()` to register a new version from inside the app, for example to snapshot state it has built up. That version behaves like any other: it shows up in the registry and can fire [artifact triggers](artifact-triggers).

--- a/content/user-guide/artifacts/artifacts-in-apps.md
+++ b/content/user-guide/artifacts/artifacts-in-apps.md
@@ -14,7 +14,7 @@ A serving app usually needs model weights or reference data on disk before it st
 import flyte
 import flyte.app
 
-env = flyte.AppEnvironment(
+env = flyte.app.AppEnvironment(
     name="classifier-api",
     resources=flyte.Resources(cpu="2", memory="8Gi"),
     parameters=[

--- a/content/user-guide/artifacts/artifacts-in-apps.md
+++ b/content/user-guide/artifacts/artifacts-in-apps.md
@@ -29,14 +29,14 @@ env = flyte.AppEnvironment(
 
 The app code reads `/tmp/model` like any local directory. Only `flyte.io.File` and `flyte.io.Dir` artifacts can be app parameters; set `type` to `"file"` or `"directory"` to match.
 
-The prebuilt serving environments accept an `ArtifactValue` directly. For example, the vLLM and SGLang app environments take one as `model_path`, which pairs naturally with [prefetched Hugging Face models](prefetch-models).
+The prebuilt serving environments accept an `ArtifactValue` directly. For example, the vLLM and SGLang app environments take one as `model_path`, which pairs naturally with [prefetched Hugging Face models](./prefetch-models).
 
 ## Versions are pinned at deploy time
 
 The artifact is resolved when the app is deployed. If you leave out `version`, the latest version at deploy time is chosen and pinned, so a new version published later does not swap weights under a running app. Redeploy to move to the newer version, or pass an explicit `version=` to stay on a known one.
 
-Union records exactly which artifact version each app deployment resolved, so the artifact's [lineage view](lineage) shows every app serving it.
+Union records exactly which artifact version each app deployment resolved, so the artifact's [lineage view](./lineage) shows every app serving it.
 
 ## Apps can publish artifacts too
 
-An app endpoint can call `flyte.remote.Artifact.create()` to register a new version from inside the app, for example to snapshot state it has built up. That version behaves like any other: it shows up in the registry and can fire [artifact triggers](artifact-triggers).
+An app endpoint can call `flyte.remote.Artifact.create()` to register a new version from inside the app, for example to snapshot state it has built up. That version behaves like any other: it shows up in the registry and can fire [artifact triggers](./artifact-triggers).

--- a/content/user-guide/artifacts/artifacts-in-apps.md
+++ b/content/user-guide/artifacts/artifacts-in-apps.md
@@ -40,3 +40,5 @@ Union records exactly which artifact version each app deployment resolved, so th
 ## Apps can publish artifacts too
 
 An app endpoint can call `flyte.remote.Artifact.create()` to register a new version from inside the app, for example to snapshot state it has built up. That version behaves like any other: it shows up in the registry and can fire [artifact triggers](./artifact-triggers).
+
+One difference from a task output: outside a task there is no producing run to stamp on the version, so pass `external_ref` if you want the new version to record where its data came from.

--- a/content/user-guide/artifacts/lineage.md
+++ b/content/user-guide/artifacts/lineage.md
@@ -18,7 +18,6 @@ On the producer side, each version records how it came to exist:
 
 On the consumer side, Union records each place a version is bound to compute:
 
-* Runs that took the artifact as a task input.
 * Apps whose deployment resolved the artifact as a parameter, down to the exact pinned version.
 * Triggers watching the artifact name, and the runs they started.
 
@@ -41,4 +40,4 @@ In Python, `flyte.remote.Artifact` exposes `source`, `created_by`, and `url`, wh
 
 ## What is not recorded
 
-Consumption is recorded where an artifact is bound to a unit of compute: a task input at `flyte.run()`, or an app parameter at deploy. Calling `Artifact.get()` inside arbitrary code and reading the data yourself is a plain fetch, and does not create a consumer edge in the graph. If you want the dependency tracked, pass the artifact as a task input or app parameter.
+Calling `Artifact.get()` in your own code and reading the data is a plain fetch, and does not create a consumer edge in the graph. Passing an artifact as a task input does not record a consumer edge yet either. Today the tracked dependencies are apps that declare the artifact as a parameter and the runs started by artifact triggers.

--- a/content/user-guide/artifacts/lineage.md
+++ b/content/user-guide/artifacts/lineage.md
@@ -23,11 +23,11 @@ On the consumer side, Union records each place a version is bound to compute:
 
 ## The lineage view
 
-Each artifact in the UI has a **Lineage** tab that draws this graph around the selected version. The source action that produced the artifact sits on the left, and the dependents fan out on the right: the triggers watching the artifact, the runs those triggers started, and the apps serving it. Each node links to its own page, so you can jump from the graph to the producing run's logs or a consuming app's deployment.
+Each artifact in the UI has a **Lineage** tab that draws this graph around the selected version. The source action that produced the artifact sits on the left, and the dependents fan out on the right: the triggers watching the artifact, the runs those triggers started, and the apps serving it. App and run nodes link to their own pages, so you can jump from the graph to a consuming app's deployment or the producing run's logs. Trigger rows expand in place to reveal the runs they started.
 
-The neighboring tabs break out the same relationships as lists: **Versions** shows the full version history, **Triggers** and **Apps** list what depends on the artifact, and **Artifact Card** renders the attached model or data card.
+The neighboring tabs break out the same relationships as lists: **Versions** shows the full version history, **Triggers** and **Apps** list what depends on the artifact, and **Artifact card** renders the attached model or data card.
 
-This gives you a birds-eye view of your data relationships. Before deleting or reworking a dataset, you can see every model trained on it and every app serving those models. When a served model misbehaves, you can walk back to the training run and the exact dataset version it consumed.
+Before deleting or reworking a dataset, you can see every model trained on it and every app serving those models. When a served model misbehaves, you can walk back to the training run and the exact dataset version it consumed.
 
 You can query the same relationships from the CLI:
 

--- a/content/user-guide/artifacts/lineage.md
+++ b/content/user-guide/artifacts/lineage.md
@@ -23,7 +23,7 @@ On the consumer side, Union records each place a version is bound to compute:
 
 ## The lineage view
 
-Each artifact in the UI has a **Lineage** tab that draws this graph around the selected version. The source action that produced the artifact sits on the left, and the dependents fan out on the right: the triggers watching the artifact, the runs those triggers started, and the apps serving it. App and run nodes link to their own pages, so you can jump from the graph to a consuming app's deployment or the producing run's logs. Trigger rows expand in place to reveal the runs they started.
+Each artifact in the UI has a **Lineage** tab that draws this graph. The source action that produced the artifact sits on the left, and the dependents fan out on the right: the triggers watching the artifact name, and the apps pinning the selected version. App and run nodes link to their own pages, so you can jump from the graph to a consuming app's deployment or the producing run's logs. Trigger rows expand in place to reveal the runs they started.
 
 The neighboring tabs break out the same relationships as lists: **Versions** shows the full version history, **Triggers** and **Apps** list what depends on the artifact, and **Artifact card** renders the attached model or data card.
 

--- a/content/user-guide/artifacts/lineage.md
+++ b/content/user-guide/artifacts/lineage.md
@@ -1,0 +1,44 @@
+---
+title: Automatic lineage tracking
+weight: 6
+variants: -flyte +union
+---
+
+# Automatic lineage tracking
+
+Every artifact version carries its history with it. Union records who produced it and everything that depends on it, without any configuration on your part. The result is a graph you can walk in either direction: from a deployed model back to the run and dataset that produced it, or from a dataset forward to every model, trigger, and app that consumes it.
+
+## What gets recorded
+
+On the producer side, each version records how it came to exist:
+
+* A task output records the run and task that produced it, with a link to that execution and its inputs and logs.
+* An upload through `flyte.remote.Artifact.create()` or `flyte create artifact` records who published it, and the `external_ref` if one was given, pointing at the original location of the data.
+* A Hugging Face prefetch records the source repo and commit.
+
+On the consumer side, Union records each place a version is bound to compute:
+
+* Runs that took the artifact as a task input.
+* Apps whose deployment resolved the artifact as a parameter, down to the exact pinned version.
+* Triggers watching the artifact name, and the runs they started.
+
+## The lineage view
+
+Each artifact in the UI has a **Lineage** tab that draws this graph around the selected version. The source action that produced the artifact sits on the left, and the dependents fan out on the right: the triggers watching the artifact, the runs those triggers started, and the apps serving it. Each node links to its own page, so you can jump from the graph to the producing run's logs or a consuming app's deployment.
+
+The neighboring tabs break out the same relationships as lists: **Versions** shows the full version history, **Triggers** and **Apps** list what depends on the artifact, and **Artifact Card** renders the attached model or data card.
+
+This gives you a birds-eye view of your data relationships. Before deleting or reworking a dataset, you can see every model trained on it and every app serving those models. When a served model misbehaves, you can walk back to the training run and the exact dataset version it consumed.
+
+You can query the same relationships from the CLI:
+
+```bash
+flyte get artifact --source-run my_run          # what a run produced
+flyte get artifact --source-external-ref s3://partner-bucket/drop/2026-08-18.csv
+```
+
+In Python, `flyte.remote.Artifact` exposes `source`, `created_by`, and `url`, which links to the artifact's page in the UI.
+
+## What is not recorded
+
+Consumption is recorded where an artifact is bound to a unit of compute: a task input at `flyte.run()`, or an app parameter at deploy. Calling `Artifact.get()` inside arbitrary code and reading the data yourself is a plain fetch, and does not create a consumer edge in the graph. If you want the dependency tracked, pass the artifact as a task input or app parameter.

--- a/content/user-guide/artifacts/prefetch-models.md
+++ b/content/user-guide/artifacts/prefetch-models.md
@@ -1,0 +1,65 @@
+---
+title: Prefetch Hugging Face models
+weight: 3
+variants: -flyte +union
+---
+
+# Prefetch Hugging Face models
+
+Serving apps and training tasks should not download model weights from the Hugging Face Hub on every cold start. Prefetching downloads the weights once, stores them in your own object storage close to your compute, and registers the result as a model artifact.
+
+`flyte.prefetch.hf_model()` launches a run that does the download and registration:
+
+```python
+import flyte
+
+flyte.init_from_config()
+
+run = flyte.prefetch.hf_model(
+    repo="HuggingFaceTB/SmolLM2-135M-Instruct",
+    hf_token_key=None,  # public repo, no token needed
+    resources=flyte.Resources(cpu="2", memory="4Gi", disk="10Gi"),
+)
+run.wait()
+```
+
+For gated repos, `hf_token_key` names the secret that holds your Hugging Face token (default `HF_TOKEN`). It is the name of the secret, not the token itself.
+
+## What gets registered
+
+On success the platform records a model artifact for the stored weights:
+
+* The artifact name defaults to the repo name, or set it with `artifact_name`.
+* The version is the Hugging Face commit id, so prefetching the same commit again republishes the same version instead of creating a duplicate.
+* The searchable metadata carries the model facts (framework, architecture, task, modality, serialization format) plus the source repo and commit.
+* The repo's README is attached as the model card.
+
+Retrieve it later with `flyte.remote.Artifact.get(artifact_name)`, or find it by source:
+
+```bash
+flyte get artifact --source-external-ref hf://HuggingFaceTB/SmolLM2-135M-Instruct
+```
+
+## Sharding large models
+
+For models that will be served with tensor parallelism, pre-shard the weights during prefetch so the serving app skips that work too:
+
+```python
+from flyte.prefetch import ShardConfig, VLLMShardArgs
+
+run = flyte.prefetch.hf_model(
+    repo="meta-llama/Llama-2-70b-hf",
+    shard_config=ShardConfig(engine="vllm", args=VLLMShardArgs(tensor_parallel_size=8)),
+    hf_token_key="HF_TOKEN",
+)
+```
+
+## From the CLI
+
+```bash
+flyte prefetch hf-model meta-llama/Llama-2-7b-hf --artifact-name llama2-7b --gpu A100:1 --wait
+```
+
+The CLI accepts the same options as the Python API, including `--cpu`, `--mem`, `--disk`, `--modality`, `--format`, and `--shard-config` with a YAML file.
+
+Once prefetched, mount the model into a serving app with an artifact parameter. See [Use artifacts in apps](artifacts-in-apps).

--- a/content/user-guide/artifacts/prefetch-models.md
+++ b/content/user-guide/artifacts/prefetch-models.md
@@ -62,4 +62,4 @@ flyte prefetch hf-model meta-llama/Llama-2-7b-hf --artifact-name llama2-7b --gpu
 
 The CLI accepts the same options as the Python API, including `--cpu`, `--mem`, `--disk`, `--modality`, `--format`, and `--shard-config` with a YAML file.
 
-Once prefetched, mount the model into a serving app with an artifact parameter. See [Use artifacts in apps](artifacts-in-apps).
+Once prefetched, mount the model into a serving app with an artifact parameter. See [Use artifacts in apps](./artifacts-in-apps).

--- a/content/user-guide/artifacts/prefetch-models.md
+++ b/content/user-guide/artifacts/prefetch-models.md
@@ -12,6 +12,7 @@ Serving apps and training tasks should not download model weights from the Huggi
 
 ```python
 import flyte
+import flyte.prefetch
 
 flyte.init_from_config()
 
@@ -50,9 +51,14 @@ from flyte.prefetch import ShardConfig, VLLMShardArgs
 run = flyte.prefetch.hf_model(
     repo="meta-llama/Llama-2-70b-hf",
     shard_config=ShardConfig(engine="vllm", args=VLLMShardArgs(tensor_parallel_size=8)),
+    resources=flyte.Resources(cpu="8", memory="64Gi", disk="500Gi", gpu="A100:8"),
     hf_token_key="HF_TOKEN",
 )
 ```
+
+Sharding needs an accelerator, and enough disk for the weights. The default
+`resources` for `flyte.prefetch.hf_model()` are `cpu="2", memory="8Gi", disk="50Gi"`
+with no GPU, so set them explicitly to match the model you are sharding.
 
 ## From the CLI
 

--- a/content/user-guide/artifacts/prefetch-models.md
+++ b/content/user-guide/artifacts/prefetch-models.md
@@ -6,9 +6,7 @@ variants: -flyte +union
 
 # Prefetch Hugging Face models
 
-Serving apps and training tasks should not download model weights from the Hugging Face Hub on every cold start. Prefetching downloads the weights once, stores them in your own object storage close to your compute, and registers the result as a model artifact.
-
-`flyte.prefetch.hf_model()` launches a run that does the download and registration:
+`flyte.prefetch.hf_model()` downloads a model from the Hugging Face Hub into your own object storage and registers the result as a model artifact. It is the third way an artifact is created, alongside [task outputs](./task-outputs) and [publishing your own](./publish-artifacts).
 
 ```python
 import flyte
@@ -16,56 +14,39 @@ import flyte.prefetch
 
 flyte.init_from_config()
 
-run = flyte.prefetch.hf_model(
-    repo="HuggingFaceTB/SmolLM2-135M-Instruct",
-    hf_token_key=None,  # public repo, no token needed
-    resources=flyte.Resources(cpu="2", memory="4Gi", disk="10Gi"),
-)
+run = flyte.prefetch.hf_model(repo="HuggingFaceTB/SmolLM2-135M-Instruct")
 run.wait()
 ```
 
-For gated repos, `hf_token_key` names the secret that holds your Hugging Face token (default `HF_TOKEN`). It is the name of the secret, not the token itself.
+For the full how-to, including sharding for multi-GPU inference, resources, tokens for gated repos, CLI usage, and serving the result from a vLLM or SGLang app, see [Prefetching models](../apps/serve-and-deploy-apps/prefetching-models). This page covers what a prefetch means for the artifact registry.
 
 ## What gets registered
 
 On success the platform records a model artifact for the stored weights:
 
-* The artifact name defaults to the repo name, or set it with `artifact_name`.
-* The version is the Hugging Face commit id, so prefetching the same commit again republishes the same version instead of creating a duplicate.
+* The artifact name defaults to the last segment of the repo id, with `.` replaced by `-`, or set it with `artifact_name`. The example above registers `SmolLM2-135M-Instruct`.
+* The version is the Hugging Face commit id.
 * The searchable metadata carries the model facts (framework, architecture, task, modality, serialization format) plus the source repo and commit.
-* The repo's README is attached as the model card.
+* The repo's README, if it has one, is attached as the model card.
 
-Retrieve it later with `flyte.remote.Artifact.get(artifact_name)`, or find it by source:
+Because the version is the upstream commit, a prefetch is idempotent. Re-running it for a model that has not moved republishes the same version instead of filling the registry with duplicates, and a genuine upstream change arrives as a new version you can [trigger on](./artifact-triggers).
+
+## Finding a prefetched model
+
+Retrieve it by name:
+
+```python
+from flyte.remote import Artifact
+
+model = Artifact.get("SmolLM2-135M-Instruct")
+```
+
+Or find it by where it came from. The `hf://` source reference is recorded automatically:
 
 ```bash
 flyte get artifact --source-external-ref hf://HuggingFaceTB/SmolLM2-135M-Instruct
 ```
 
-## Sharding large models
-
-For models that will be served with tensor parallelism, pre-shard the weights during prefetch so the serving app skips that work too:
-
-```python
-from flyte.prefetch import ShardConfig, VLLMShardArgs
-
-run = flyte.prefetch.hf_model(
-    repo="meta-llama/Llama-2-70b-hf",
-    shard_config=ShardConfig(engine="vllm", args=VLLMShardArgs(tensor_parallel_size=8)),
-    resources=flyte.Resources(cpu="8", memory="64Gi", disk="500Gi", gpu="A100:8"),
-    hf_token_key="HF_TOKEN",
-)
-```
-
-Sharding needs an accelerator, and enough disk for the weights. The default
-`resources` for `flyte.prefetch.hf_model()` are `cpu="2", memory="8Gi", disk="50Gi"`
-with no GPU, so set them explicitly to match the model you are sharding.
-
-## From the CLI
-
-```bash
-flyte prefetch hf-model meta-llama/Llama-2-7b-hf --artifact-name llama2-7b --gpu A100:1 --wait
-```
-
-The CLI accepts the same options as the Python API, including `--cpu`, `--mem`, `--disk`, `--modality`, `--format`, and `--shard-config` with a YAML file.
+That same reference is what makes a prefetched model traceable back to its Hub repo and commit in the [lineage view](./lineage).
 
 Once prefetched, mount the model into a serving app with an artifact parameter. See [Use artifacts in apps](./artifacts-in-apps).

--- a/content/user-guide/artifacts/prefetch-models.md
+++ b/content/user-guide/artifacts/prefetch-models.md
@@ -41,12 +41,12 @@ from flyte.remote import Artifact
 model = Artifact.get("SmolLM2-135M-Instruct")
 ```
 
-Or find it by where it came from. The `hf://` source reference is recorded automatically:
+Or find it by where it came from. The source repo and commit are recorded as searchable metadata:
 
 ```bash
-flyte get artifact --source-external-ref hf://HuggingFaceTB/SmolLM2-135M-Instruct
+flyte get artifact --attr source_repo=HuggingFaceTB/SmolLM2-135M-Instruct
 ```
 
-That same reference is what makes a prefetched model traceable back to its Hub repo and commit in the [lineage view](./lineage).
+Those `source_repo` and `source_commit` attributes are what make a prefetched model traceable back to its Hub repo and commit.
 
 Once prefetched, mount the model into a serving app with an artifact parameter. See [Use artifacts in apps](./artifacts-in-apps).

--- a/content/user-guide/artifacts/prefetch-models.md
+++ b/content/user-guide/artifacts/prefetch-models.md
@@ -25,7 +25,7 @@ For the full how-to, including sharding for multi-GPU inference, resources, toke
 On success the platform records a model artifact for the stored weights:
 
 * The artifact name defaults to the last segment of the repo id, with `.` replaced by `-`, or set it with `artifact_name`. The example above registers `SmolLM2-135M-Instruct`.
-* The version is the Hugging Face commit id.
+* The version is the Hugging Face commit ID.
 * The searchable metadata carries the model facts (framework, architecture, task, modality, serialization format) plus the source repo and commit.
 * The repo's README, if it has one, is attached as the model card.
 

--- a/content/user-guide/artifacts/publish-artifacts.md
+++ b/content/user-guide/artifacts/publish-artifacts.md
@@ -28,7 +28,7 @@ published = Artifact.create(
 print(published.name, published.version)
 ```
 
-If you do not pass a `version`, one is generated for you. Pass `attrs`, `kind`, and `card` the same way as in task-produced [metadata](task-outputs#metadata). The call is synchronous by default; use `Artifact.create.aio(...)` from async code.
+If you do not pass a `version`, one is generated for you. Pass `attrs`, `kind`, and `card` the same way as in task-produced [metadata](./task-outputs#metadata). The call is synchronous by default; use `Artifact.create.aio(...)` from async code.
 
 The `external_ref` records where the data came from. When `Artifact.create()` runs inside a task, the producing run is stamped on the artifact automatically; outside a task, `external_ref` is the provenance you can attach.
 

--- a/content/user-guide/artifacts/publish-artifacts.md
+++ b/content/user-guide/artifacts/publish-artifacts.md
@@ -1,0 +1,62 @@
+---
+title: Publish your own artifacts
+weight: 2
+variants: -flyte +union
+---
+
+# Publish your own artifacts
+
+Not every dataset or model is produced by a task. You can publish an existing asset as an artifact from anywhere: a laptop, a notebook, a CI job, or an external pipeline. This is how you bootstrap a registry from assets you already have.
+
+## From Python
+
+Use `flyte.remote.Artifact.create()`. It uploads the value and registers a version in one call:
+
+```python
+import flyte
+from flyte.io import File
+from flyte.remote import Artifact
+
+flyte.init_from_config()
+
+published = Artifact.create(
+    File.from_local_sync("data/2026-08-18.csv"),
+    name="incoming_dataset",
+    description="Dataset dropped off by a partner",
+    external_ref="s3://partner-bucket/drop/2026-08-18.csv",
+)
+print(published.name, published.version)
+```
+
+If you do not pass a `version`, one is generated for you. Pass `attrs`, `kind`, and `card` the same way as in task-produced [metadata](task-outputs#metadata). The call is synchronous by default; use `Artifact.create.aio(...)` from async code.
+
+The `external_ref` records where the data came from. When `Artifact.create()` runs inside a task, the producing run is stamped on the artifact automatically; outside a task, `external_ref` is the provenance you can attach.
+
+## From the CLI
+
+`flyte create artifact` publishes a file directly:
+
+```bash
+flyte create artifact my-model --from-file model.pt --kind model --attr framework=torch
+flyte create artifact llama3 --from-file weights.bin --external-ref hf://meta-llama/Meta-Llama-3-8B
+flyte create artifact my-model --from-file model.pt --card model_card.html --card-type model
+```
+
+`--attr` is repeatable, `--kind` is one of `model`, `data`, or `generic`, and the card format is inferred from the file extension.
+
+## Finding artifacts
+
+`flyte get artifact` browses the registry:
+
+```bash
+flyte get artifact                        # all artifact names, with latest version info
+flyte get artifact my-model               # every version of my-model, newest first
+flyte get artifact my-model 1.0           # details of one version
+flyte get artifact --search model         # names containing "model"
+flyte get artifact --source-run my_run    # versions produced by a run
+flyte get artifact --kind model --attr framework=torch
+```
+
+The same queries are available in Python. `Artifact.get(name)` returns the latest version by default, `Artifact.listall()` iterates versions newest first with server-side filtering, and `Artifact.list_names()` lists distinct names with their version counts.
+
+Artifacts are scoped to a project and domain. All of these calls accept `project` and `domain` arguments, and default to the ones in your config.

--- a/content/user-guide/artifacts/task-outputs.md
+++ b/content/user-guide/artifacts/task-outputs.md
@@ -82,4 +82,4 @@ data = Artifact.get("training-set", version="v3")   # pinned version
 run = flyte.run(evaluate, model=model, data=data)
 ```
 
-The task body receives a plain `File`, `Dir`, or `DataFrame` and needs no artifact-specific code. Union records the run as a consumer of those artifact versions, which is what powers [lineage tracking](lineage).
+The task body receives a plain `File`, `Dir`, or `DataFrame` and needs no artifact-specific code.

--- a/content/user-guide/artifacts/task-outputs.md
+++ b/content/user-guide/artifacts/task-outputs.md
@@ -32,7 +32,7 @@ async def train() -> File:
 Every run of this task registers a new version of `trained-model`. Union records the producing run on the artifact, so you can always trace a version back to the execution that created it.
 
 > [!WARNING] Both parts are required
-> Without `produces_artifacts=True`, the `flyte.artifacts.new()` wrapper is silently unwrapped and the task returns a plain value. No artifact is registered, no trigger fires, and there is nothing for an app to bind to.
+> The wrapper is stripped from the output value either way. Without `produces_artifacts=True` the platform never extracts the metadata, so no artifact is registered, no trigger fires, and there is nothing for an app to bind to. Nothing warns you.
 
 ## What can be an artifact
 

--- a/content/user-guide/artifacts/task-outputs.md
+++ b/content/user-guide/artifacts/task-outputs.md
@@ -1,0 +1,85 @@
+---
+title: Task outputs as artifacts
+weight: 1
+variants: -flyte +union
+---
+
+# Task outputs as artifacts
+
+The most common way to create an artifact is to register a task output. Two things are required: the task must be declared with `produces_artifacts=True`, and the return value must be wrapped with `flyte.artifacts.new()`.
+
+```python
+import flyte
+from flyte import artifacts
+from flyte.io import File
+
+env = flyte.TaskEnvironment(name="training")
+
+
+@env.task(produces_artifacts=True)
+async def train() -> File:
+    weights = await File.from_local("model.pt")
+    return artifacts.new(
+        weights,
+        artifacts.Metadata(
+            name="trained-model",
+            description="Classifier trained on the latest training set",
+            attrs={"framework": "pytorch"},
+        ),
+    )
+```
+
+Every run of this task registers a new version of `trained-model`. Union records the producing run on the artifact, so you can always trace a version back to the execution that created it.
+
+> [!WARNING] Both parts are required
+> Without `produces_artifacts=True`, the `flyte.artifacts.new()` wrapper is silently unwrapped and the task returns a plain value. No artifact is registered, no trigger fires, and there is nothing for an app to bind to.
+
+## What can be an artifact
+
+An artifact must be an offloaded value: a `flyte.io.File`, a `flyte.io.Dir`, or a `flyte.io.DataFrame`. Primitives, dataclasses, and Pydantic models cannot be artifacts. Wrap a raw dataframe with `DataFrame.from_df()` first.
+
+The wrapped value must also be a top-level task output. Nesting an artifact inside a list, a dictionary, or a model raises an error. In a multi-output task, only the wrapped slot becomes an artifact:
+
+```python
+@env.task(produces_artifacts=True)
+async def train() -> tuple[File, float]:
+    ...
+    return artifacts.new(weights, metadata), accuracy
+```
+
+## Metadata
+
+`flyte.artifacts.Metadata` carries the identity of the artifact. Only `name` is required. If you leave out `version`, the version comes from the producing run, so every execution registers a distinct version. You can also set a `description`, string-valued `attrs` for searching and filtering, a `kind` (`"model"`, `"data"`, or `"generic"`), and a card.
+
+For models there is a helper that fills in the standard fields and sets `kind="model"`:
+
+```python
+card = artifacts.Card.create_from(content=card_html, format="html", card_type="model")
+
+metadata = artifacts.Metadata.create_model_metadata(
+    name="trained-model",
+    description="A toy classifier",
+    framework="PyTorch",
+    architecture="ResNet50",
+    task="Image Classification",
+    serial_format="pt",
+    card=card,
+)
+```
+
+A card is a document attached to the artifact and rendered in the UI. `flyte.artifacts.Card.create_from()` accepts inline content or a local file, in formats including HTML, Markdown, JSON, YAML, CSV, and PNG.
+
+## Consuming artifacts in tasks
+
+Downstream tasks take artifacts as ordinary typed inputs. Fetch a reference with `flyte.remote.Artifact.get()` and pass it to `flyte.run()`:
+
+```python
+from flyte.remote import Artifact
+
+model = Artifact.get("trained-model")               # latest version
+data = Artifact.get("training-set", version="v3")   # pinned version
+
+run = flyte.run(evaluate, model=model, data=data)
+```
+
+The task body receives a plain `File`, `Dir`, or `DataFrame` and needs no artifact-specific code. Union records the run as a consumer of those artifact versions, which is what powers [lineage tracking](lineage).

--- a/content/user-guide/artifacts/task-outputs.md
+++ b/content/user-guide/artifacts/task-outputs.md
@@ -51,7 +51,7 @@ async def train() -> tuple[File, float]:
 
 `flyte.artifacts.Metadata` carries the identity of the artifact. Only `name` is required. If you leave out `version`, the version comes from the producing run, so every execution registers a distinct version. You can also set a `description`, string-valued `attrs` for searching and filtering, a `kind` (`"model"`, `"data"`, or `"generic"`), and a card.
 
-For models there is a helper that fills in the standard fields and sets `kind="model"`:
+For models there is a helper that fills in the standard fields and records the artifact's kind as `model`:
 
 ```python
 card = artifacts.Card.create_from(content=card_html, format="html", card_type="model")

--- a/content/user-guide/authenticating.md
+++ b/content/user-guide/authenticating.md
@@ -1,6 +1,6 @@
 ---
 title: Authenticating
-weight: 5
+weight: 6
 variants: -flyte +union
 ---
 

--- a/content/user-guide/cluster-workload-management/_index.md
+++ b/content/user-guide/cluster-workload-management/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Cluster and workload management
-weight: 7
+weight: 8
 variants: -flyte +union
 mermaid: true
 ---

--- a/content/user-guide/migration/_index.md
+++ b/content/user-guide/migration/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Migration
-weight: 11
+weight: 12
 variants: +flyte +union
 ---
 

--- a/content/user-guide/project-patterns/_index.md
+++ b/content/user-guide/project-patterns/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Project patterns
-weight: 8
+weight: 9
 variants: +flyte +union
 ---
 

--- a/content/user-guide/run-scaling/_index.md
+++ b/content/user-guide/run-scaling/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Scale your runs
-weight: 9
+weight: 10
 variants: +flyte +union
 llm_readable_bundle: true
 ---

--- a/content/user-guide/tasks/task-configuration/triggers.md
+++ b/content/user-guide/tasks/task-configuration/triggers.md
@@ -12,6 +12,21 @@ Triggers allow you to automate and parameterize an execution by scheduling its s
 In Flyte 1 these were configured with a `LaunchPlan` (the `flytekit.LaunchPlan` API) and `CronSchedule`. Flyte 2 replaces them with `flyte.Trigger` and `flyte.Cron`, described below.
 {{< /note >}}
 
+{{< variant union >}}
+{{< markdown >}}
+
+Two trigger types are available:
+
+* **Schedule triggers** run a task based on a Cron expression or a fixed-rate schedule. They are described below.
+* **Artifact triggers** run a task when a new version of a named artifact lands. See [Trigger on new versions](../../artifacts/artifact-triggers).
+
+Support is coming for webhook triggers, which will hit an API endpoint to run your task.
+
+{{< /markdown >}}
+{{< /variant >}}
+{{< variant flyte >}}
+{{< markdown >}}
+
 Currently, only **schedule triggers** are supported.
 This type of trigger runs a task based on a Cron expression or a fixed-rate schedule.
 
@@ -19,6 +34,9 @@ Support is coming for other trigger types, such as:
 
 * Webhook triggers: Hit an API endpoint to run your task.
 * Artifact triggers: Run a task when a specific artifact is produced.
+
+{{< /markdown >}}
+{{< /variant >}}
 
 ## Triggers are set in the task decorator
 

--- a/content/user-guide/user-management.md
+++ b/content/user-guide/user-management.md
@@ -1,6 +1,6 @@
 ---
 title: User management
-weight: 6
+weight: 7
 variants: -flyte +union
 ---
 


### PR DESCRIPTION
## Summary

Adds a new **Artifacts** section to the user guide, placed after **Apps** in the sidebar. The section is Union-only (`-flyte +union`).

An index page introduces artifacts (a named, versioned reference to an object in storage) with six cards, each backed by a full page:

- **Task outputs as artifacts** — `produces_artifacts=True` + `flyte.artifacts.new()`, metadata, model/data cards, and consuming artifacts as task inputs
- **Publish your own artifacts** — `Artifact.create()` and `flyte create artifact` for datasets and models produced outside tasks, with `external_ref` provenance
- **Prefetch Hugging Face models** — `flyte.prefetch.hf_model()`, versioned by HF commit, README attached as the model card, vLLM sharding
- **Trigger on new versions** — `flyte.OnArtifact` + `flyte.TriggeredArtifact`, fires regardless of who published the version
- **Use artifacts in apps** — `flyte.app.ArtifactValue` with deploy-time version pinning
- **Automatic lineage tracking** — producer and consumer edges, the Lineage tab in the UI, and the fetch vs tracked-consumption distinction

Sidebar weights of the sections after Apps are bumped by one to make room.

## Lineage view in the UI
<img width="1999" height="1093" alt="lineage-ui" src="https://github.com/user-attachments/assets/b04a6882-7c5f-4dc5-b8ac-8d694fc6dcde" />

## Notes

- Content is grounded in the flyte-sdk implementation (`flyte.artifacts`, `flyte.remote.Artifact`, `flyte.prefetch`, `flyte.OnArtifact`, `flyte.app.ArtifactValue`) and the artifacts/triggers PRDs.
- `user-guide/tasks/task-configuration/triggers.md` still says artifact triggers are "coming"; worth updating in a follow-up to link here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
