### PR TITLE
docsy(v2): fix four dead icon names and a non-existent AppEnvironment example

### DIFF
--- a/content/api-reference/_index.md
+++ b/content/api-reference/_index.md
@@ -19,7 +19,7 @@ This will install both the Flyte SDK and CLI.
 
 {{< grid >}}
 
-{{< link-card target="flyte-sdk" icon="workflow" title="Flyte SDK" >}}
+{{< link-card target="flyte-sdk" icon="code-square" title="Flyte SDK" >}}
 The Flyte SDK provides the core Python API for building workflows and apps on your Union instance.
 {{< /link-card >}}
 

--- a/content/community/contributing-docs/shortcodes.md
+++ b/content/community/contributing-docs/shortcodes.md
@@ -45,7 +45,7 @@ Examples:
 * A shortcode with parameters
 
 ```markdown
-{{</* link-card target="union-sdk" icon="workflow" title="Union SDK" */>}}
+{{</* link-card target="union-sdk" icon="code-square" title="Union SDK" */>}}
 The Union SDK provides the Python API for building Union workflows and apps.
 {{</* /link-card */>}}
 ```

--- a/content/deployment/terraform/_index.md
+++ b/content/deployment/terraform/_index.md
@@ -42,7 +42,7 @@ To get started with the Union Terraform provider:
 Install and configure the Union Terraform provider
 {{< /link-card >}}
 
-{{< link-card target="./management" icon="settings" title="Resource management" >}}
+{{< link-card target="./management" icon="gear" title="Resource management" >}}
 Learn about available resources and data sources
 {{< /link-card >}}
 

--- a/content/user-guide/apps/_index.md
+++ b/content/user-guide/apps/_index.md
@@ -11,7 +11,7 @@ An app is a long-running service that Flyte keeps up, rather than a job that run
 Apps are declared the same way tasks are. An `AppEnvironment` names the image, the port, and the scaling behavior, and the code inside it is an ordinary web application.
 
 ```python
-app = flyte.AppEnvironment(name="dashboard", image=..., port=8080)
+app = flyte.app.AppEnvironment(name="dashboard", image=..., port=8080)
 ```
 
 Because apps and tasks live in the same project, an app can read what a task produced without moving data between systems, and a task can call an app it depends on.

--- a/content/user-guide/cluster-workload-management/_index.md
+++ b/content/user-guide/cluster-workload-management/_index.md
@@ -134,7 +134,7 @@ Group clusters that share a data plane. Create and manage pools, or stay on the 
 Register execution clusters into a pool and inspect their state, capacity, and bound queues.
 {{< /link-card >}}
 
-{{< link-card target="queues" icon="workflow" title="Managing queues" >}}
+{{< link-card target="queues" icon="list-task" title="Managing queues" >}}
 Create and manage the scheduling lanes that route workloads to a pool and enforce concurrency, priority, and fairness.
 {{< /link-card >}}
 

--- a/content/user-guide/migration/_index.md
+++ b/content/user-guide/migration/_index.md
@@ -10,11 +10,11 @@ Guides for migrating to Flyte 2 from other systems.
 
 {{< grid >}}
 
-{{< link-card target="flyte-2" icon="package-2" title="From Flyte 1 to 2" >}}
+{{< link-card target="flyte-2" icon="box-seam" title="From Flyte 1 to 2" >}}
 What's new in Flyte 2 (pure Python execution, simplified API, fine-grained reproducibility) and how to port a Flyte 1 codebase.
 {{< /link-card >}}
 
-{{< link-card target="from-airflow" icon="git-branch" title="From Airflow to Flyte" >}}
+{{< link-card target="from-airflow" icon="git" title="From Airflow to Flyte" >}}
 Mapping from Airflow concepts (DAGs, operators, schedules, XCom, trigger rules) to their Flyte 2 equivalents.
 {{< /link-card >}}
 


### PR DESCRIPTION
## Summary

Two pre-existing defects in published v2 content. **DOC-1444.**

## 1. `flyte.AppEnvironment` does not exist

`content/user-guide/apps/_index.md:14` shipped a copy-pasteable example that raises. Verified against the SDK at released tag **v2.6.1**:

- `hasattr(flyte, 'AppEnvironment')` → **False**
- `'AppEnvironment' in flyte.__all__` → **False**
- `flyte.app.AppEnvironment` → **True**

Every other `AppEnvironment` reference in the corpus (17 of them) already uses the correct `flyte.app.` form, so this was a lone outlier — and it had **already been copied** into an in-flight PR (#1454).

## 2. Four dead icon names

Not in Bootstrap Icons, which is what Shoelace resolves `<sl-icon name="…">` against, so they fetch **404 and render an empty slot**:

| Broken | Now | Site |
|---|---|---|
| `workflow` | `list-task` | `user-guide/cluster-workload-management/_index.md:137` |
| `workflow` | `code-square` | `api-reference/_index.md:22` |
| `workflow` | `code-square` | `community/contributing-docs/shortcodes.md:48` |
| `settings` | `gear` | `deployment/terraform/_index.md:45` |
| `package-2` | `box-seam` | `user-guide/migration/_index.md:13` |
| `git-branch` | `git` | `user-guide/migration/_index.md:17` |

All four are **Lucide** names — the wrong icon vocabulary. Nothing caught it because the failure is invisible: the icon is decorative and `aria-hidden` (no build error), and a missing icon is not a broken link (the link checker cannot see it).

One sits in `contributing-docs/shortcodes.md` — the page that **teaches** the `link-card` shortcode. That is plausibly where the others were copied from, and it is wrong on **both** version lines, which is consistent.

Replacements verified present in the **Shoelace 2.20.0** asset bundle — the version `baseof.html` actually pins — rather than assumed from the name reading sensibly.

## Deliberately untouched

`running-remote.md`'s `icon="bento"` and `icon="control_knobs"` are **correct**. That is the `dropdown` shortcode, which Emojifies its parameter — they are valid gemoji, not dead Bootstrap names. I changed them at first and reverted after reading the shortcode.

## Related

- v1 twin: `docsy/v1-dead-icons`
- CI guard so this cannot recur: unionai-docs-infra `docsy/icon-name-validation`

---
— docsy · automated docs agent · [DOC-1444](https://linear.app/unionai/issue/DOC-1444/dead-icon-names-render-blank-on-15-call-sites-across-v2-v1-and-a-non) · [run report](https://github.com/unionai/docsy/blob/main/runs/2026-08-18-docsy-artifacts-pr-1454.md)