### PR TITLE
docsy(v1): fix three dead icon names across six call sites

### DIFF
--- a/content/api-reference/_index.md
+++ b/content/api-reference/_index.md
@@ -22,11 +22,11 @@ This will install the Union and Flytekit SDKs and the `union` CLI.
 {{< /markdown >}}
 {{< grid >}}
 
-{{< link-card target="flytekit-sdk" icon="workflow" title="Flytekit SDK" >}}
+{{< link-card target="flytekit-sdk" icon="code-square" title="Flytekit SDK" >}}
 The Flytekit SDK provides the core Python API for building Union.ai workflows and apps.
 {{< /link-card >}}
 
-{{< link-card target="union-sdk" icon="workflow" title="Union SDK" >}}
+{{< link-card target="union-sdk" icon="code-square" title="Union SDK" >}}
 The Union SDK provides additional Union.ai-specific capabilities, on top of the core Flytekit SDK.
 {{< /link-card >}}
 
@@ -54,7 +54,7 @@ This will install the Flytekit SDKs and the `pyflyte` CLI.
 {{< /markdown >}}
 {{< grid >}}
 
-{{< link-card target="flytekit-sdk" icon="workflow" title="Flytekit SDK" >}}
+{{< link-card target="flytekit-sdk" icon="code-square" title="Flytekit SDK" >}}
 The Flytekit SDK provides the core Python API for building Flyte workflows.
 {{< /link-card >}}
 

--- a/content/community/contributing-docs/shortcodes.md
+++ b/content/community/contributing-docs/shortcodes.md
@@ -45,7 +45,7 @@ Examples:
 * A shortcode with parameters
 
 ```markdown
-{{</* link-card target="union-sdk" icon="workflow" title="Union SDK" */>}}
+{{</* link-card target="union-sdk" icon="code-square" title="Union SDK" */>}}
 The Union SDK provides the Python API for building Union workflows and apps.
 {{</* /link-card */>}}
 ```

--- a/content/deployment/selfmanaged/byok-data-plane-setup-on-aws/_index.md
+++ b/content/deployment/selfmanaged/byok-data-plane-setup-on-aws/_index.md
@@ -20,7 +20,7 @@ Use the {{< key product_name >}} [EKS Blueprints addon](https://www.npmjs.com/pa
 
 {{< grid >}}
 
-{{< link-card target="./cdk" icon="zap" title="CDK setup" >}}
+{{< link-card target="./cdk" icon="lightning-charge" title="CDK setup" >}}
 Automate data plane provisioning with AWS CDK and EKS Blueprints
 {{< /link-card >}}
 

--- a/content/deployment/terraform/_index.md
+++ b/content/deployment/terraform/_index.md
@@ -42,7 +42,7 @@ To get started with the Union Terraform provider:
 Install and configure the Union Terraform provider
 {{< /link-card >}}
 
-{{< link-card target="./management" icon="settings" title="Resource Management" >}}
+{{< link-card target="./management" icon="gear" title="Resource Management" >}}
 Learn about available resources and data sources
 {{< /link-card >}}
 


### PR DESCRIPTION
## Summary

The v1 twin of the v2 fix. **DOC-1444.** Same defect, independently present on this line.

Three names are not in Bootstrap Icons, which is what Shoelace resolves `<sl-icon name="…">` against, so they fetch **404 and render an empty slot**:

| Broken | Now | Sites |
|---|---|---|
| `workflow` | `code-square` | `api-reference/_index.md:25,29,57` · `community/contributing-docs/shortcodes.md:48` |
| `settings` | `gear` | `deployment/terraform/_index.md:45` |
| `zap` | `lightning-charge` | `deployment/selfmanaged/byok-data-plane-setup-on-aws/_index.md:23` |

All three are **Lucide** names. The failure is invisible — the icon is decorative and `aria-hidden` (no build error), and a missing icon is not a broken link (the link checker cannot see it).

One sits in `contributing-docs/shortcodes.md`, the page that **teaches** the `link-card` shortcode — wrong on **both** lines, consistent with it being the source the others were copied from.

Replacements verified present in the **Shoelace 2.20.0** asset bundle.

## Scope

v1 is an **active** line and these are obvious errors in **published** content, so this is the `v1-fix` exception, not v1 feature work.

## Not changed

`tutorials/_index.md` has 21 `icon=""` (empty). Harmless — `link-card` guards with `with`, so an empty value emits no icon at all. Redundant, not broken, and out of scope here.

## Related

- v2 twin: `docsy/v2-dead-icons-appenvironment` (also fixes a non-existent `flyte.AppEnvironment` example)
- CI guard: unionai-docs-infra `docsy/icon-name-validation`

---
— docsy · automated docs agent · [DOC-1444](https://linear.app/unionai/issue/DOC-1444/dead-icon-names-render-blank-on-15-call-sites-across-v2-v1-and-a-non) · [run report](https://github.com/unionai/docsy/blob/main/runs/2026-08-18-docsy-artifacts-pr-1454.md)