### PR TITLE
docsy(v2): Ray images must ship wget; document head node resource floor

### DIFF
--- a/content/integrations/ray/_index.md
+++ b/content/integrations/ray/_index.md
@@ -32,7 +32,7 @@ image = (
 ```
 
 > [!WARNING] Your image must include `wget`
-> KubeRay's readiness and liveness probes for the head pod shell out to `wget`
+> KubeRay's readiness and liveness probes for the head and worker pods shell out to `wget`
 > to poll the raylet and GCS health endpoints. If the image has no `wget`, both
 > probes fail permanently with `wget: command not found`, the head pod never
 > reports `Ready`, the workers stay parked in their `wait-gcs-ready` init
@@ -104,11 +104,12 @@ ray_env = flyte.TaskEnvironment(
 | `pod_template` | `PodTemplate` | Full pod template (mutually exclusive with `requests`/`limits`) |
 
 The head node runs the Ray dashboard, which starts nine subprocess modules on
-top of GCS and the raylet. Give it at least 2 CPU and 4Gi of memory:
+top of GCS and the raylet. Give it 2 CPU and 4Gi of memory:
 
 ```python
-head_node_config=HeadNodeConfig(
-    requests=flyte.Resources(cpu=2, memory="4Gi"),
+ray_config = RayJobConfig(
+    head_node_config=HeadNodeConfig(requests=flyte.Resources(cpu=2, memory="4Gi")),
+    worker_node_config=[WorkerNodeConfig(group_name="ray-group", replicas=2)],
 )
 ```
 

--- a/content/integrations/ray/_index.md
+++ b/content/integrations/ray/_index.md
@@ -36,9 +36,8 @@ image = (
 > to poll the raylet and GCS health endpoints. If the image has no `wget`, both
 > probes fail permanently with `wget: command not found`, the head pod never
 > reports `Ready`, the workers stay parked in their `wait-gcs-ready` init
-> container, and the job is never submitted. The run sits in `Queued` with no
-> error message. Install it with `.with_apt_packages("wget")`, or use a base
-> image that already ships it.
+> container, and the job is never submitted. Install it with
+> `.with_apt_packages("wget")`, or use a base image that already ships it.
 
 {{< variant union >}}
 {{< markdown >}}

--- a/content/integrations/ray/_index.md
+++ b/content/integrations/ray/_index.md
@@ -26,9 +26,19 @@ Your task image must also include a compatible version of Ray:
 ```python
 image = (
     flyte.Image.from_debian_base(name="ray")
+    .with_apt_packages("wget")
     .with_pip_packages("ray[default]==2.46.0", "flyteplugins-ray")
 )
 ```
+
+> [!WARNING] Your image must include `wget`
+> KubeRay's readiness and liveness probes for the head pod shell out to `wget`
+> to poll the raylet and GCS health endpoints. If the image has no `wget`, both
+> probes fail permanently with `wget: command not found`, the head pod never
+> reports `Ready`, the workers stay parked in their `wait-gcs-ready` init
+> container, and the job is never submitted. The run sits in `Queued` with no
+> error message. Install it with `.with_apt_packages("wget")`, or use a base
+> image that already ships it.
 
 {{< variant union >}}
 {{< markdown >}}
@@ -93,6 +103,18 @@ ray_env = flyte.TaskEnvironment(
 | `requests` | `Resources` | Resource requests for the head node |
 | `limits` | `Resources` | Resource limits for the head node |
 | `pod_template` | `PodTemplate` | Full pod template (mutually exclusive with `requests`/`limits`) |
+
+The head node runs the Ray dashboard, which starts nine subprocess modules on
+top of GCS and the raylet. Give it at least 2 CPU and 4Gi of memory:
+
+```python
+head_node_config=HeadNodeConfig(
+    requests=flyte.Resources(cpu=2, memory="4Gi"),
+)
+```
+
+With less (1 CPU / 1000Mi, for example), `ray start --head` exits 1 and KubeRay
+recycles the head pod in a loop, so the cluster never becomes ready.
 
 ### Connecting to an existing cluster
 

--- a/content/integrations/ray/_index.md
+++ b/content/integrations/ray/_index.md
@@ -112,8 +112,10 @@ head_node_config=HeadNodeConfig(
 )
 ```
 
-With less (1 CPU / 1000Mi, for example), `ray start --head` exits 1 and KubeRay
-recycles the head pod in a loop, so the cluster never becomes ready.
+Under-provisioning the head node is a common cause of a cluster that never becomes
+ready: if the dashboard cannot start, `ray start --head` fails and KubeRay recycles
+the head pod in a loop. A head pod at 1 CPU and 1000Mi has been observed failing
+this way.
 
 ### Connecting to an existing cluster
 


### PR DESCRIPTION
## Why

KubeRay's head-pod **readiness and liveness probes are hardcoded to shell out to `wget`**:

```
bash -c "wget --tries 1 -T 2 -q -O- http://localhost:52365/api/local_raylet_healthz | grep success && \
         wget --tries 1 -T 10 -q -O- http://localhost:8265/api/gcs_healthz | grep success"
```

The `ImageSpec` example on the Ray page builds from `flyte.Image.from_debian_base()`, which does not ship `wget`. Every Ray task built from it fails both probes permanently:

```
Warning  Unhealthy  pod/<run>-a0-0-head  Readiness probe failed: bash: line 1: wget: command not found
```

The head pod never reports `Ready`, so the RayCluster never reaches `RayClusterProvisioned`, workers park forever in their `wait-gcs-ready` init container, the RayJob is never submitted, and the console shows only "cluster is creating". **The user sees a run stuck in `Queued` with no error.**

Confirmed live on `demo.hosted.unionai.cloud`: run `ucjtq7mtstjh6vpcbj74` (project `chrismatteson`, domain `development`) plus two more RayClusters in that namespace, all stuck the same way on the same image. The working cluster in `flytesnacks-development` uses `ghcr.io/flyteorg/ray`, which does ship `/usr/bin/wget`.

## What changed

`content/integrations/ray/_index.md`:

1. Added `.with_apt_packages("wget")` to the example image.
2. Added a warning callout under the image example describing the failure mode, so anyone hitting the stuck-in-`Queued` symptom can find it by searching.
3. Added a head node resource floor (2 CPU / 4Gi) under the `HeadNodeConfig` parameter table. The head runs the Ray dashboard, which starts nine subprocess modules; at 1 CPU / 1000Mi `ray start --head` exits 1 and KubeRay recycles the head pod in a loop.

## Follow-up (not in this PR)

The linked examples in `unionai/unionai-examples` (`v2/integrations/flyte-plugins/ray/*.py`) likely build images without `wget` too. That needs a separate PR in that repo.

## Checks

- `npx markdownlint-cli2` — 0 issues
- `npx cspell` — 0 issues

https://claude.ai/code/session_01VSxwVebGsX8Y3GaXyVD6mh