### PR TITLE
docsy(v2): document the two narrative gaps left by four API regens

### DIFF
--- a/content/user-guide/apps/serve-and-deploy-apps/prefetching-models.md
+++ b/content/user-guide/apps/serve-and-deploy-apps/prefetching-models.md
@@ -61,6 +61,8 @@ If the model requires authentication:
 The default value for `hf_token_key` is `HF_TOKEN`, where `HF_TOKEN` is the name of the Flyte secret containing your
 HuggingFace token. If this secret doesn't exist, you can create a secret using the [flyte create secret CLI](../../tasks/task-configuration/secrets).
 
+Public models need no token at all. Pass `hf_token_key=None` to prefetch anonymously, and no secret is attached to the prefetch task.
+
 ### With resources
 
 By default, the prefetch task uses minimal resources (2 CPUs, 8GB of memory, 50Gi of disk storage), using

--- a/content/user-guide/get-started/run-modes/running-devbox.md
+++ b/content/user-guide/get-started/run-modes/running-devbox.md
@@ -84,6 +84,28 @@ This pulls the necessary containers and starts a local Flyte instance. Once read
 The first start may take a few minutes while Docker images are downloaded.
 {{< /note >}}
 
+## Check the devbox status
+
+To see whether the devbox is up, and where it is:
+
+```bash
+flyte get devbox
+```
+
+This reports the run state, the UI and image registry endpoints, the container image version in use, and where the cluster keeps its state on disk. It is the quickest way to tell a devbox that is still starting from one that is ready.
+
+Add `--no-probes` to skip the readiness probe and the container resource sample, which makes the check faster and works offline:
+
+```bash
+flyte get devbox --no-probes
+```
+
+For a machine-readable report, pass an output format to the top-level command:
+
+```bash
+flyte -of json-raw get devbox
+```
+
 ## Configure
 
 Create a config file that points to the devbox:

--- a/content/user-guide/get-started/run-modes/running-devbox.md
+++ b/content/user-guide/get-started/run-modes/running-devbox.md
@@ -86,6 +86,9 @@ The first start may take a few minutes while Docker images are downloaded.
 
 ## Check the devbox status
 
+> [!NOTE]
+> `flyte get devbox` requires flyte 2.6.2 or later.
+
 To see whether the devbox is up, and where it is:
 
 ```bash

--- a/content/user-guide/tasks/task-programming/reports.md
+++ b/content/user-guide/tasks/task-programming/reports.md
@@ -187,3 +187,40 @@ if __name__ == "__main__":
 > The report contains only what you explicitly `log()` or `replace()`. Returning a value whose type has a renderer attached does **not** by itself add it to the report — render the value and log the HTML, as shown above.
 
 Flyte's SDK also implements a few renderers of this kind internally — for pandas and PyArrow DataFrames and for Markdown strings. These aren't exposed as public API (only the `flyte.types.Renderable` protocol is), so treat them as examples of the same pattern rather than importable helpers.
+
+## Fetching a report after the run
+
+Everything above is about *writing* a report from inside a task. To *read* a finished report from outside the run, for example to embed it in a notebook or attach it to a CI job, fetch it through the remote API:
+
+```python
+import flyte
+from flyte.remote import Run
+
+flyte.init_from_config()
+
+run = Run.get("my-run-name")
+html = run.get_report()
+```
+
+`get_report()` returns the report as an HTML string. It requests a signed download link for the report artifact and downloads the contents, so the call needs an initialized client.
+
+By default it returns the report for the latest attempt. Pass `attempt` to fetch an earlier one:
+
+```python
+html = run.get_report(attempt=1)
+```
+
+`Run.get_report()` returns the report of the run's **root action**. A run whose tasks call other tasks has a report per action, so to fetch the report for a nested action, use `flyte.remote.Action.get_report()` on that action instead:
+
+```python
+from flyte.remote import Action
+
+action = Action.get(run_name="my-run-name", name="my-subtask")
+html = action.get_report()
+```
+
+Both are synchronous by default. From async code, call the `.aio` variant:
+
+```python
+html = await run.get_report.aio()
+```

--- a/content/user-guide/tasks/task-programming/reports.md
+++ b/content/user-guide/tasks/task-programming/reports.md
@@ -215,8 +215,14 @@ html = run.get_report(attempt=1)
 ```python
 from flyte.remote import Action
 
-action = Action.get(run_name="my-run-name", name="my-subtask")
+action = Action.get(run_name="my-run-name", name="6n505tdw46zu7fpmgtui1r1uw")
 html = action.get_report()
+```
+
+Nested actions are named deterministically from the parent action, the task identity, the inputs and the call sequence, so the name is a generated string rather than the task's function name. List the actions in a run to find the one you want:
+
+```bash
+flyte get action my-run-name
 ```
 
 Both are synchronous by default. From async code, call the `.aio` variant:


### PR DESCRIPTION
## Summary

Closes the narrative half of the accumulated `docsy:api-surface-delta` backlog: **docs#1262, #1373, #1424** (DOC-1362) and **#1457** (DOC-1447).

**Four regens, two gaps in this PR.** Enumerating them was most of the work, because version churn buries the signal — #1457 alone is 309 files, of which **307 of the 366 added lines are `version:` frontmatter bumps**. Strip those and little remains; most of what does was already covered.

> [!IMPORTANT] Scope corrected after review
> The original framing of this PR ("four regens, two gaps") was too confident on two counts, both found by an independent review of this branch and both now recorded below rather than left implicit.
>
> 1. **A third gap existed:** tracked local runs (`--tracked` / `--tracked-strict` / `--local-tracked`, regen #1424) had no narrative coverage anywhere. It is now drafted in [#1462](https://github.com/unionai/unionai-docs/pull/1462), held under the publish gate because the feature is unreleased.
> 2. **The backlog is five regens, not four.** #1442 is in the `docsy:api-surface-delta` label set and was excluded here without explanation. See "The fifth regen" below.
>
> Three defects in this PR's own content were also found and are fixed in the latest commit.


## Gap 1 — `flyte get devbox` (new in 2.6.2)

Verified **new**, not reworded: present at released tag **v2.6.2** (`cli/_get.py:864-895`), **zero occurrences at v2.6.1**.

`running-devbox.md` taught `start`, `stop` and `delete` but gave no way to answer *"did it come up?"* — which is the reader's question at exactly that point in the page. Added as its own section between starting and configuring, covering `--no-probes` and `flyte -of json-raw get devbox`.

## Gap 2 — fetching a report after the run

`reports.md` covered *writing* a report from inside a task and said nothing about *reading* one afterwards. That is a different reader task (pull a finished report into a notebook or a CI job) and it was uncovered.

Documents `Run.get_report()`, the `attempt` argument, and the `.aio` variant. It also covers the distinction most likely to bite: **`Run.get_report()` returns the *root action's* report**, so a run whose tasks call other tasks needs `Action.get_report()` for a nested one. The SDK's own docstring was amended to redirect readers there, and that redirect is what flagged this delta as material in the first place.

**Signatures verified against v2.6.2, not inferred:** `Run.get(name)`, `Action.get(run_name=, name=)`, `Run.get_report(attempt=)` with a real `.aio` attribute.

## What was already covered — recorded so it is not redone

| Delta | Status |
|---|---|
| **Artifacts** (#1373/#1424 headline, 7 new reference pages) | Shipped yesterday as the user-guide artifacts section, [#1454](https://github.com/unionai/unionai-docs/pull/1454) |
| **Default pool/queue deletability** (#1457) | `queues.md` already documents the new semantics, including the `run.default_queue` guard |
| **`TaskTemplate`, `DeployedAppEnvironment`** (#1262) | Already referenced in `how-task-deployment-works.md` and `how-app-deployment-works.md` |
| **`AsyncFunctionTaskTemplate`** (#1262) | **Deliberately not documented.** Its own docstring says it is "automatically created when an asynchronous function is decorated with the task decorator" — users never write it, so zero narrative mentions is correct, not a gap |
| **Run recovery** `--recover` / `--recover-from` / `--force-rerun-action` / `--allow-missing-outputs` (#1373/#1424) | **Uncovered on `main`, but claimed:** in flight as [#1439](https://github.com/unionai/unionai-docs/pull/1439). Omitting it from this table was the record gap, not the work |
| **Tracked local runs** `--tracked` / `--tracked-strict` / `--local-tracked` (#1424) | **Was missed.** Now [#1462](https://github.com/unionai/unionai-docs/pull/1462), held until the feature ships |
| **`hf_token_key: str` → `str \| None`** (#1424) | **Was missed.** `prefetching-models.md` sent readers of public models to create a secret they do not need. Fixed in this PR |
| **Grafana agent instrumentation** `register_instrumentor` etc. (#1373/#1424) | Already covered in `integrations/grafana-agent-observability/` |
| **`flyte.load_plugin_config`, `flyte.load_interactive_ctx`** (#1424) | Advanced extension surface, deliberately skipped. Recording the decision so the next pass does not re-derive it |

## The fifth regen (#1442), and why it is not folded in

`gh pr list --label "docsy:api-surface-delta"` returns **#1262, #1283 (v1), #1373, #1424, #1442, #1457**. #1442 (2.6.0 → 2.6.1, `material`) spun DOC-1442, which covered only `flyte create config --devbox` (shipped as #1453). Its **other** delta was never dispositioned: `flyteplugins.ray.AutoscalerOptionsConfig` (new page) and `RayJobConfig.autoscaler_options` (new parameter).

`integrations/ray/_index.md` documents `enable_autoscaling` but has **no `autoscaler_options` row**, so the knob that configures the feature the page already teaches is undocumented. That is a real gap.

It is **not** folded in here because [#1458](https://github.com/unionai/unionai-docs/pull/1458) is currently editing that same page. Folding it in would collide. It gets its own ticket, sequenced after #1458 merges.

## Fixes applied after review

| Fix | Why |
|---|---|
| `hf_token_key=None` documented on `prefetching-models.md` | The page told every reader to create a secret. Verified at `_hf_model.py:883`: a falsy `hf_token_key` attaches no secret |
| Nested action name in the `Action.get_report()` example | `name="my-subtask"` reads as the task's function name. Nested actions are `base36(md5(...))`, a 25-char generated string, so the example could not resolve. Replaced with a real name, plus `flyte get action <run-name>` to discover it |
| `flyte get devbox` version note | New in 2.6.2 (0 occurrences at v2.6.1, 8 at v2.6.2), while the next section on the page gates `--devbox` at 2.6.1. A 2.6.1 reader hit "no such command" |

One proposed fix was **rejected on verification**: the nested-action example was to become `name="a1"`, on the grounds that `a0, a1, …` is established elsewhere in the docs. It is not. `interacting-with-runs.md` shows only `a0` and hedges it as "usually called `a0`". Only the root action is `a0`, so `a1` would have replaced one wrong example with another.


## Note on reviewing regen PRs

Two things make these easy to under-review, worth knowing:

* The GitHub API's `files` array **caps at 100**, so #1457's UI file count understated it by **3×** (really 309).
* `gh pr diff` **refuses above 300 files** outright, so the diff has to be taken locally from the base and head SHAs. That is the same threshold at which Copilot structurally opts out of regen PRs — **the automated reviewer disappears at exactly the size where a human is least likely to read the diff.**

---
— docsy · automated docs agent · [DOC-1362](https://linear.app/unionai/issue/DOC-1362/narrative-docs-impact-of-the-accumulated-2512-260-api-surface-deltas) · [DOC-1447](https://linear.app/unionai/issue/DOC-1447/narrative-impact-flyte-get-devbox-new-in-262-is-absent-from-the-devbox)

