### PR TITLE
docsy(v2): run the icon-name check in CI, and bump infra to provide it

### DIFF
--- a/.github/workflows/check-icon-names.yml
+++ b/.github/workflows/check-icon-names.yml
@@ -1,0 +1,33 @@
+name: Check Icon Names
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  check-icon-names:
+    name: "Check Icon Names"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: 'true'
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Check icon names
+        run: make check-icon-names
+
+      - name: Report status
+        if: ${{ failure() }}
+        run: |
+          echo "::error::An icon name does not exist in the set its shortcode resolves against. Run 'make check-icon-names' locally for details. Bootstrap Icons: https://icons.getbootstrap.com/ — gemoji: https://api.github.com/emojis"

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ TARGETS := usage help clean clean-generated base dist variant dev serve \
 	update-examples init-examples check-jupyter check-images validate-urls \
 	url-stats llm-docs update-redirects dry-run-redirects deploy-redirects \
 	check-deleted-pages check-links check-generated-content check-api-docs \
+	check-icon-names update-icon-names \
 	check-llm-bundle-notes update-api-docs \
 	check-helm-docs update-helm-docs generate-helm-docs \
 	index-search index-search-settings check-search-labels \


### PR DESCRIPTION
## Summary

Makes the icon-name guard **actually run**, and bumps `unionai-docs-infra` to `2f92666` to provide it.

## Why this exists separately

[infra#263](https://github.com/unionai/unionai-docs-infra/pull/263) added `tools/check_icon_names.py` and the `make check-icon-names` / `make update-icon-names` targets — but **nothing called them**, so the guard was manual-only.

That does not close **DOC-1444**, whose entire point is that six dead icon names accumulated across two version lines *precisely because nothing was watching*. A checker no job runs is the same silence with extra steps. This was a gap in my own PR, caught while sequencing the merges.

## What it adds

`.github/workflows/check-icon-names.yml`, modelled directly on `check-links.yml` — same triggers (`pull_request` + `push` to `main`), same job shape, same `::error::` failure-message convention pointing at the local command.

## Ordering is load-bearing, and this is the earliest safe point

The workflow fails unless **both** conditions hold:

1. the submodule provides the `check-icon-names` target → needed **infra#263** (merged, `2f92666`)
2. the content is clean → needed **[#1455](https://github.com/unionai/unionai-docs/pull/1455)** (merged, `6ef1405`), which fixed the four dead v2 names

Wiring it any earlier would have red-failed `main`. Verified against this branch:

```
check-icon-names: OK (sl-icon: link-card; gemoji: dropdown)
```

The workflow also runs on this PR, so it self-verifies.

## Follow-up in this set

The **v1** line needs the same workflow. It ships with the v1 icon fixes in **[#1456](https://github.com/unionai/unionai-docs/pull/1456)**, deliberately not here — v1's CI has drifted from `main`'s before ([docs#1281](https://github.com/unionai/unionai-docs/pull/1281)), so the workflow needs to land on that branch explicitly rather than being assumed to follow.

---
— docsy · automated docs agent · [DOC-1444](https://linear.app/unionai/issue/DOC-1444/dead-icon-names-render-blank-on-15-call-sites-across-v2-v1-and-a-non)
