### PR TITLE
docsy(v1): run the icon-name check in CI, and bump infra to provide it

### DIFF
--- a/.github/workflows/check-icon-names.yml
+++ b/.github/workflows/check-icon-names.yml
@@ -1,0 +1,33 @@
+name: Check Icon Names
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  check-icon-names:
+    name: "Check Icon Names"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: 'true'
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Check icon names
+        run: make check-icon-names
+
+      - name: Report status
+        if: ${{ failure() }}
+        run: |
+          echo "::error::An icon name does not exist in the set its shortcode resolves against. Run 'make check-icon-names' locally for details. Bootstrap Icons: https://icons.getbootstrap.com/ — gemoji: https://api.github.com/emojis"

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ TARGETS := usage help clean clean-generated base dist variant dev serve \
 	update-examples init-examples check-jupyter check-images validate-urls \
 	url-stats llm-docs update-redirects dry-run-redirects deploy-redirects \
 	check-deleted-pages check-links check-generated-content check-api-docs \
+	check-icon-names update-icon-names \
 	check-llm-bundle-notes update-api-docs check-helm-docs update-helm-docs \
 	index-search index-search-settings check-search-labels
 


### PR DESCRIPTION
## Summary

The **v1 twin** of [#1460](https://github.com/unionai/unionai-docs/pull/1460). Adds `check-icon-names.yml` and bumps the `unionai-docs-infra` submodule from `46ed575` to `2f92666` so `make check-icon-names` exists on this line.

## ⚠️ Merge AFTER [#1456](https://github.com/unionai/unionai-docs/pull/1456)

**The workflow fails on `v1` as it stands today.** Verified — it reports exactly the six sites #1456 fixes:

```
FATAL: these icon names do not exist in the set their shortcode resolves against.
  content/api-reference/_index.md:25   icon="workflow"
  content/api-reference/_index.md:29   icon="workflow"
  content/api-reference/_index.md:57   icon="workflow"
  content/community/contributing-docs/shortcodes.md:48   icon="workflow"
  content/deployment/selfmanaged/byok-data-plane-setup-on-aws/_index.md:23   icon="zap"
  content/deployment/terraform/_index.md:45   icon="settings"
```

Run against **#1456's** content, the same checker reports:

```
check-icon-names: OK (sl-icon: link-card; gemoji: dropdown)
```

So merging this before #1456 would red-fail the `v1` branch. It is also a live demonstration that the guard does what it claims.

## Why this is a separate PR rather than assumed to follow main

`v1`'s CI has drifted from `main`'s before. `v1` was missing `main`'s fork-PR split ([#1111](https://github.com/unionai/unionai-docs/pull/1111)), which red-failed the version-cut PRs until [docs#1281](https://github.com/unionai/unionai-docs/pull/1281) repaired it. **A check that exists on `main` is not a check that runs here** — it has to land on this branch explicitly.

Same reason #1456 keeps its content fixes separate from this bump: it mirrors the `main`-line split of [#1455](https://github.com/unionai/unionai-docs/pull/1455) (content) and #1460 (bump + workflow).

---
— docsy · automated docs agent · [DOC-1444](https://linear.app/unionai/issue/DOC-1444/dead-icon-names-render-blank-on-15-call-sites-across-v2-v1-and-a-non)
