### PR TITLE
docsy(v2): document tracked local runs (--tracked / --tracked-strict)

### DIFF
--- a/content/user-guide/get-started/run-modes/_index.md
+++ b/content/user-guide/get-started/run-modes/_index.md
@@ -48,7 +48,7 @@ The same task code runs unchanged across all three modes. Start with local execu
 |--------|-------------------|--------|--------|
 | **⚡️ Execution** | In-process Python | Containerized, local Docker | Containerized, cloud |
 | **🐳 Docker required** | No | Yes | No (remote build) |
-| **💻 Flyte UI** | No (TUI only) | Yes (`localhost:30080`) | Yes |
+| **💻 Flyte UI** | TUI, or the console with `--tracked` | Yes (`localhost:30080`) | Yes |
 | **📦 Container images** | Ignored | Built locally | Built locally or remotely |
 | **🔀 Parallelism** | Sequential | Cluster-level | Cluster-level |
 | **⭐️ Best for** | Fast iteration, debugging | Testing container builds, full Flyte features | Production, GPUs, scale |

--- a/content/user-guide/get-started/run-modes/running-locally.md
+++ b/content/user-guide/get-started/run-modes/running-locally.md
@@ -115,6 +115,26 @@ persists the inputs and outputs of every task run locally, so you can always go 
 flyte start tui
 ```
 
+{{< variant union >}}
+{{< markdown >}}
+
+## Track local runs in the console
+
+A local run normally leaves no trace on the control plane. Add `--tracked` and the run still executes on your machine, but its progress is reported to {{< key product_name >}} so you can watch it in the console next to your remote runs:
+
+```bash
+flyte run --tracked hello.py main
+```
+
+The command prints a console link when the run starts. Tracking covers the run's actions and attempts, their phases, and their inputs, outputs, reports and cache status. Logs are not reported, so `print()` output stays in your terminal.
+
+Reporting never gets in the way of the run itself: if the control plane is unreachable, the failure is logged and your local run finishes normally.
+
+Use `flyte create config --local-tracked` to track every local run without passing the flag. For the full option reference, including strict reporting and run-name rules, see [Run command options](../../tasks/task-deployment/run-command-options).
+
+{{< /markdown >}}
+{{< /variant >}}
+
 ---
 
 ## What works locally
@@ -129,6 +149,16 @@ Most Flyte features work in both local and remote execution. The table below sum
 | **Serving** | Run apps locally with `python serve.py` or `flyte.with_servecontext(mode="local")`. | [Serve and deploy apps](../../apps/serve-and-deploy-apps/_index) |
 | **Plugins** | Same decorators and APIs as remote. Secrets come from environment variables. | [Integrations](../../../api-reference/integrations/_index) |
 | **Secrets** | Read from `.env` files or environment variables. No `flyte create secret` needed. | [Secrets](../../tasks/task-configuration/secrets) |
+
+{{< variant union >}}
+{{< markdown >}}
+
+> [!NOTE] Visibility is the exception
+> With `--tracked`, a local run also reports its state to the control plane and appears in the console.
+> See [Track local runs in the console](#track-local-runs-in-the-console).
+
+{{< /markdown >}}
+{{< /variant >}}
 
 ---
 

--- a/content/user-guide/tasks/task-deployment/run-command-options.md
+++ b/content/user-guide/tasks/task-deployment/run-command-options.md
@@ -118,7 +118,7 @@ flyte run --tracked --tracked-strict my_example.py my_task
 
 ### Naming a tracked run
 
-Tracked runs are named `local-<id>` unless you pass `--name`. A name you supply must be at most 30 characters and must not begin with `u` or `r`, both of which are reserved for runs the platform names itself. A name that breaks either rule fails before the run starts.
+Tracked runs are named `local-<id>` unless you pass `--name`. Tracking adds two rules on top of the usual `--name` behavior: the name must be at most 30 characters, and it must not begin with `u` or `r`, both of which are reserved for runs the platform names itself. A name that breaks either rule fails before the run starts.
 
 ### Tracking every local run
 

--- a/content/user-guide/tasks/task-deployment/run-command-options.md
+++ b/content/user-guide/tasks/task-deployment/run-command-options.md
@@ -27,6 +27,19 @@ The `flyte run` command provides the following options:
 | `--run-project`             |       | text   | *from config*             | Execute deployed task in this project (`deployed-task` only). |
 | `--run-domain`              |       | text   | *from config*             | Execute deployed task in this domain (`deployed-task` only).  |
 
+{{< variant union >}}
+{{< markdown >}}
+
+These additional options are available on {{< key product_name >}}:
+
+| Option             | Short | Type | Default | Description                                                              |
+|--------------------|-------|------|---------|--------------------------------------------------------------------------|
+| `--tracked`        |       | flag | `false` | Run the task locally while reporting run state to the control plane.     |
+| `--tracked-strict` |       | flag | `false` | Fail the run if reporting fails. Requires `--tracked`.                   |
+
+{{< /markdown >}}
+{{< /variant >}}
+
 ## `--project`, `--domain`
 
 **`flyte run --domain <DOMAIN> --project <PROJECT> <PATH>|deployed-task <TASK_NAME>`**
@@ -77,6 +90,48 @@ flyte run my_example.py my_task --input "test_data"
 - **Debugging**: Full access to local debugging tools and environment
 - **Resource constraints**: When remote resources are unavailable or expensive
 - **Data locality**: When working with large local datasets
+
+{{< variant union >}}
+{{< markdown >}}
+
+## `--tracked`, `--tracked-strict`
+
+**`flyte run --tracked <PATH> <TASK_NAME>`**
+
+The `--tracked` option runs the task on your machine, exactly as `--local` does, while reporting the run's progress to the control plane so that it appears in the {{< key product_name >}} console alongside your remote runs. It implies `--local`, so you do not need to pass both:
+
+```bash
+flyte run --tracked my_example.py my_task --input "test_data"
+```
+
+Because the run is reported to the control plane, `--tracked` needs an endpoint, project and domain in your configuration, and it cannot be combined with a remote run.
+
+Tracking reports the run's actions and attempts, their phases, and their inputs, outputs, reports and cache status. Logs are not reported: your task's output stays in the terminal where you launched the run.
+
+Reporting is best-effort by design. If the control plane is slow or unreachable, the failure is logged and the local run continues to completion, so tracking never blocks or fails work that would otherwise have succeeded. To debug reporting itself, add `--tracked-strict`, which turns any reporting failure into a loud run failure:
+
+```bash
+flyte run --tracked --tracked-strict my_example.py my_task
+```
+
+`--tracked-strict` is only meaningful together with `--tracked`; enabling it on its own raises an error.
+
+### Naming a tracked run
+
+Tracked runs are named `local-<id>` unless you pass `--name`. A name you supply must be at most 30 characters and must not begin with `u` or `r`, both of which are reserved for runs the platform names itself. A name that breaks either rule fails before the run starts.
+
+### Tracking every local run
+
+To track local runs without passing the flag each time, write the setting into your config file:
+
+```bash
+flyte create config --local-tracked
+```
+
+This sets the `local.tracked` key, after which `flyte run --local` reports to the control plane on its own. The matching key for strict mode is `local.tracked_strict`.
+
+{{< /markdown >}}
+{{< /variant >}}
 
 ## `--copy-style`
 


### PR DESCRIPTION
## DO NOT MERGE until tracked runs is released

Peeter confirmed on 2026-08-19 that tracked runs is not released yet. This PR is drafted under the publish gate: the docs are ready, the merge waits for the feature to ship. [DOC-1343](https://linear.app/unionai/issue/DOC-1343) stays in `Tracking` until then.

## The gap

Regen #1424 published `--tracked`, `--tracked-strict` and `flyte create config --local-tracked` in the generated CLI reference, but no narrative page mentions any of them. `grep -rIn "tracked" content/user-guide` returns nothing on `main`. Two pages are actively misleading as a result:

- `run-command-options.md` opens with "The `flyte run` command provides the following options:" and an exhaustive table that lists `--local` but not `--tracked`.
- `running-locally.md` and the run-modes comparison table describe local runs as leaving no trace on the control plane, which is exactly what `--tracked` changes.

Surfaced by the review of #1459, which claimed the four API regens left two narrative gaps. This was a third.

## What I verified, and where

All against fetched `origin/main`, not a local checkout and not memory.

| Claim | Source |
|---|---|
| `--tracked` implies `--local`; needs endpoint, project, domain | `flyte-sdk@5b8c0380:src/flyte/cli/_run.py:194-206` |
| `--tracked-strict` only valid with `--tracked`; raises otherwise | `_run.py:207-217`, `src/flyte/_run.py:1058-1064` |
| Reports actions, attempts, phases, inputs, outputs, reports, cache status | `src/flyte/_persistence/_remote_reporter.py` `record_*`, `_upload_terminal_artifacts` |
| Logs are not reported | no log-link path anywhere in `_remote_reporter.py` |
| Best-effort: never fails or blocks the local run | `_remote_reporter.py` module docstring; bounded retries + bounded terminal flush |
| Auto-name `local-<8 hex>`; user names <=30 chars, no leading `u`/`r` | `generate_tracked_run_name`, `validate_tracked_run_name` (`_remote_reporter.py:96-122`) |
| `local.tracked` / `local.tracked_strict` config keys | `src/flyte/config/_internal.py:72-73`; `cli/_create.py:573-576` |
| Console link printed at start | `src/flyte/_run.py:1191`; `remote/_client/controlplane.py:131` |

## Design calls made, and why

**Tracking is documented as a modifier on local execution, not a fourth run mode.** `--tracked` implies `--local` and the task still runs in the local Python process, so a peer page next to Local/Devbox/Remote would misrepresent it. It lands as a section in `running-locally.md` plus an option section in `run-command-options.md`.

This is the taxonomy problem [DOC-1343](https://linear.app/unionai/issue/DOC-1343) predicted: a run that executes on your laptop but registers with the control plane is locally executed *and* remotely visible, a combination the current Local/Devbox/Remote vocabulary cannot express. **[DOC-1326](https://linear.app/unionai/issue/DOC-1326) should ratify this framing before it is encoded in `style-spec.md`.**

**Gated to the `union` variant.** `flyteorg/flyte@5cbd1710a` carries only the `flyteidl2` protos and generated stubs for `TrackedRunService` and has no server implementation; it is implemented in `unionai/cloud`. Verified no leakage: the built `flyte` variant contains zero occurrences of "tracked" across all three pages, the `union` variant has them.

**No rows added to the shared options table.** #1439 established the precedent of documenting Union-only run options in a gated section rather than duplicating the table, and adding union-only rows to a shared table would be a variant-safety bug. If #1439 merges first, its `--recover-from` family and these two should be folded into one gated addendum table.

## Open question for eng

**Self-managed enablement is undocumented and may not work.** The dataproxy gate `trackedRuns.enabled` is *"Dark by default"* (`cloud:dataproxy/config/config.go:137-140`). It is on for production, canary and staging, and off for production-serverless. But the generated tenant Helm baseline ships `trackedRuns.enabled: false` (`dataproxy/deploy/helm_generated.yaml:198`) and the tenant chart exposes only rate-limiting, no enablement value. So a Self-managed operator appears to have no supported way to turn this on. If that is right, this page needs a Self-managed prerequisite section, and the Self-managed deployment docs need the Helm value. **Not blocking the draft; blocking an accurate answer for Self-managed readers.**

## Checks

Full `make dist` green (both variants), `make check-links` green, `make check-icon-names` green, markdownlint clean on the changed files (the one hit is pre-existing in `running-remote.md`, untouched here). Rendered HTML inspected: correct `<h2>` with matching anchor, gated blocks render as top-level siblings rather than nesting inside the preceding element, and the post-table aside renders as a proper `sl-alert`.

## Also found

[DOC-1439](https://linear.app/unionai/issue/DOC-1439) "Missing documentation for tracked runs feature" (Triage, unlabelled) duplicates [DOC-1343](https://linear.app/unionai/issue/DOC-1343). Recommend closing it as Duplicate. Your call, not mine.

---
— docsy · automated docs agent · [DOC-1343](https://linear.app/unionai/issue/DOC-1343)
