### PR TITLE
docsy(v1): bump infra — promote preserves versions.toml comments

### DIFF
--- a/versions.toml
+++ b/versions.toml
@@ -7,8 +7,6 @@
 #              primary line does; a secondary line (v1) sets false.
 # indexed    = whether this line's stable tree is search-indexed. Defaults true
 #              (the stable tree is normally the line's one canonical surface).
-# NOTE: comments below are NOT preserved across a promote (tomllib cannot
-#       round-trip them). Re-add any explanation the line depends on.
 stable = "v1.16.26.4"
 enumerated = [
   "v1.16.26.3",


### PR DESCRIPTION
Picks up [infra#268](https://github.com/unionai/unionai-docs-infra/pull/268) — [DOC-1457](https://linear.app/unionai/issue/DOC-1457). **This is the line the fix exists for.**

`promote_versions_toml` now edits `versions.toml` **in place** with `tomlkit`, so comments survive a cut. v1's file carries **29 comment lines**, two of them load-bearing: why `v1.16.26.2` stays un-enumerated, and the DOC-1291 record that the line's noindex state was previously correct **only by accident** and that **v1 is ACTIVE, not frozen**. A reader of the stripped file infers the opposite.

## Also drops the now-false NOTE

```diff
-# NOTE: comments below are NOT preserved across a promote (tomllib cannot
-#       round-trip them). Re-add any explanation the line depends on.
```

#264 added that truthfully; #268 made it false. Leaving it would tell the next reader to re-add explanation by hand after every cut, which is now wrong.

Verified the cleaned file round-trips through the new promote:

```
promote: stable=v1.16.28.0 (was v1.16.26.4; 2 older pin(s); comments preserved)
comments: 27 -> 27
NOT preserved note present: False
keys: {'stable': 'v1.16.28.0', 'enumerated': ['v1.16.26.3', 'v1.16.26.4'],
       'latest': False, 'indexed': False}
```

## Why this needed to land before the next cut

The v1 regen to flytekit 1.16.28 is an **`sdk-release`** cut, so `regen-api-docs.yml` folds `--promote` into the regen PR itself. Without #268 those 29 comment lines would have been deleted inside a ~294-file diff, where no reviewer would have seen them go. They were already restored by hand once, after this afternoon's `v1.16.26.4` cut.

---
— docsy · automated docs agent · [DOC-1457](https://linear.app/unionai/issue/DOC-1457)