### PR TITLE
docsy(v1): fail the regen fold loudly instead of reporting a false verdict

### DIFF
--- a/.github/workflows/regen-api-docs.yml
+++ b/.github/workflows/regen-api-docs.yml
@@ -112,8 +112,30 @@ jobs:
         if: steps.drift.outputs.drift == 'true' && hashFiles('versions.toml') != ''
         run: |
           set -euo pipefail
-          eval "$(REPO_ROOT=$PWD uv run --quiet unionai-docs-infra/tools/api_generator/manifest.py --check --format shell)"
-          if [ "${DOCS_CUT_KIND:-}" = "sdk-release" ] && [ "${DOCS_SDK_ON_PYPI:-}" = "true" ]; then
+          # Capture BEFORE eval. `eval "$(cmd)"` discards cmd's exit status: a crash
+          # yields empty output and `eval ""` succeeds, so the step passes and the
+          # condition below simply reads false. `set -e` cannot see it, and the `:-`
+          # defaults defeat `set -u` (docs-cut.yml uses bare ${DOCS_TAG} and so fails
+          # loudly by accident; this step defended itself into silence).
+          #
+          # 2026-08-19: manifest.py gained an `import tomlkit` whose dependency was
+          # declared only in pyproject.toml, not its PEP 723 block, so under `uv run`
+          # it died on import. This step reported "Not an SDK-release cut" -- which was
+          # false -- and the v1 regen to flytekit 1.16.28 opened with no versions.toml
+          # promote. The cut silently did not happen. (infra#269, DOC-1457)
+          if ! plan="$(REPO_ROOT=$PWD uv run --quiet unionai-docs-infra/tools/api_generator/manifest.py --check --format shell)"; then
+            echo "::error::manifest.py --check failed. Cannot determine whether this regen is an SDK-release cut; refusing to guess."
+            exit 1
+          fi
+          eval "$plan"
+          # A crash is not the only way to learn nothing: the script could succeed and
+          # print nothing. "Not an SDK-release cut" must mean we ASKED and the answer
+          # was no -- never that we failed to ask.
+          if [ -z "${DOCS_CUT_KIND:-}" ]; then
+            echo "::error::manifest.py --check produced no DOCS_CUT_KIND. Raw output: ${plan:-<empty>}"
+            exit 1
+          fi
+          if [ "${DOCS_CUT_KIND}" = "sdk-release" ] && [ "${DOCS_SDK_ON_PYPI:-}" = "true" ]; then
             REPO_ROOT=$PWD uv run --quiet unionai-docs-infra/tools/api_generator/manifest.py --promote
             REPO_ROOT=$PWD uv run --quiet unionai-docs-infra/tools/api_generator/manifest.py --write --variant both --out data/version-manifest.json
             echo "Folded ${DOCS_TAG} into this regen PR: versions.toml stable=${DOCS_TAG} + data/version-manifest.json (inline cut tag)."


### PR DESCRIPTION
`eval "\$(manifest.py --check ...)"` **discards the command's exit status.** A crash yields empty output, `eval ""` succeeds, the step passes, and the sdk-release condition below simply reads false.

`set -e` cannot see it — the failing command is inside a substitution. And the `\${VAR:-}` defaults defeat `set -u`. Note `docs-cut.yml` uses bare `\${DOCS_TAG}` and therefore **fails loudly by accident**; this step defended itself into silence.

## What it cost, today

`manifest.py` gained an `import tomlkit` whose dependency was declared only in `pyproject.toml`, not its PEP 723 block, so under `uv run` it died on import. This step reported:

```
Not an SDK-release cut (kind=none, on_pypi=?) → no promotion.
```

That was **false**. The v1 regen to flytekit 1.16.28 opened with the full 294-file refresh and **no `versions.toml` promote** — the cut silently did not happen, and nothing was red. Fixed at source in [infra#269](https://github.com/unionai/unionai-docs-infra/pull/269); this fixes the mechanism that hid it.

## The change

1. **Capture before eval**, fail on non-zero status.
2. **Fail again if the output carried no `DOCS_CUT_KIND`** — a successful-but-silent run is the other way to learn nothing.

A genuine manual z-bump regen still skips the fold without erroring. *"Not an SDK-release cut" must mean we asked and the answer was no, never that we failed to ask.*

## Verified by simulation

```
=== OLD (the bug) ===
Not an SDK-release cut (kind=none)
  exit=0
=== NEW (fixed) ===
::error::manifest.py --check failed. Refusing to guess.
  exit=1
=== NEW, command succeeds but prints nothing ===
::error::manifest.py --check produced no DOCS_CUT_KIND
  exit=1
```

---
— docsy · automated docs agent · [DOC-1457](https://linear.app/unionai/issue/DOC-1457)