### PR TITLE
docsy(v1): strip inert RST from two hand-authored pages

### DIFF
--- a/content/architecture/workflow-state-transitions.md
+++ b/content/architecture/workflow-state-transitions.md
@@ -58,9 +58,9 @@ flowchart TD
 ```
 
 A workflow always starts in the `Ready` state and ends either in `Failed`, `Succeeded`, or `Aborted` state.
-Any system error within a state causes a retry on that state. These retries are capped by `system retries <system-retry>` which eventually lead to an `Aborted` state if the failure persists.
+Any system error within a state causes a retry on that state. These retries are capped by system retries which eventually lead to an `Aborted` state if the failure persists.
 
-Every transition between states is recorded in FlyteAdmin using :std:ref:`workflowexecutionevent`.
+Every transition between states is recorded in FlyteAdmin using `workflowexecutionevent`.
 
 The phases in the above state diagram are captured in the admin database as specified here `workflowexecution.phase` and are sent as a part of the Execution event.
 
@@ -103,9 +103,9 @@ The `start node` begins by executing all its child-nodes using a modified depth 
 Nodes can be of different types as listed below, but all the nodes traverse through the same transitions:
 
 1. Start Node - Only exists during the execution and is not modeled in the core spec.
-2. :std:ref:`Task Node`
-3. :std:ref:`Branch Node`
-4. :std:ref:`Workflow Node`
+2. Task Node
+3. Branch Node
+4. Workflow Node
 5. Dynamic Node - Just a task node that does not return output but constitutes a dynamic workflow.
    When the task runs, it remains in the `RUNNING` state. Once the task completes and Flyte starts executing the dynamic workflow,
    the overarching node that contains both the original task and the dynamic workflow enters `DYNAMIC_RUNNING` state.
@@ -113,7 +113,7 @@ Nodes can be of different types as listed below, but all the nodes traverse thro
 
 Every transition between states is recorded in FlyteAdmin using `nodeexecutionevent`.
 
-Every `NodeExecutionEvent` can have any :std:ref:`nodeexecution.phase`.
+Every `NodeExecutionEvent` can have any `nodeexecution.phase`.
 
 The state machine specification for the illustration can be found [here](https://mermaid-js.github.io/mermaid-live-editor/#/edit/eyJjb2RlIjoic3RhdGVEaWFncmFtLXYyXG4gICAgWypdIC0tPiBOb3RZZXRTdGFydGVkXG4gICAgWypdIC0tPiBBYm9ydGVkIDogV2lsbCBzdG9wIHRoZSBub2RlIGV4ZWN1dGlvblxuICAgIE5vdFlldFN0YXJ0ZWQgLS0-IFF1ZXVlZCA6IElmIGFsbCB1cHN0cmVhbSBub2RlcyBhcmUgcmVhZHkgaS5lLCBpbnB1dHMgYXJlIHJlYWR5XG4gICAgTm90WWV0U3RhcnRlZCAtLT4gU2tpcHBlZCA6IElmIHRoZSBicmFuY2ggd2FzIG5vdCB0YWtlblxuICAgIFF1ZXVlZCAtLT4gUnVubmluZyA6IFN0YXJ0IHRhc2sgZXhlY3V0aW9uIC0gYXR0ZW1wdCAwXG4gICAgUnVubmluZyAtLT4gVGltaW5nT3V0IDogSWYgdGFzayB0aW1lb3V0IGhhcyBlbGFwc2VkIGFuZCByZXRyeV9hdHRlbXB0cyA-PSBtYXhfcmV0cmllc1xuICAgIFRpbWluZ091dCAtLT4gVGltZWRPdXQgOiBJdCB0b3RhbCBub2RlIHRpbWVvdXQgaGFzIGVsYXBzZWRcbiAgICBSdW5uaW5nIC0tPiBSZXRyeWFibGVGYWlsdXJlIDogb24gcmV0cnlhYmxlIGZhaWx1cmVcbiAgICBSdW5uaW5nIC0tPiBEeW5hbWljUnVubmluZyA6IEZvciBkeW5hbWljIG5vZGVzIGdlbmVyYXRpbmcgd29ya2Zsb3dzXG4gICAgUmV0cnlhYmxlRmFpbHVyZSAtLT4gUnVubmluZyA6IGlmIHJldHJ5X2F0dGVtcHRzIDwgbWF4X3JldHJpZXNcbiAgICBSZXRyeWFibGVGYWlsdXJlIC0tPiBGYWlsaW5nIDogcmV0cnlfYXR0ZW1wdHMgPj0gbWF4X3JldHJpZXNcbiAgICBGYWlsaW5nIC0tPiBGYWlsZWRcbiAgICBSdW5uaW5nIC0tPiBTdWNjZWVkaW5nIDogSW50ZXJuYWwgc3RhdGVcbiAgICBEeW5hbWljUnVubmluZyAtLT4gU3VjY2VlZGluZ1xuICAgIER5bmFtaWNSdW5uaW5nIC0tPiBSZXRyeWFibGVGYWlsdXJlXG4gICAgRHluYW1pY1J1bm5pbmcgLS0-IFRpbWluZ091dFxuICAgIFN1Y2NlZWRpbmcgLS0-IFN1Y2NlZWRlZCA6IFVzZXIgb2JzZXJ2ZXMgdGhlIHRhc2sgYXMgc3VjY2VlZGVkXG4gICAgU3VjY2VlZGVkIC0tPiBbKl1cbiAgICBGYWlsZWQgLS0-IFsqXVxuIiwibWVybWFpZCI6e30sInVwZGF0ZUVkaXRvciI6ZmFsc2V9).
 

--- a/content/deployment/flyte-configuration/performance.md
+++ b/content/deployment/flyte-configuration/performance.md
@@ -156,7 +156,7 @@ a. Platform default: This allows to set platform-wide defaults for maximum paral
           maxParallelism: 25
 ```
 
-b. Default for a specific launch plan. For any launch plan, the ``max_parallelism`` value can be changed using :py:meth:`flytekit.LaunchPlan.get_or_create` or the :std:ref:`ref_flyteidl.admin.LaunchPlanCreateRequest`
+b. Default for a specific launch plan. For any launch plan, the ``max_parallelism`` value can be changed using `flytekit.LaunchPlan.get_or_create` or the `flyteidl.admin.LaunchPlanCreateRequest`
 
 **Flytekit Example**
 


### PR DESCRIPTION
Seven Sphinx roles sat in **hand-written** v1 prose and reached readers as literal text.

**No regen can ever fix these.** The generator does not touch `content/architecture` or `content/deployment`, so the converter fix in [infra#265](https://github.com/unionai/unionai-docs-infra/pull/265) never sees them — which is why they survived the 1.16.28 regen (#1477) that cleared the other 32.

## The target style was already in the file

`workflow-state-transitions.md` was inconsistent with itself:

| Line | Wrote |
|---|---|
| 65 | ```workflowexecution.phase``` — bare code span |
| 63 | `:std:ref:\`workflowexecutionevent\`` — RST role |
| 116 | ```nodeexecutionevent``` — bare code span |
| 116 | `:std:ref:\`nodeexecution.phase\`` — RST role |

So the fix is to match what the file already did for the siblings, not to invent a convention.

The node-type list split the same way: items 1, 5 and 6 are plain prose names (*Start Node*, *Dynamic Node*, *End Node*) while 2–4 were RST refs to sections that no longer exist. They are prose, not identifiers, so they are now plain text.

## One extra, found by sweeping rather than counting

Line 61 carried a Sphinx target embedded in a code span:

```
`system retries <system-retry>`
```

which rendered as monospace `system retries <system-retry>` — a dangling target shown to the reader. Same class of defect, same paragraph, missed by my original role-only grep. I swept both files for RST artifacts generally rather than re-counting the seven I already knew about.

## Judgment call

Dropped the `ref_` prefix from `:std:ref:\`ref_flyteidl.admin.LaunchPlanCreateRequest\`` — that is a Sphinx **target-name** prefix, not part of the proto's name.

Neither identifier appears in any v1 linkmap, so these code spans will not autolink. They render as plain code, which is correct and strictly better than literal RST; if a linkmap ever covers them they autolink for free.

## Verified in the built output, not the source

```
rendered architecture page:  :std:ref: -> 0   <system-retry> -> 0
rendered performance page:   :py:meth: -> 0   :std:ref: -> 0
                             flytekit.LaunchPlan.get_or_create renders as <code>
whole v1 dist:               files with RST roles -> 0
```

`make dist` green both variants, `make check-links` green.

---
— docsy · automated docs agent