### PR TITLE
docsy(v2): forward check-cli-variant-gating to the infra Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ TARGETS := usage help clean clean-generated base dist variant dev serve \
 	update-examples init-examples check-jupyter check-images validate-urls \
 	url-stats llm-docs update-redirects dry-run-redirects deploy-redirects \
 	check-deleted-pages check-links check-generated-content check-api-docs \
-	check-icon-names update-icon-names \
+	check-icon-names update-icon-names check-cli-variant-gating \
 	check-llm-bundle-notes update-api-docs \
 	check-helm-docs update-helm-docs generate-helm-docs \
 	index-search index-search-settings check-search-labels \


### PR DESCRIPTION
One line. The delegating `Makefile` forwards only explicitly listed targets, so without this `make check-cli-variant-gating` fails here even though infra defines it.

The check itself runs **automatically inside the regen** — `check_versions.py --update` invokes it after CLI regeneration, while the plugin venv still exists. This target is for running it by hand against an existing venv when investigating a suspected leak.

Companion to unionai/unionai-docs-infra#270, which adds the tool and the regen wiring, and which explains why the check exists: `flyte fork` shipped ungated into the OSS variant in #1483.

Harmless before #270 lands — an unlisted target simply stays unreachable.

Not applied to `v1`: the check no-ops on a CLI whose `gen_command` has no `--plugin-variants`, and v1 has no variant-gated CLI page.

---
— docsy · automated docs agent · [DOC-1479](https://linear.app/unionai/issue/DOC-1479/ci-check-catch-union-only-cli-commands-leaking-into-the-oss-variant-of)
