### PR TITLE
docsy(v2): retire the three oldest pins to get the deploy under Cloudflare's file cap

### DIFF
--- a/versions.toml
+++ b/versions.toml
@@ -6,10 +6,11 @@
 # latest     = whether this line owns the global /docs/latest URL. Only the
 #              primary line does; a secondary line (v1) sets false.
 stable = "v2.6.3.0"
+# Retention: Cloudflare Pages caps a deployment at 20,000 files, and every
+# entry here materializes another full site tree (~3,000 files). Seven trees
+# broke the deploy outright on 2026-08-21. Keep this list short; retiring a
+# pin needs a redirect row in unionai-docs-infra/redirects.csv.
 enumerated = [
-  "v2.5.16.3",
-  "v2.5.18.3",
-  "v2.6.0.0",
   "v2.6.1.0",
   "v2.6.2.0",
 ]


### PR DESCRIPTION
**Unblocks a broken production deploy.** Companion to unionai/unionai-docs-infra#272.

The Pages deploy has failed since the v2.6.3.0 cut ([run 32500868099](https://github.com/unionai/unionai-docs/actions/runs/32500868099)):

```
Error: Pages only supports up to 20,000 files in a deployment.
```

Every entry in `enumerated` materializes another full site tree — roughly **3,000 files** each (719 content pages × 2 variants, each emitting an `index.html` plus its `page.md` twin, plus 278 static files). Promoting v2.6.3.0 demoted v2.6.2.0 out of `stable` into `enumerated`, so it became its own tree for the first time. That took `dist/` to **seven trees** and over the ceiling.

Consequences right now:

- nothing has deployed since the cut; the live site still serves the pre-merge build
- the search-index step is gated behind a successful deploy, so the Algolia index is stale
- **every subsequent push to `main` fails the same way** until the tree count comes down

## This change

| | before | after |
|---|---|---|
| trees | 7 | 4 |
| `enumerated` | v2.5.16.3, v2.5.18.3, v2.6.0.0, v2.6.1.0, v2.6.2.0 | v2.6.1.0, v2.6.2.0 |

Retired pins redirect to `/docs/v2` with the path preserved, so `/docs/v2.5.16.3/union/user-guide/x` lands on `/docs/v2/union/user-guide/x` rather than the root.

## Two things for the record

**The limit is file count, not bytes.** DOC-1448 analysed this exact growth curve two days ago but framed it entirely in bytes (1.93 GiB, 151 MiB of images, formats and dimensions). Its image-weight item would not have prevented this by a single file.

**This is a floor, not a fix.** The next cut adds a tree again and we are back here. A bounded retention policy that prunes old pins at cut time is the real remedy, and `VERSIONING.md` has no retention rule at all today. I have added a comment above the list so the constraint is at least visible where someone edits it.

---
— docsy · automated docs agent · [DOC-1448](https://linear.app/unionai/issue/DOC-1448)
