### PR TITLE
docsy(v2): correct the dependency-inclusion constraint on multiple environments

### DIFF
--- a/content/user-guide/tasks/task-configuration/multiple-environments.md
+++ b/content/user-guide/tasks/task-configuration/multiple-environments.md
@@ -24,11 +24,7 @@ There are, however, two additional constraints that you must take into account.
 If `task_1` in environment `env_1` calls a `task_2` in environment `env_2`, then:
 
 1. `env_1` must declare a deployment-time dependency on `env_2` in the `depends_on` parameter of `TaskEnvironment` that defines `env_1`.
-2. The image used in the `TaskEnvironment` of `env_1` must include the import-time dependencies of the module that defines `task_2` (unless `task_2` is invoked as a remote task).
-
-<!-- TODO: Link to remote tasks when that page is live
 2. The image used in the `TaskEnvironment` of `env_1` must include the import-time dependencies of the module that defines `task_2` (unless [`task_2` is invoked as a remote task](../task-programming/remote-tasks)).
--->
 
 ### Task `depends_on` constraints
 
@@ -105,12 +101,8 @@ Keep at module level anything that has to resolve when the module is imported:
 
 #### Invoke the child task remotely
 
-You can also avoid the requirement by invoking a task in another environment _remotely_.
-The parent then refers to the child task by name instead of importing it, so the parent image needs nothing from the child's module.
-
-<!-- TODO: Link to remote tasks when that page is live
 You can also avoid the requirement by [invoking a task in another environment _remotely_](../task-programming/remote-tasks).
--->
+The parent then refers to the child task by name instead of importing it, so the parent image needs nothing from the child's module.
 
 ## Example
 
@@ -183,11 +175,7 @@ Finally, we define the `main` task itself:
 {{< code file="/unionai-examples/v2/user-guide/task-configuration/multiple-environments/af2/main.py" fragment="task" lang="python" >}}
 
 Here we call, in turn, the `run_msa` and `run_fold` tasks.
-Since we call them directly rather than as remote tasks, `main_image` has to be able to import the modules that define them.
-
-<!-- TODO: Link to remote tasks when that page is live
-Note that we call them directly, not as [remote tasks](../task-programming/remote-tasks), which is why `main_image` has to be able to import the modules that define them.
--->
+Since we call them directly rather than as [remote tasks](../task-programming/remote-tasks), `main_image` has to be able to import the modules that define them.
 
 The final piece of the puzzle is the `if __name__ == "__main__":` block that allows us to run the `main` task on the configured Flyte backend:
 

--- a/content/user-guide/tasks/task-configuration/multiple-environments.md
+++ b/content/user-guide/tasks/task-configuration/multiple-environments.md
@@ -24,10 +24,10 @@ There are, however, two additional constraints that you must take into account.
 If `task_1` in environment `env_1` calls a `task_2` in environment `env_2`, then:
 
 1. `env_1` must declare a deployment-time dependency on `env_2` in the `depends_on` parameter of `TaskEnvironment` that defines `env_1`.
-2. The image used in the `TaskEnvironment` of `env_1` must include all dependencies of the module containing the `task_2` (unless `task_2` is invoked as a remote task).
+2. The image used in the `TaskEnvironment` of `env_1` must include the import-time dependencies of the module that defines `task_2` (unless `task_2` is invoked as a remote task).
 
 <!-- TODO: Link to remote tasks when that page is live
-2. The image used in the `TaskEnvironment` of `env_1` must include all dependencies of the module containing the `task_2` (unless [`task_2` is invoked as a remote task](../task-programming/remote-tasks)).
+2. The image used in the `TaskEnvironment` of `env_1` must include the import-time dependencies of the module that defines `task_2` (unless [`task_2` is invoked as a remote task](../task-programming/remote-tasks)).
 -->
 
 ### Task `depends_on` constraints
@@ -43,17 +43,73 @@ The alternative strategy of building all environments defined in the set of depl
 
 ### Dependency inclusion constraints
 
-When a parent task invokes a child task in a different environment, the container image of the parent task environment must include all dependencies used by the child task.
-This is necessary because of the way task invocation works in Flyte:
+When a parent task invokes a child task in a different environment, the container image of the parent task environment must include the import-time dependencies of the module that defines the child task.
+This is narrower than every dependency the child task uses.
+It is what Python evaluates when the module is imported:
 
-- When a child task is invoked by function name, that function, necessarily, has to be imported into the parent tasks's Python environment.
-- This results in all the dependencies of the child task function also being imported.
-- But, nonetheless, the actual execution of the child task occurs in its own environment.
+- To invoke a child task by function name, the parent has to import the module that defines it. Importing that module runs the module's top-level statements: its module-level imports, its `Image` and `TaskEnvironment` definitions, and the `@env.task` decoration of each task in it.
+- Decorating a task builds its interface, which resolves the type annotations on the task's parameters and return value. Every name in those annotations has to be importable in the parent image.
+- The body of the child task function does not run in the parent. The child task still executes in its own environment, using its own image.
 
-To avoid this requirement, you can invoke a task in another environment _remotely_.
+So the parent image needs what the child's module imports at the top level, plus what the child task's signature refers to.
+It does not need a package that the child task imports inside its function body.
+
+You have two ways to keep a dependency out of the parent image: import it inside the task function, or invoke the child task remotely.
+
+#### Import the dependency inside the task function
+
+If a package is only used in the body of a child task, import it there rather than at module level.
+
+The child task, in `other/run.py`:
+
+```python
+import flyte
+
+other_env = flyte.TaskEnvironment(
+    name="other_env",
+    image=flyte.Image.from_debian_base().with_pip_packages("polars"),
+)
+
+@other_env.task
+async def row_count(path: str) -> int:
+    import polars as pl
+
+    return pl.read_parquet(path).height
+```
+
+The parent task, in `main.py`:
+
+```python
+import flyte
+
+from other.run import other_env, row_count
+
+env = flyte.TaskEnvironment(
+    name="main_env",
+    depends_on=[other_env],
+    image=flyte.Image.from_debian_base(),
+)
+
+@env.task
+async def main(path: str) -> int:
+    return await row_count(path)
+```
+
+The image for `main_env` does not include `polars`, because `other/run.py` imports it inside `row_count` rather than at module level.
+Importing `other/run.py` in the parent still works, and `row_count` still runs in `other_env`, where `polars` is installed.
+
+Keep at module level anything that has to resolve when the module is imported:
+
+- Names used in a task's parameter or return annotations. A name imported only in the function body raises `NameError` when the module is imported, including in a module that uses `from __future__ import annotations`.
+- Values passed to `TaskEnvironment`, `Image`, or the `@env.task` decorator, such as the package lists used to build an image.
+
+#### Invoke the child task remotely
+
+You can also avoid the requirement by invoking a task in another environment _remotely_.
+The parent then refers to the child task by name instead of importing it, so the parent image needs nothing from the child's module.
 
 <!-- TODO: Link to remote tasks when that page is live
-To avoid this requirement, you can [invoke a task in another environment _remotely_](../task-programming/remote-tasks).
+You can also avoid the requirement by [invoking a task in another environment _remotely_](../task-programming/remote-tasks).
 -->
 
 ## Example
@@ -110,7 +166,12 @@ We then assemble the image and the environment:
 {{< code file="/unionai-examples/v2/user-guide/task-configuration/multiple-environments/af2/main.py" fragment="image_and_env" lang="python" >}}
 
 The image for the `main` task (`main_image`) is built by starting with `fold_image` (the image for the `run_fold` task) and adding `MSA_PACKAGES` (the dependency list for the `run_msa` task).
-This ensures that `main_image` includes all dependencies needed by both the `run_fold` and `run_msa` tasks.
+This ensures that `main_image` can import `fold/run.py` and `msa/run.py`, whatever those modules import at the top level.
+
+{{< note >}}
+In this small example neither `msa/run.py` nor `fold/run.py` actually imports its packages at the top level, so a smaller `main_image` would also run.
+Composing the parent image from the child images is the pattern that keeps working once those modules do import their packages at module level, and it saves you working out which ones they are.
+{{< /note >}}
 
 The environment for the `main` task is defined with:
 
@@ -122,10 +183,10 @@ Finally, we define the `main` task itself:
 {{< code file="/unionai-examples/v2/user-guide/task-configuration/multiple-environments/af2/main.py" fragment="task" lang="python" >}}
 
 Here we call, in turn, the `run_msa` and `run_fold` tasks.
-Since we call them directly rather than as remote tasks, we had to ensure that `main_image` includes all dependencies needed by both tasks.
+Since we call them directly rather than as remote tasks, `main_image` has to be able to import the modules that define them.
 
 <!-- TODO: Link to remote tasks when that page is live
-Note that we call them directly, not as [remote tasks](../task-programming/remote-tasks), which is why we had to ensure that `main_image` includes all dependencies needed by both tasks.
+Note that we call them directly, not as [remote tasks](../task-programming/remote-tasks), which is why `main_image` has to be able to import the modules that define them.
 -->
 
 The final piece of the puzzle is the `if __name__ == "__main__":` block that allows us to run the `main` task on the configured Flyte backend:


### PR DESCRIPTION
Corrects the "Dependency inclusion constraints" section of the v2 multiple-environments page, which overstated what the parent task's image has to contain and contradicted the constraints list a few paragraphs above it.

**Reported by** Matthias Georg Nodeland (Nav) in #ask-union, who tested the case and found a working third option the page does not mention. He is right, for a narrower reason than "the constraint is wrong": the constraint is real, it is just about import-time dependencies, not about everything the child task uses.

## What the code says

Grounded against `flyteorg/flyte-sdk` @ `origin/main` (`b5100ffe`):

- `TaskEnvironment.task`'s decorator (`src/flyte/_task_environment.py:382`) calls `NativeInterface.from_callable(func)` at decoration time.
- `NativeInterface.from_callable` (`src/flyte/models.py:533`) runs `inspect.signature(func)` and `typing.get_type_hints(func, include_extras=True)`, and re-raises on failure. So a task's parameter and return annotations are resolved eagerly when its module is imported, including in a module using `from __future__ import annotations`.
- The container loads a task by `importlib.import_module` (`src/flyte/_internal/resolvers/default.py:22`). A parent that calls a child by function name therefore imports the child's module, which runs that module's top-level statements and the `@env.task` decoration of every task in it.
- The child's function body does not run in the parent. In a backend run the parent's call goes to the controller, which serializes the child's already-built interface to the wire (`src/flyte/_internal/controllers/remote/_controller.py`, `_submit` → `translate_task_to_wire`) and the child executes in its own environment.
- `depends_on` changes none of this. `_recursive_discover` (`src/flyte/_deploy.py:659`) walks in-memory `Environment` objects at deploy time.

Verified both directions against the installed SDK: a child task whose body imports a package works when the parent image lacks it; a child task whose return annotation names something imported only in the body fails at import with `NameError`, under `from __future__ import annotations`. The two-module example in the new section was run end to end on a local backend.

## Changes

- The constraints-list item and the section body now state the same requirement: the parent image must include **the import-time dependencies of the module that defines the child task**.
- Replaced the mechanism bullets. They said importing the child function "results in all the dependencies of the child task function also being imported", which is not what Python does.
- Added function-local imports as an option alongside remote invocation, with a runnable two-module example and the caveat about what still has to resolve at import time (annotations, and values passed to `TaskEnvironment` / `Image` / `@env.task`).
- Reconciled the AlphaFold2 example prose with the corrected requirement, plus a note: in that example neither child module actually imports its packages at the top level, so a smaller `main_image` would run. Composing the parent image from the child images is still the pattern worth showing, because it keeps working once those modules do import at module level.

Content-only, v2 only (`TaskEnvironment` is a Flyte 2 construct). Built with `make base` + `VARIANT=union make variant`; the section and the note render correctly.

---
— docsy · automated docs agent · [DOC-1492](https://linear.app/unionai/issue/DOC-1492/multiple-environments-dependency-inclusion-constraints-overstates-the) · [run report](https://github.com/unionai/docsy/blob/main/runs/2026-08-24-coverage-multiple-env-import-time-deps.md)

