### PR TITLE
docsy(v2): record retired pins, and deploy their redirects from that

### DIFF
--- a/.github/workflows/deploy-redirects.yml
+++ b/.github/workflows/deploy-redirects.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches: [main, v1]
-    paths: ['unionai-docs-infra']
+    paths: ['unionai-docs-infra', 'versions.toml']
 
 jobs:
   deploy-redirects:
@@ -18,7 +18,7 @@ jobs:
           submodules: 'true'
           fetch-depth: 2  # Need previous commit to detect submodule changes
 
-      - name: Check if redirects.csv changed
+      - name: Check if the deployed redirect set changed
         id: check-redirects
         run: |
           set -euo pipefail
@@ -30,6 +30,13 @@ jobs:
           fi
           # For push events, check if the unionai-docs-infra submodule ref changed and
           # whether that change includes redirects.csv
+          # Retired-pin redirects are derived from versions.toml `retired`, so a
+          # change there changes the deployed set just as much as a CSV edit does.
+          if ! git diff --quiet HEAD~1 HEAD -- versions.toml; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "versions.toml changed, proceeding with deploy."
+            exit 0
+          fi
           OLD_REF=$(git diff HEAD~1 HEAD -- unionai-docs-infra | grep "^-Subproject" | awk '{print $3}' || true)
           NEW_REF=$(git diff HEAD~1 HEAD -- unionai-docs-infra | grep "^+Subproject" | awk '{print $3}' || true)
           if [ -z "$OLD_REF" ] || [ -z "$NEW_REF" ]; then
@@ -56,6 +63,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+
+      # deploy_redirects.py reads BOTH lines' versions.toml. The checkout has only
+      # this branch, so make the sibling ref resolvable or the deploy fails closed.
+      - name: Fetch both documentation lines
+        if: steps.check-redirects.outputs.changed == 'true'
+        run: git fetch --depth=1 origin main v1
 
       - name: Deploy redirects to Cloudflare
         if: steps.check-redirects.outputs.changed == 'true'

--- a/versions.toml
+++ b/versions.toml
@@ -9,9 +9,21 @@ stable = "v2.6.6.0"
 # Retention: Cloudflare Pages caps a deployment at 20,000 files, and every
 # entry here materializes another full site tree (~3,000 files). Seven trees
 # broke the deploy outright on 2026-08-21. Keep this list short; retiring a
-# pin needs a redirect row in unionai-docs-infra/redirects.csv.
+# pin is recorded in `retired` below, which is where its redirect comes from.
 enumerated = [
   "v2.6.2.0",
   "v2.6.3.0",
   "v2.6.5.0",
 ]
+# Pins that have been retired. A pin leaves `enumerated` and arrives here in the
+# same edit, made by `manifest.py --promote`, and its redirect is DERIVED from
+# this list at deploy time -- do NOT add a row to redirects.csv (DOC-1497; see
+# unionai-docs-infra/VERSIONING.md "Retired pins redirect themselves").
+retired = [
+  "v2.5.16.3",
+  "v2.5.18.3",
+  "v2.6.0.0",
+  "v2.6.1.0",
+  "v2.6.2.0",
+]
+


### PR DESCRIPTION
Companion to unionai/unionai-docs-infra#279, which stops storing retired-pin redirect rows and derives them instead.

## What this side does

Seeds `retired` with the four pins already retired, plus `v2.6.2.0` which the next cut retires:

```toml
retired = ["v2.5.16.3", "v2.5.18.3", "v2.6.0.0", "v2.6.1.0", "v2.6.2.0"]
```

From here `manifest.py --promote` appends to it automatically, in the same edit that drops the pin from `enumerated`.

The workflow now fires on `versions.toml` as well as the submodule pointer — a change to `retired` changes the deployed redirect set exactly as a CSV edit does — and fetches both branches, because the deploy reads both lines and sends the union.

## Verified

`--dry-run` against the real corpus, before and after: **8,760 → 8,761** sources, nothing lost, no duplicates, the single addition being `v2.6.2.0`.

## One deliberate wrinkle

Seeding `v2.6.2.0` before its cut merges means it redirects while its tree is still published. That is the same trade we took with the `v2.6.1.0` row: the alternative ordering leaves 404s, and it resolves the moment the cut lands.

This also **supersedes infra#278**, the hand-written row for that pin — close it rather than merge it.

---
— docsy · automated docs agent · [DOC-1497](https://linear.app/unionai/issue/DOC-1497)