### PR TITLE
docsy(v1): record retired pins, and deploy their redirects from that

### DIFF
--- a/.github/workflows/deploy-redirects.yml
+++ b/.github/workflows/deploy-redirects.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches: [main, v1]
-    paths: ['unionai-docs-infra']
+    paths: ['unionai-docs-infra', 'versions.toml']
 
 jobs:
   deploy-redirects:
@@ -18,7 +18,7 @@ jobs:
           submodules: 'true'
           fetch-depth: 2  # Need previous commit to detect submodule changes
 
-      - name: Check if redirects.csv changed
+      - name: Check if the deployed redirect set changed
         id: check-redirects
         run: |
           set -euo pipefail
@@ -30,6 +30,13 @@ jobs:
           fi
           # For push events, check if the unionai-docs-infra submodule ref changed and
           # whether that change includes redirects.csv
+          # Retired-pin redirects are derived from versions.toml `retired`, so a
+          # change there changes the deployed set just as much as a CSV edit does.
+          if ! git diff --quiet HEAD~1 HEAD -- versions.toml; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "versions.toml changed, proceeding with deploy."
+            exit 0
+          fi
           OLD_REF=$(git diff HEAD~1 HEAD -- unionai-docs-infra | grep "^-Subproject" | awk '{print $3}' || true)
           NEW_REF=$(git diff HEAD~1 HEAD -- unionai-docs-infra | grep "^+Subproject" | awk '{print $3}' || true)
           if [ -z "$OLD_REF" ] || [ -z "$NEW_REF" ]; then
@@ -56,6 +63,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+
+      # deploy_redirects.py reads BOTH lines' versions.toml. The checkout has only
+      # this branch, so make the sibling ref resolvable or the deploy fails closed.
+      - name: Fetch both documentation lines
+        if: steps.check-redirects.outputs.changed == 'true'
+        run: git fetch --depth=1 origin main v1
 
       - name: Deploy redirects to Cloudflare
         if: steps.check-redirects.outputs.changed == 'true'

--- a/versions.toml
+++ b/versions.toml
@@ -13,6 +13,14 @@ enumerated = [
   "v1.16.26.4",
   "v1.16.28.0",
 ]
+# Pins that have been retired. A pin leaves `enumerated` and arrives here in the
+# same edit, made by `manifest.py --promote`, and its redirect is DERIVED from
+# this list at deploy time -- do NOT add a row to redirects.csv (DOC-1497; see
+# unionai-docs-infra/VERSIONING.md "Retired pins redirect themselves").
+# This line has not retired a pin yet. `enumerated` is at the cap, so its next
+# cut will be the first, and it will be handled without anyone doing anything.
+retired = []
+
 # v1.16.26.2 is deliberately not enumerated. It documents exactly the same
 # product state as .3 (flytekit 1.16.26, union 0.1.203); .3 only makes heading
 # anchors readable (DOC-1357). Serving it would add a near-duplicate tree for no


### PR DESCRIPTION
Companion to unionai/unionai-docs-infra#279 and unionai-docs#TBD (main).

This line has **never retired a pin**, so `retired` starts empty. But `enumerated` is at the cap, so its next cut will be the first — and it will be handled without anyone doing anything, which is the point.

## The workflow change is not cosmetic parity

The deploy PUTs the **whole** redirect list and fires on either branch. So this branch must also fetch both lines and send the union: a v1 deploy that saw only its own `retired` would republish a list missing **every** v2 retired pin and silently undo them.

That is the same class of bug as a stale submodule pointer republishing an older list — which has bitten this repo before — arrived at from a new direction.

---
— docsy · automated docs agent · [DOC-1497](https://linear.app/unionai/issue/DOC-1497)