### PR TITLE
docsy(v2): serialize redirect deploys across both lines

### DIFF
--- a/.github/workflows/deploy-redirects.yml
+++ b/.github/workflows/deploy-redirects.yml
@@ -6,6 +6,18 @@ on:
     branches: [main, v1]
     paths: ['unionai-docs-infra', 'versions.toml']
 
+# ONE Cloudflare list, two branches. Each run replaces the whole list, so two
+# deploys in flight together are a last-writer-wins race, and back-to-back ones
+# spend a bulk-operation budget that is shared per account, not per branch --
+# five runs in twenty minutes hit Cloudflare's rate limit twice on 2026-08-26.
+# The group is deliberately NOT keyed on the branch: serializing the two lines
+# against each other is the entire point.
+concurrency:
+  group: deploy-redirects
+  # Never cancel: each run carries a different intended list, so a cancelled one
+  # is a change that silently never reaches the edge.
+  cancel-in-progress: false
+
 jobs:
   deploy-redirects:
     name: "Deploy Redirects"


### PR DESCRIPTION
One Cloudflare list, two branches, and **each run replaces the whole list**. Nothing stopped the `main` and `v1` deploys running at once — a last-writer-wins race — and back-to-back runs spend a bulk-operation budget shared **per account, not per branch**.

Five runs in twenty minutes hit Cloudflare's rate limit twice on 2026-08-26 while landing the derived-redirects change.

```yaml
concurrency:
  group: deploy-redirects        # NOT keyed on the branch — that is the point
  cancel-in-progress: false
```

**The group is deliberately not branch-scoped.** Serializing the two lines against each other is the entire reason for adding it; a `${{ github.ref }}` key would leave the race exactly as it is.

**`cancel-in-progress` stays false.** Each run carries a different intended list, so a cancelled run is a change that silently never reaches the edge — the same failure this is meant to prevent, arrived at from the other side.

Companion: unionai/unionai-docs-infra#280 waits out the limit when it is hit. This stops us hitting it.

---
— docsy · automated docs agent · [DOC-1497](https://linear.app/unionai/issue/DOC-1497)